### PR TITLE
Fuzz contract constructor arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Adapted from https://github.com/ChrisPenner/haskell-stack-travis-ci
-language: nix
+language: minimal
 sudo: true
 
 cache:
@@ -13,31 +13,28 @@ matrix:
   fast_finish: true
   include:
     # Add build targets here
-    - env: GHCVER=8.2.1 CACHE_NAME=8.2.1 BUILD_BINARY=1
-      compiler: ": #stack 8.2.1"
-    - env: GHCVER=8.2.1 CACHE_NAME=8.2.1-osx BUILD_BINARY=1
-           LDFLAGS=-L/usr/local/opt/readline/lib CFLAGS=-I/usr/local/opt/readline/include
+    - env: CACHE_NAME=linux BUILD_BINARY=1
+    - env: CACHE_NAME=osx BUILD_BINARY=1
+           LDFLAGS=-L/usr/local/opt/readline/lib
+           CFLAGS=-I/usr/local/opt/readline/include
+           STACK_OPTS="--extra-include-dirs=/usr/local/opt/readline/include --extra-lib-dirs=/usr/local/opt/readline/lib"
       os: osx
-      compiler: ": #stack 8.2.1"
 
 install:
  - unset CC
  - export PATH=$HOME/.local/bin:$PATH
  - ./.travis/install-ghr.sh
  - ./.travis/install-stack.sh
+ - ./.travis/install-secp256k1.sh
 
 script:
  - echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
- - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
-   stack install readline --extra-include-dirs=/usr/local/opt/readline/include
-                          --extra-lib-dirs=/usr/local/opt/readline/lib;
-   fi
- - |
-   set -ex
+ - set -ex
+ - STACK_OPTS="$STACK_OPTS --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib"
    # Run tests
-   stack --no-terminal test --ghc-options="$GHC_OPTIONS"
-   set +ex
+ - stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
+ - set +ex
 
 after_success:
  - |

--- a/.travis/install-secp256k1.sh
+++ b/.travis/install-secp256k1.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eux
+
+gitRef="1086fda4c1975d0cad8d3cad96794a64ec12dca4"
+
+curl -LO "https://github.com/bitcoin-core/secp256k1/archive/$gitRef.zip"
+
+unzip "$gitRef.zip"
+
+cd "secp256k1-$gitRef"
+
+./autogen.sh
+# hevm needs reecovery module
+# don't install shared library so linker must used static
+# enable pic so static library can link against dynamic correctly
+./configure --enable-module-recovery --enable-shared=no --with-pic
+sudo make install

--- a/README.md
+++ b/README.md
@@ -13,28 +13,47 @@ It supports relatively sophisticated grammar-based fuzzing campaigns to falsify 
 ## Installation
 
 [stack](https://www.haskellstack.org/) is highly recommended to install echidna.
-If you are a particularly opinionated experienced Haskell user, cabal or hpack should work, but they are neither officially supported nor tested. 
+If you are a particularly opinionated experienced Haskell user, cabal or hpack should work, but they are neither officially supported nor tested. Install stack by following stack's [installation guide](https://docs.haskellstack.org/en/stable/install_and_upgrade/).
 
-Before starting with it, make sure you have libgmp-dev installed otherwise ghc will fail to compile. Also, libbz2 and libreadline are required by some packages. For instance, in Ubuntu/Debian you can execute:
+### Build-time Dependencies
+
+Before starting with it, make sure you have libgmp-dev installed otherwise ghc will fail to compile. Echidna or its dependencies also require the following libraries
+
+* bzip2
+* readline
+* zlib
+* ncurses
+* secp256k1
+
+Most of the necessary libraries are available for most linux distributions. For debian, the following command will get you most of the way there:
 
 ```
-# apt-get install libgmp-dev libbz2-dev libreadline-dev
+# apt-get install libgmp-dev libbz2-dev libreadline-dev zlib1g-dev libncurses5-dev
 ```
 
-[solc](https://www.npmjs.com/package/solc) is another echidna dependency not handled via stack.
-It is technically optional, but working with solidity source will fail without it.
-Install `solc` following the [official document](https://solidity.readthedocs.io/en/v0.4.24/installing-solidity.html).
-Note that `solc` must be installed by any method other than `npm / Node.js`.
-
-Once solc is installed, installing stack (`brew install haskell-stack`) and running
+but it does not install secp256k1. Currently, the best way to handle this is by building libsecp256k1 from [source](https://github.com/bitcoin-core/secp256k1). The build instructions are available in the secp256k1 repo, but make sure you enable the recovery module when you configure it.
 
 ```
-stack upgrade
-stack setup
-stack install
+./configure --enable-module-recovery
 ```
 
-from inside the echidna directory should be all that's needed.
+After building the library, remember the location of the include directory which contains the secp256k1 headers, and the library artifacts. If you ran `make`, these will be `secp256k1/include` and `secp256k1/.libs`.
+
+You must use these paths when running `stack install`/`stack build` commands below:
+
+```
+stack install --extra-include-dir=secp256k1/include --extra-lib-dir=secp256k1/.libs
+```
+
+To automatically apply those flags to all `stack build`/`stack install` commands you run, add the following lines to `~/.stack/config.yaml`:
+```
+extra-include-dirs:
+- secp256k1/include
+extra-lib-dirs:
+- secp256k1/.libs
+```
+
+If you ran `make install`, these paths will be `/usr/local/include` and `/usr/local/lib` instead. If you installed the includes and libs to your systems standard paths for those things, they will be found automatically by stack.
 
 If you have weird problems involving `readline` on MacOS, try:
 
@@ -47,7 +66,30 @@ stack install readline --extra-include-dirs=/usr/local/opt/readline/include --ex
 stack install
 ```
 
-Notably, if you are using stack, `stack ghci` will set up a REPL with all functions in scope.
+### Build-time Dependencies w/ nix
+
+If you instead wish to manage system dependencies using stack's [Nix integration](https://docs.haskellstack.org/en/stable/nix_integration/), you can skip installing system libraries, and instead use the `--nix` flag with all of stack's build commands. For example, instead of running
+
+```
+stack install
+```
+
+you would run
+
+```
+stack install --nix
+```
+
+This will tell stack to use Nix to download or build the requisite dependencies, and then run `stack install`.
+
+### Runtime Dependencies
+
+[solc](https://www.npmjs.com/package/solc) is another echidna dependency not handled via stack.
+It is technically optional, but working with solidity source will fail without it.
+Install `solc` following the [official document](https://solidity.readthedocs.io/en/v0.4.24/installing-solidity.html).
+Note that `solc` must be installed by any method other than `npm / Node.js`.
+
+Once solc is installed, you will be able to run `echidna-test` on Solidity source files.  Notably, if you are using stack, `stack ghci` will set up a REPL with all functions in scope.
 This can be quite useful for playing around with the library.
 
 ## Docker Installation

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -51,6 +51,7 @@ import Echidna.Property (PropertyType(..))
 import Echidna.Output (reportPassedTest, reportFailedTest)
 import Echidna.Solidity (TestableContract, ctorCode, functions, events, config, constructor)
 import Echidna.Event (extractSeqLog, Events)
+import Debug.Trace
 --import Echidna.Shrinking (minimizeTestcase)
 -------------------------------------------------------------------
 -- Fuzzing and Hedgehog Init
@@ -203,7 +204,7 @@ ePropertySeq'   n ps tcon          = do
                                                ts      = view functions tcon
 
 checkProperties ::  [(Text, (VM -> Bool))] -> VM -> ([Text],[Text])
-checkProperties ps vm = if fatal vm then ([], map fst ps)
+checkProperties ps vm = if fatal vm then trace "fatal vm" ([], map fst ps)
                         else (map fst $ filter snd bs, map fst $ filter (not . snd) bs)
                         where bs = map (\(t,p) -> (t, p vm)) ps
 
@@ -222,7 +223,8 @@ checkTest ShouldReturnFalseRevert      = checkFalseOrRevertTest
 checkBoolExpTest ::  Bool -> Addr -> VM -> Text -> Bool
 checkBoolExpTest b addr v t = case evalState (execCall (SolCall t [] (addressWord160 addr) 0)) v of
   VMSuccess (B s) -> s == encodeAbiValue (AbiBool b)
-  _               -> False
+  --_               -> False
+  r               -> traceShow r False
 
 checkRevertTest :: Addr -> VM -> Text -> Bool
 checkRevertTest addr v t = case evalState (execCall (SolCall t [] (addressWord160 addr) 0)) v of

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -3,13 +3,14 @@
 
 module Echidna.Solidity where
 
-import Control.Lens               ((^.), (%=), assign, use, set, view, makeLenses)
+import Control.Lens               ((^.), (%=), use, view, makeLenses)
 import Control.Exception          (Exception)
 import Control.Monad              (liftM2)
 import Control.Monad.Catch        (MonadThrow(..))
 import Control.Monad.IO.Class     (MonadIO(..))
 import Control.Monad.Reader       (MonadReader, ask)
-import Control.Monad.State.Strict (MonadState, execState, modify, runState)
+import Control.Monad.State.Strict (MonadState, execState, modify)
+import Data.Aeson.Types           (Value)
 import Data.ByteString            (ByteString)
 import Data.Foldable              (toList)
 import Data.List                  (find, partition)
@@ -23,20 +24,19 @@ import System.IO.Temp             (writeSystemTempFile)
 import qualified Data.Map as Map (lookup)
 
 import Echidna.ABI    (SolSignature)
-import Echidna.Config (Config(..), contractAddr, gasLimit, prefix, solcArgs, ignored, initialValue)
+import Echidna.Config (Config(..), prefix, solcArgs, ignored)
 
 
 import EVM
-  (Contract, VM, VMResult(..), contract, codeContract, contracts, env, gas, callvalue, loadContract, replaceCodeOfSelf, resetState, state)
-import EVM.Concrete (Blob(..), w256)
-import EVM.Exec     (exec, vmForEthrunCreation)
+  (Contract, VM, contract, contracts, env, state, Error, loadContract)
 import EVM.Keccak   (newContractAddress)
-import EVM.Solidity (abiMap, contractName, creationCode, methodInputs, methodName, readSolc, SolcContract, eventMap)
+import EVM.Solidity (abiMap, contractName, creationCode, constructorInputs, methodInputs, methodName, readSolc, SolcContract, eventMap)
 import EVM.Types    (Addr, W256)
-import EVM.ABI      (Event)
+import EVM.ABI      (Event, AbiType)
 
 data TestableContract = TestableContract
-  { _initialVM     :: VM
+  { _ctorCode      :: ByteString
+  , _constructor   :: [(Text, AbiType)]
   , _functions     :: [SolSignature]
   , _tests         :: [Text]
   , _events        :: Map W256 Event 
@@ -52,7 +52,7 @@ makeLenses ''TestableContract
 
 data EchidnaException = BadAddr Addr
                       | CompileFailure
-                      | ConstructorFailure Text
+                      | ConstructorFailure EVM.Error
                       | NoContracts
                       | TestArgsFound Text
                       | ContractNotFound Text
@@ -60,12 +60,13 @@ data EchidnaException = BadAddr Addr
                       | NoFuncs
                       | NoTests
                       | OnlyTests
+                      | ParseValueError AbiType Value String
 
 instance Show EchidnaException where
   show = \case
     BadAddr a             -> "No contract at " ++ show a ++ " exists"
     CompileFailure        -> "Couldn't compile given file"
-    (ConstructorFailure c)-> "Constructor of " ++ show c ++ " reverted during its execution"
+    (ConstructorFailure e)-> "Constructor encoutered an error during its execution: " ++ show e
     NoContracts           -> "No contracts found in given file"
     (ContractNotFound c)  -> "Given contract " ++ show c ++ " not found in given file"
     (TestArgsFound t)     -> "Test " ++ show t ++ " has arguments, aborting"
@@ -73,6 +74,7 @@ instance Show EchidnaException where
     NoFuncs               -> "ABI is empty, are you sure your constructor is right?"
     NoTests               -> "No tests found in ABI"
     OnlyTests             -> "Only tests and no public functions found in ABI"
+    ParseValueError t v s -> "Failed to parse " ++ show v ++ " as " ++ show t ++ ": " ++ s
 
 instance Exception EchidnaException
 
@@ -110,17 +112,6 @@ readContract filePath selectedContractName = do
         warn :: (MonadIO m) => Bool -> Text -> m ()
         warn p s = if p then liftIO $ print s else pure ()
 
--- | loads the solidity file at `filePath` and selects either the default or specified contract to analyze
-
-checkCREATE :: (MonadIO m, MonadThrow m, MonadReader Config m) => Int -> SolcContract -> m (ByteString, VM)
-checkCREATE v c = 
-                 let setInitialValue = set (state . callvalue) (fromIntegral v) in 
-                 case (runState exec . setInitialValue . vmForEthrunCreation  $ c ^. creationCode) of
-                 (VMSuccess (B bc), vm) ->  return (bc, vm)
-                 _                      ->  throwM $ ConstructorFailure (c ^. contractName) 
-
-
-
 loadSolidity :: (MonadIO m, MonadThrow m, MonadReader Config m)
              => FilePath
              -> Maybe Text
@@ -128,20 +119,20 @@ loadSolidity :: (MonadIO m, MonadThrow m, MonadReader Config m)
 loadSolidity filePath selectedContract = do
     conf <- ask
     c    <- readContract filePath selectedContract
-    (bc, vm) <- checkCREATE (conf ^. initialValue) c
-    let load = do resetState
-                  assign (state . gas) (w256 $ conf ^. gasLimit)
-                  assign (state . contract) (conf ^. contractAddr)
-                  assign (state . codeContract) (conf ^. contractAddr)
-                  loadContract (vm ^. state . contract)
-        loaded = execState load $ execState (replaceCodeOfSelf bc) vm
-        abi = map (liftM2 (,) (view methodName) (map snd . view methodInputs)) . toList $ c ^. abiMap
+    let abi = map (liftM2 (,) (view methodName) (map snd . view methodInputs)) . toList $ c ^. abiMap
         (ts, funs) = partition (isPrefixOf (conf ^. prefix) . fst) abi
-    let funs' = filter ((\e -> not $ e `elem` (conf ^. ignored))  . fst) funs
+        funs' = filter ((\e -> not $ e `elem` (conf ^. ignored))  . fst) funs
     if null abi then throwM NoFuncs else pure ()
     if null funs then throwM OnlyTests else pure ()
     case find (not . null . snd) ts of
-      Nothing      -> return $ TestableContract loaded funs' (fst <$> ts) (view eventMap c) conf
+      Nothing      -> return $
+          TestableContract
+          (c ^. creationCode)
+          (c ^. constructorInputs)
+          funs'
+          (fst <$> ts)
+          (view eventMap c)
+          conf
       (Just (t,_)) -> throwM $ TestArgsFound t
 
 
@@ -153,6 +144,3 @@ insertContract c = do a <- (`newContractAddress` 1) <$> use (state . contract)
 currentContract :: MonadThrow m => VM -> m Contract
 currentContract v = let a = v ^. state . contract in
   maybe (throwM $ BadAddr a) pure . Map.lookup a $ v ^. env . contracts
-
-addSolidity :: (MonadIO m, MonadReader Config m, MonadThrow m, MonadState VM n) => FilePath -> Maybe Text -> m (n ())
-addSolidity f mc = pure . insertContract =<< currentContract =<< view initialVM <$> loadSolidity f mc

--- a/package.yaml
+++ b/package.yaml
@@ -17,15 +17,15 @@ dependencies:
   - data-dword           >= 0.3.1  && < 0.4
   - deepseq
   - directory
-  - exceptions           >= 0.8.1  && < 0.9
+  - exceptions
   - hedgehog             >= 0.6
   - hevm
   - hashable
-  - lens                 >= 4.15.1 && < 4.16
+  - lens
   - mtl                  >= 2.2.1  && < 2.3
   - multiset             >= 0.3    && < 0.4
-  - optparse-applicative >= 0.12.0 && < 0.14
-  - process              >= 1.4.3  && < 1.5
+  - optparse-applicative >= 0.12.0
+  - process              >= 1.4.3
   - stm
   - temporary            >= 1.2.1  && < 1.3
   - text                 >= 1.2.2  && < 1.3
@@ -34,6 +34,7 @@ dependencies:
   - wl-pprint-annotated
   - yaml
   - unordered-containers
+  - pretty-show
 
 default-extensions:
   - OverloadedStrings

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ dependencies:
   - multiset             >= 0.3    && < 0.4
   - optparse-applicative >= 0.12.0
   - process              >= 1.4.3
+  - scientific
   - stm
   - temporary            >= 1.2.1  && < 1.3
   - text                 >= 1.2.2  && < 1.3

--- a/perprop/Main.hs
+++ b/perprop/Main.hs
@@ -119,8 +119,8 @@ selectSender n ss = view address (f $ filter (\s -> (view name s) == n) ss)
 -- {{{
 
 readConf :: FilePath -> IO (Maybe (Config, [Property]))
-readConf f = decodeEither <$> BS.readFile f >>= \case
-  Left e -> putStrLn ("couldn't parse config, " ++ e) >> pure Nothing
+readConf f = decodeEither' <$> BS.readFile f >>= \case
+  Left e -> putStrLn ("couldn't parse config, " ++ show e) >> pure Nothing
   Right (PerPropConf t r s a p) -> pure . Just . (,p) $
     defaultConfig -- & contractAddr .~ (selectSender "owner" s)
                   & addrList ?~ (view address <$> s)

--- a/solidity/constructor.sol
+++ b/solidity/constructor.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.4.22;
+
+contract Test {
+  uint private val;
+
+  constructor (uint _val) public {
+    require(_val > 0);
+    val = _val;
+  }
+
+  function inc() public {
+    val++;
+  }
+
+  function echidna_check() public view returns (bool){
+    return val > 0;
+  }
+}

--- a/solidity/coverage/multi.sol
+++ b/solidity/coverage/multi.sol
@@ -4,16 +4,16 @@ contract C {
   bool state3 = false;
   
   function f(uint x) {
-    //require(x == 12);
+    require(x == 12);
     state1 = true;
   }
 
   function g(uint y) {
     require(state1);
-    //require(y == 8);
+    require(y == 8);
     state2 = true;    
   }
-  /*
+  
   function h(uint z) {
     require(state2);
     require(z == 0);
@@ -24,9 +24,9 @@ contract C {
     uint x = 0;
     return;
   }
-  */
+  
   function echidna_state3() returns (bool) {
-    return (!state2);
+    return (!state3);
   }
 
 }

--- a/solidity/coverage/single.sol
+++ b/solidity/coverage/single.sol
@@ -1,5 +1,10 @@
 contract C {
   bool state = true;
+
+  function C(uint x) {
+     require(x <= 1024);
+  }
+
   function f(uint x, uint y, uint z) {
     require(x == 12);
     require(y == 8);

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,25 +1,28 @@
-resolver: lts-8.15
+resolver: lts-12.16
 
 packages:
 - '.'
 
 extra-deps:
-- git: https://github.com/dapphub/hevm.git
-  commit: 40b4ce9d38ed711ffd6065e697807100b3f0a3c3
-- brick-0.18
-- config-ini-0.2.1.1
-- data-clist-0.1.2.0
 - ghci-pretty-0.0.2
-- hedgehog-0.6
 - HSH-2.1.3
 - ipprint-0.6
-- megaparsec-6.4.0
-- optparse-applicative-0.13.2.0
-- parser-combinators-0.4.0
-- restless-git-0.5.0
+- restless-git-0.7
 - rosezipper-0.2
 - sr-extra-1.46.3.2
 - temporary-1.2.1.1
 - tree-view-0.5
-- vty-5.16
-- word-wrap-0.4.1
+- s-cargot-0.1.4.0
+- Unixutils-1.54.1
+- readline-1.0.3.0
+- hevm-0.21
+- multiset-0.3.4.1
+- text-format-0.3.2
+
+nix:
+  packages:
+  - bzip2
+  - readline
+  - zlib
+  - ncurses
+  - secp256k1


### PR DESCRIPTION
In order to have constructor information, I had to update to hevm-0.21. This required bumping the stack resolver to have a new enough version of the time package that was compatible with hevm, and removing some version constraint (though I didn't try very hard to have a tight bound, I was happy to let stack handle the version compatibilities).

I moved VM initialization from before TestableContract construction to after. Now it happens right before executing each generated sequence of SolCalls, and if the contract reverts, that test is skipped, just like what was being done when a random function call caused a revert.