### PR TITLE
Show the senders when printing a list of transactions

### DIFF
--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -64,7 +64,7 @@ type Names = Role -> Addr -> String
 -- | Given rules for pretty-printing associated address, pretty-print a 'Transaction'.
 ppTx :: (MonadReader x m, Has Names x) => Tx -> m String
 ppTx (Tx c s r v) = let sOf = either ppSolCall (const "<CREATE>") in
-  view hasLens <&> \f -> sOf c ++ f Sender s ++ f Receiver r
+  view hasLens <&> \f -> sOf c ++ " from " ++ f Sender s ++ f Receiver r
                       ++ (if v == 0 then "" else "Value: " ++ show v)
 
 -- | Given a number of boxes checked and a number of total boxes, pretty-print progress in box-checking.


### PR DESCRIPTION
This small PR enables to show where the transactions are coming from when Echidna finds a counter-example. This is particularly useful when you are using multiple senders. For instance, using the `multisender.sol` example:

```
$ echidna-test examples/solidity/basic/multisender.sol --config examples/solidity/basic/multisender.yaml
...
echidna_all_sender: failed!💥  
  Call sequence, shrinking (4825/5000):
    s3() from 0x0000000000000000000000000000000000000003
    s2() from 0x0000000000000000000000000000000000000002
    s1() from 0x0000000000000000000000000000000000000001
```
