### PR TITLE
`Open _` should also `exitSuccess` because it is not reported as a failure in the UI

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -86,6 +86,12 @@ isDone :: (MonadReader x m, Has CampaignConf x) => Campaign -> m Bool
 isDone (Campaign ts _) = view (hasLens . to (liftM2 (,) testLimit shrinkLimit)) <&> \(tl, sl) ->
   all (\case Open i -> i >= tl; Large i _ -> i >= sl; _ -> True) $ snd <$> ts
 
+-- | Given a 'Campaign', check if the test results should be reported as a
+-- success or a failure.
+isSuccess :: Campaign -> Bool
+isSuccess (Campaign ts _) =
+  any (\case { Passed -> True; Open _ -> True; _ -> False; }) $ snd <$> ts
+
 -- | Given an initial 'VM' state and a @('SolTest', 'TestState')@ pair, as well as possibly a sequence
 -- of transactions and the state after evaluation, see if:
 -- (0): The test is past its 'testLimit' or 'shrinkLimit' and should be presumed un[solve|shrink]able

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -35,8 +35,7 @@ opts = info (options <**> helper) $ fullDesc
 
 main :: IO ()
 main = do (Options f c cov conf) <- execParser opts
-          cfg          <- maybe (pure defaultConfig) parseConfig conf
-          Campaign r _ <- runReaderT (loadSolTests f (pack <$> c) >>= \(v,w,ts) -> ui v w ts) $
-                            cfg & cConf %~ if cov then \k -> k {knownCoverage = Just mempty} else id
-          if any (/= Passed) $ snd <$> r then exitWith $ ExitFailure 1
-                                         else exitSuccess
+          cfg <- maybe (pure defaultConfig) parseConfig conf
+          cpg <- runReaderT (loadSolTests f (pack <$> c) >>= \(v,w,ts) -> ui v w ts) $
+                   cfg & cConf %~ if cov then \k -> k {knownCoverage = Just mempty} else id
+          if not . isSuccess $ cpg then exitWith $ ExitFailure 1 else exitSuccess


### PR DESCRIPTION
quick and easy merge let's go