### PR TITLE
Increase the default seqLen to 100

### DIFF
--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -1,5 +1,5 @@
 testLimit: 10000
-seqLen: 10
+seqLen: 100
 shrinkLimit: 5000
 reverts: true
 dashboard: true

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -61,7 +61,7 @@ instance FromJSON EConfig where
                 let good = if reverts then (`elem` [ResTrue, ResRevert]) else (== ResTrue)
                 return $ TestConf (good . maybe ResOther classifyRes . view result) (const psender)
         cc = CampaignConf <$> v .:? "testLimit"   .!= 10000
-                          <*> v .:? "seqLen"      .!= 10
+                          <*> v .:? "seqLen"      .!= 100
                           <*> v .:? "shrinkLimit" .!= 5000
                           <*> pure Nothing
         names = const $ const mempty :: Names


### PR DESCRIPTION
Finding even length 2-3 sequences with contracts with many functions is almost impossible with length 10.  100 may be too small, still, but is a reasonable low-cost improvement.

Documentation of the combinatorics of short sequences can be found, e.g.:  https://agroce.github.io/ase08.pdf -- or in various papers by Arcuri/Fraser.  See also https://github.com/agroce/paper-testlength/blob/master/testlengthdraft.pdf -- top graph in each page is branch coverage ranges at different lengths.  Python APIs tend to hit maximum around 200+ length, but are likely more complex than most Solidity "API"s