### PR TITLE
Increased cache timeout to 1000 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
         - .stack-work
         - /usr/local/include
         - /usr/local/lib
+    timeout: 1000
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
The current cache timeout (180 seconds) is stopping travis to completely cache all the compiled hackage packages, increasing the CI test time a lot. The increased cache timeout should help to avoid this issue.