### PR TITLE
User defined addresses can hold and receive ether

### DIFF
--- a/examples/solidity/basic/balance.sol
+++ b/examples/solidity/basic/balance.sol
@@ -1,0 +1,11 @@
+contract C {
+  constructor() public {
+      //msg.sender.transfer(0);
+  }
+
+  function f() public {}
+  function echidna_balance() public returns (bool) { 
+      return address(msg.sender) == address(0x1) && msg.sender.balance == 42; 
+  }
+
+}

--- a/examples/solidity/basic/balance.sol
+++ b/examples/solidity/basic/balance.sol
@@ -1,11 +1,11 @@
 contract C {
   constructor() public {
-      //msg.sender.transfer(0);
+      msg.sender.transfer(0); // this contract has no ether, but this call to transfer should not fail
   }
 
   function f() public {}
   function echidna_balance() public returns (bool) { 
-      return address(msg.sender) == address(0x1) && msg.sender.balance == 42; 
+      return address(msg.sender) == address(0x42) && msg.sender.balance == 42; 
   }
 
 }

--- a/examples/solidity/basic/balance.yaml
+++ b/examples/solidity/basic/balance.yaml
@@ -1,3 +1,4 @@
-sender: ["0x1"]
-psender: "0x1"
+deployer: "0x42"
+sender: ["0x42"]
+psender: "0x42"
 initialBalance: 42

--- a/examples/solidity/basic/balance.yaml
+++ b/examples/solidity/basic/balance.yaml
@@ -1,0 +1,3 @@
+sender: ["0x1"]
+psender: "0x1"
+initialBalance: 42

--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -9,6 +9,7 @@ shrinkLimit: 5000
 contractAddr: "0x00a329c0648769a73afac7f9381e08fb43dbea72"
 deployer: "0x00a329c0648769a73afac7f9381e08fb43dbea70"
 sender: ["0x00a329c0648769a73afac7f9381e08fb43dbea70"]
+initialBalance: 0xffffffff
 psender: "0x00a329c0648769a73afac7f9381e08fb43dbea70"
 prefix: "echidna_"
 solcArgs: ""

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -70,12 +70,13 @@ instance FromJSON EConfig where
                                            "unrecognized ui type (should be text, json, or none)" in
     EConfig <$> cc
             <*> pure names
-            <*> (SolConf <$> v .:? "contractAddr" .!= 0x00a329c0648769a73afac7f9381e08fb43dbea72
-                         <*> v .:? "deployer"     .!= 0x00a329c0648769a73afac7f9381e08fb43dbea70
-                         <*> v .:? "sender"       .!= [0x00a329c0648769a73afac7f9381e08fb43dbea70]
-                         <*> v .:? "prefix"       .!= "echidna_"
-                         <*> v .:? "solcArgs"     .!= ""
-                         <*> v .:? "quiet"        .!= False)
+            <*> (SolConf <$> v .:? "contractAddr"   .!= 0x00a329c0648769a73afac7f9381e08fb43dbea72
+                         <*> v .:? "deployer"       .!= 0x00a329c0648769a73afac7f9381e08fb43dbea70
+                         <*> v .:? "sender"         .!= [0x00a329c0648769a73afac7f9381e08fb43dbea70]
+                         <*> v .:? "initialBalance" .!= 0xffffffff
+                         <*> v .:? "prefix"         .!= "echidna_"
+                         <*> v .:? "solcArgs"       .!= ""
+                         <*> v .:? "quiet"          .!= False)
             <*> tc
             <*> (UIConf <$> v .:? "dashboard" .!= True <*> style)
   parseJSON _ = parseJSON (Object mempty)

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -31,6 +31,7 @@ data ErrorClass = RevertE | IllegalE | UnknownE
 classifyError :: Error -> ErrorClass
 classifyError (Revert _)             = RevertE
 classifyError (UnrecognizedOpcode _) = RevertE
+classifyError (Query _)              = RevertE
 classifyError StackUnderrun          = IllegalE
 classifyError BadJumpDestination     = IllegalE
 classifyError StackLimitExceeded     = IllegalE

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -100,7 +100,7 @@ contracts fp = do
 populateAddresses :: [Addr] -> Integer -> VM -> VM
 populateAddresses []     _ vm = vm
 populateAddresses (a:as) b vm = populateAddresses as b (vm & set (env . EVM.contracts . at a) (Just account))
-                                 where account = initialContract mempty & set nonce 1 & set balance (w256 $ fromInteger b)
+  where account = initialContract mempty & set nonce 1 & set balance (w256 $ fromInteger b)
 
 -- | Given an optional contract name and a list of 'SolcContract's, try to load the specified
 -- contract, or, if not provided, the first contract in the list, into a 'VM' usable for Echidna

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -102,7 +102,6 @@ populateAddresses []     _ vm = vm
 populateAddresses (a:as) b vm = populateAddresses as b (vm & set (env . EVM.contracts . at a) (Just account))
                                  where account = initialContract mempty & set nonce 1 & set balance (w256 $ fromInteger b)
 
-
 -- | Given an optional contract name and a list of 'SolcContract's, try to load the specified
 -- contract, or, if not provided, the first contract in the list, into a 'VM' usable for Echidna
 -- testing and extract an ABI and list of tests. Throws exceptions if anything returned doesn't look
@@ -122,7 +121,7 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
   -- Local variables
   (SolConf ca d ads b pref _ _) <- view hasLens
   let bc = c ^. creationCode
-      blank = populateAddresses (ads++[d]) b (vmForEthrunCreation bc)
+      blank = populateAddresses (ads |> d) b (vmForEthrunCreation bc)
       abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c ^. abiMap)
       (tests, funs) = partition (isPrefixOf pref . fst) abi
 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -90,20 +90,19 @@ integrationTests = testGroup "Solidity Integration Testing"
         ("echidna_all_sender solved without " ++ unpack n, solvedWith (n, []) "echidna_all_sender"))
 
   , testContract "basic/contractAddr.sol" Nothing
-      [ ("echidna_address failed",                         solved "echidna_address") ]
+      [ ("echidna_address failed",                solved "echidna_address") ]
   , testContract "basic/contractAddr.sol" (Just "basic/contractAddr.yaml")
-      [ ("echidna_address failed",                         passed "echidna_address") ]      
-  , testContract "basic/constants.sol"        Nothing
+      [ ("echidna_address failed",                passed "echidna_address") ]
+  , testContract "basic/constants.sol"    Nothing
       [ ("echidna_found failed",                  not . solved "echidna_found") ]
-  , testContract "basic/constants2.sol"        Nothing
-      [ ("echidna_found32 failed",                  not . solved "echidna_found32") ]
-  , testContract "coverage/single.sol"        Nothing
+  , testContract "basic/constants2.sol"   Nothing
+      [ ("echidna_found32 failed",                not . solved "echidna_found32") ]
+  , testContract "coverage/single.sol"    Nothing
       [ ("echidna_state failed",                  not . solved "echidna_state") ]
-  , testContract "coverage/multi.sol"        Nothing
-      [ ("echidna_state3 failed",                  not . solved "echidna_state3") ]
-  , testContract "basic/balance.sol"        (Just "basic/balance.yaml")
-      [ ("echidna_balance failed",                  passed       "echidna_balance") ]
-
+  , testContract "coverage/multi.sol"     Nothing
+      [ ("echidna_state3 failed",                 not . solved "echidna_state3") ]
+  , testContract "basic/balance.sol"      (Just "basic/balance.yaml")
+      [ ("echidna_balance failed",                passed       "echidna_balance") ]
   ]
 
 testContract :: FilePath -> Maybe FilePath -> [(String, Campaign -> Bool)] -> TestTree

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -101,6 +101,9 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_state failed",                  not . solved "echidna_state") ]
   , testContract "coverage/multi.sol"        Nothing
       [ ("echidna_state3 failed",                  not . solved "echidna_state3") ]
+  , testContract "basic/balance.sol"        (Just "basic/balance.yaml")
+      [ ("echidna_balance failed",                  passed       "echidna_balance") ]
+
   ]
 
 testContract :: FilePath -> Maybe FilePath -> [(String, Campaign -> Bool)] -> TestTree


### PR DESCRIPTION
This PR enable `deployer` and `sender` addresses to receive hold and ether. Also, a Query HEVM error is no longer fatal error: it reverts the transaction. It should fix #180.