### PR TITLE
Added support to configure the value of the CREATE transaction using balanceContract

### DIFF
--- a/examples/solidity/basic/balance.sol
+++ b/examples/solidity/basic/balance.sol
@@ -1,11 +1,12 @@
 contract C {
-  constructor() public {
-      msg.sender.transfer(0); // this contract has no ether, but this call to transfer should not fail
+  constructor() payable public {
+      msg.sender.transfer(0);
+      msg.sender.transfer(123);
   }
 
   function f() public {}
   function echidna_balance() public returns (bool) { 
-      return address(msg.sender) == address(0x42) && msg.sender.balance == 42; 
+      return address(msg.sender) == address(0x42) && msg.sender.balance == (42+123) && address(this).balance == 0;
   }
 
 }

--- a/examples/solidity/basic/balance.yaml
+++ b/examples/solidity/basic/balance.yaml
@@ -1,4 +1,5 @@
 deployer: "0x42"
 sender: ["0x42"]
 psender: "0x42"
-initialBalance: 42
+balanceAddr: 42
+balanceContract: 123

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -74,7 +74,8 @@ instance FromJSON EConfig where
             <*> (SolConf <$> v .:? "contractAddr"   .!= 0x00a329c0648769a73afac7f9381e08fb43dbea72
                          <*> v .:? "deployer"       .!= 0x00a329c0648769a73afac7f9381e08fb43dbea70
                          <*> v .:? "sender"         .!= [0x00a329c0648769a73afac7f9381e08fb43dbea70]
-                         <*> v .:? "initialBalance" .!= 0xffffffff
+                         <*> v .:? "balanceAddr"    .!= 0xffffffff
+                         <*> v .:? "balanceContract".!= 0
                          <*> v .:? "prefix"         .!= "echidna_"
                          <*> v .:? "solcArgs"       .!= ""
                          <*> v .:? "solcLibs"       .!= []

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -75,7 +75,8 @@ instance Exception SolException
 data SolConf = SolConf { _contractAddr    :: Addr    -- ^ Contract address to use
                        , _deployer        :: Addr    -- ^ Contract deployer address to use
                        , _sender          :: [Addr]  -- ^ Sender addresses to use
-                       , _initialBalance  :: Integer -- ^ Initial balance of deployer and senders
+                       , _balanceAddr     :: Integer -- ^ Initial balance of deployer and senders
+                       , _balanceContract :: Integer -- ^ Initial balance of contract to test
                        , _prefix          :: Text    -- ^ Function name prefix used to denote tests
                        , _solcArgs        :: String  -- ^ Args to pass to @solc@
                        , _solcLibs        :: [String] -- ^ List of libraries to load, in order.
@@ -137,9 +138,9 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
     unless q . putStrLn $ "Analyzing contract: " <> unpack (c ^. contractName)
 
   -- Local variables
-  (SolConf ca d ads b pref _ libs _) <- view hasLens
+  (SolConf ca d ads bala balc pref _ libs _) <- view hasLens
   let bc = c ^. creationCode
-      blank = populateAddresses (ads |> d) b (vmForEthrunCreation bc)
+      blank = populateAddresses (ads |> d) bala (vmForEthrunCreation bc)
       abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c ^. abiMap)
       (tests, funs) = partition (isPrefixOf pref . fst) abi
 
@@ -152,7 +153,7 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
   case find (not . null . snd) tests of
     Just (t,_) -> throwM $ TestArgsFound t                                     -- Test args check
     Nothing    -> loadLibraries ls addrLibrary d blank >>=
-                    fmap (, funs, fst <$> tests) . execStateT (execTx $ Tx (Right bc) d ca 0)
+                    fmap (, funs, fst <$> tests) . execStateT (execTx $ Tx (Right bc) d ca (w256 $ fromInteger balc))
 
   where choose []    _        = throwM NoContracts
         choose (c:_) Nothing  = return c

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -119,6 +119,6 @@ setupTx (Tx c s r v) = liftSH . sequence_ $
   , tx . origin .= s, state . caller .= s, state . callvalue .= v, setup] where
     setup = case c of
       Left cd  -> loadContract r >> state . calldata .= encode cd
-      Right bc -> assign (env . contracts . at r) (Just $ initialContract (RuntimeCode bc)) >> loadContract r
+      Right bc -> assign (env . contracts . at r) (Just $ initialContract (RuntimeCode bc) & set balance v) >> loadContract r
     encode (n, vs) = abiCalldata
       (n <> "(" <> T.intercalate "," (abiTypeSolidity . abiValueType <$> vs) <> ")") $ V.fromList vs


### PR DESCRIPTION
This PR adds the `balanceContract` parameter to specify the amount of ether to send to the constructor. It also renames the `initialBalance` parameter to `balanceAddr` to avoid confusion (I will update the wiki when this PR is merged).