### PR TITLE
Added HARVEY examples from the paper

### DIFF
--- a/examples/solidity/harvey/baz.sol
+++ b/examples/solidity/harvey/baz.sol
@@ -1,0 +1,45 @@
+contract Baz {
+
+    bool private state1;
+    bool private state2;
+    bool private state3;
+    bool private state4;
+    bool private state5;
+
+    function baz(int256 a, int256 b, int256 c) public returns (int256) {
+        int256 d = b + c;
+        //minimize(d < 1 ? 1 - d : 0);
+        //minimize(d < 1 ? 0 : d);
+        if (d < 1) {
+            //minimize(b < 3 ? 3 - b : 0);
+            //minimize(b < 3 ? 0 : b - 2);
+            if (b < 3) {
+                state1 = true;
+                return 1;
+            }
+            //minimize(a == 42 ? 1 : 0);
+            //minimize(a == 42 ? 0 : |a - 42|);
+            if (a == 42) {
+                state2 = true;
+                return 2;
+            }
+    
+            state3 = true;
+            return 3;
+        } else {
+        //minimize(c < 42 ? 42 - c : 0);
+        //minimize(c < 42 ? 0 : c - 41);
+        if (c < 42) {
+            state4 = true;
+            return 4;
+        }
+        state5 = true;
+        return 5;
+        }
+    }
+
+    function echidna_all_states() public returns (bool) {
+        return !state1 || !state2 || !state3 || !state4 || !state5;
+    }
+
+}

--- a/examples/solidity/harvey/foo.sol
+++ b/examples/solidity/harvey/foo.sol
@@ -1,0 +1,33 @@
+contract Foo {
+    int256 private x;
+    int256 private y;
+    bool private state;
+    constructor () public {
+        x = 0;
+        y = 0;
+    }
+
+    function Bar() public returns (int256) {
+        if (x == 42) {
+            state = true;
+            return 1; 
+        }
+        return 0;
+    }
+
+    function SetY(int256 ny) public { 
+	y = ny;
+    }
+
+    function IncX() public { 
+	x++; 
+    }
+
+    function CopyY() public { 
+	x = y; 
+    }
+
+    function echidna_assert() public returns (bool) {
+        return !state;
+    }
+}

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -114,6 +114,11 @@ integrationTests = testGroup "Solidity Integration Testing"
   , testContract "basic/library.sol"      (Just "basic/library.yaml")
       [ ("echidna_library_call failed",           solved "echidna_library_call") ]
 
+  -- Examples from the HARVEY paper
+  , testContract "harvey/foo.sol"         Nothing
+      [ ("echidna_assert failed",                 solved "echidna_assert") ]
+  , testContract "harvey/baz.sol"         Nothing
+      [ ("echidna_all_states failed",             solved "echidna_all_states") ]
   ]
 
 testContract :: FilePath -> Maybe FilePath -> [(String, Campaign -> Bool)] -> TestTree


### PR DESCRIPTION
Added foo.sol and baz.sol, directly from the [HARVEY paper](https://arxiv.org/pdf/1905.06944.pdf), with minimal modifications to add a suitable echidna properties to explore all the states. Echidna can solve them in seconds.