### PR TITLE
Timeout for a campaign

### DIFF
--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -12,3 +12,4 @@ psender: "0x00a329c0648769a73afac7f9381e08fb43dbea70"
 prefix: "echidna_"
 solcArgs: ""
 quiet: False
+timeout: -1

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -175,7 +175,7 @@ campaign u v w ts d = let d' = fromMaybe mempty d in fmap (fromMaybe mempty) (vi
     step        = runUpdate (updateTest v Nothing) >> u >> runCampaign
     runCampaign = use (hasLens . tests . to (fmap snd)) >>= update
     update c      = (liftIO getCPUTime) >>= \t -> view hasLens >>= \(CampaignConf tl q sl _ tm) ->
-      if | t > 0 && t >= tm                              -> u
+      if | tm > 0 && t >= tm                              -> u
          | any (\case Open  n   -> n < tl; _ -> False) c -> callseq v w q >> step
          | any (\case Large n _ -> n < sl; _ -> False) c -> step
          | otherwise                                     -> u

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -174,7 +174,7 @@ campaign u v w ts d = let d' = fromMaybe mempty d in fmap (fromMaybe mempty) (vi
   >>= \c -> execStateT runCampaign (Campaign ((,Open (-1)) <$> ts) c d') where
     step        = runUpdate (updateTest v Nothing) >> u >> runCampaign
     runCampaign = use (hasLens . tests . to (fmap snd)) >>= update
-    update c      = (liftIO getCPUTime) >>= \t -> view hasLens >>= \(CampaignConf tl q sl _ tm) ->
+    update c      = liftIO getCPUTime >>= \t -> view hasLens >>= \(CampaignConf tl q sl _ tm) ->
       if | tm > 0 && t >= tm                              -> u
          | any (\case Open  n   -> n < tl; _ -> False) c -> callseq v w q >> step
          | any (\case Large n _ -> n < sl; _ -> False) c -> step

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -72,7 +72,7 @@ ppTS :: (MonadReader x m, Has CampaignConf x, Has Names x) => TestState -> m Str
 ppTS (Failed e)  = pure $ "could not evaluate ☣\n  " ++ show e
 ppTS (Solved l)  = ppFail Nothing l
 ppTS Passed      = pure "passed! 🎉"
-ppTS (Open i)    = view hasLens >>= \(CampaignConf t _ _ _) ->
+ppTS (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _) ->
                      if i >= t then ppTS Passed else pure $ "fuzzing " ++ progress i t
 ppTS (Large n l) = view (hasLens . to shrinkLimit) >>= \m -> ppFail (if n < m then Just (n,m) 
                                                                               else Nothing) l


### PR DESCRIPTION
Added a timeout (in second) for a campaign. Use the keyword `timeout`. By default is `-1`, that means no timeout.