### PR TITLE
Add --version to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Echidna exports an API to build powerful fuzzing systems, and has a multitude of
 
 ## Installation
 
-If you want to quickly test Echidna in Linux, we offer a statically linked binary release of v1.0.0.0 to download [here](https://github.com/crytic/echidna/releases/tag/1.0.0.0). 
+If you want to quickly test Echidna in Linux, we offer a statically linked binary release of v1.1.0.0 to download [here](https://github.com/crytic/echidna/releases/tag/1.1.0.0).
 
 Otherwise, to install the latest revision of Echidna, we recommend to use [docker](https://www.docker.com/):
 

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@ name: echidna
 
 author: JP Smith
 
-version: 1.0.0.0
+version: 1.1.0.0
 
 ghc-options: -Wall -fno-warn-orphans -O2 -threaded +RTS -N -RTS
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -3,7 +3,9 @@ module Main where
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.Random (getRandom)
 import Data.Text (pack)
+import Data.Version (showVersion)
 import Options.Applicative
+import Paths_echidna (version)
 import System.Exit (exitWith, exitSuccess, ExitCode(..))
 
 import Echidna.ABI
@@ -26,8 +28,13 @@ options = Options <$> argument str (metavar "FILE"
                   <*> optional (option str $ long "config"
                         <> help "Config file")
 
+versionOption :: Parser (a -> a)
+versionOption = infoOption
+                  ("Echidna " ++ showVersion version)
+                  (long "version" <> help "Show version")
+
 opts :: ParserInfo Options
-opts = info (options <**> helper) $ fullDesc
+opts = info (helper <*> versionOption <*> options) $ fullDesc
   <> progDesc "EVM property-based testing framework"
   <> header "Echidna"
 


### PR DESCRIPTION
This PR adds `--version` option to CLI (solves https://github.com/crytic/echidna/issues/277). I've included only the long option, `-v` might be handy for verbose in future.
```
$ stack exec -- echidna-test --help
Echidna

Usage: echidna-test [--version] FILE [CONTRACT] [--config ARG]
  EVM property-based testing framework

Available options:
  -h,--help                Show this help text
  --version                Show version
  FILE                     Solidity file to analyze
  CONTRACT                 Contract to analyze
  --config ARG             Config file
```

```
$ stack exec -- echidna-test --version
Echidna 1.1.0.0
```

I've also updated package.yaml and README to reflect the new 1.1.0.0 release.