### PR TITLE
Fix initialization

### DIFF
--- a/examples/solidity/basic/construct.sol
+++ b/examples/solidity/basic/construct.sol
@@ -1,0 +1,14 @@
+contract C {
+  bool state = true;
+  function f() public {
+    D a = new D();
+    D b = new D();
+    state = false;
+  }
+
+  function echidna_construct() public returns (bool) {
+    return state;
+  }
+}
+
+contract D {}

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -112,7 +112,7 @@ addresses = view hasLens <&> \(SolConf ca d ads _ _ _ _ _ _ _ _) ->
 populateAddresses :: [Addr] -> Integer -> VM -> VM
 populateAddresses []     _ vm = vm
 populateAddresses (a:as) b vm = populateAddresses as b (vm & set (env . EVM.contracts . at a) (Just account))
-  where account = initialContract (RuntimeCode mempty) & set nonce 1 & set balance (w256 $ fromInteger b)
+  where account = initialContract (RuntimeCode mempty) & set nonce 0 & set balance (w256 $ fromInteger b)
 
 -- | Address to load the first library
 addrLibrary :: Addr
@@ -151,6 +151,7 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
   (SolConf ca d ads bala balc pref _ _ libs _ ch) <- view hasLens
   let bc = c ^. creationCode
       blank = populateAddresses (ads |> d) bala (vmForEthrunCreation bc)
+            & env . EVM.contracts %~ sans 0x3be95e4159a131e56a84657c4ad4d43ec7cd865d -- fixes weird nonce issues
       abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c ^. abiMap)
       (tests, funs) = partition (isPrefixOf pref . fst) abi
 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -194,6 +194,8 @@ integrationTests = testGroup "Solidity Integration Testing"
       , ("echidna_set1 failed",                    passed      "ASSERTION set1") ]
   , testContract "basic/time.sol"         (Just "basic/time.yaml")
       [ ("echidna_timepassed passed",              solved      "echidna_timepassed") ]
+  , testContract "basic/construct.sol"    Nothing
+      [ ("echidna_construct passed",               solved      "echidna_construct") ]
   , testContract "abiv2/Ballot.sol"       Nothing
       [ ("echidna_test failed",                    solved      "echidna_test") ]
   , testContract "abiv2/Dynamic.sol"      Nothing


### PR DESCRIPTION
Previously, contracts couldn't create multiple new contracts because of a quick with `vmForEthrunCreation` that messed up our nonce state. This PR fixes that + adds a regression test.