### PR TITLE
Enforce non-empty list for rElem

### DIFF
--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -23,6 +23,7 @@ import EVM.Concrete (Word(..), Whiff(..))
 
 import qualified Control.Monad.Fail as M (MonadFail(..))
 import qualified Data.ByteString as BS
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Yaml as Y
 
 import Echidna.Campaign
@@ -96,7 +97,7 @@ instance FromJSON EConfig where
             <*> pure names
             <*> (SolConf <$> v .:? "contractAddr"   .!= 0x00a329c0648769a73afac7f9381e08fb43dbea72
                          <*> v .:? "deployer"       .!= 0x00a329c0648769a73afac7f9381e08fb43dbea70
-                         <*> v .:? "sender"         .!= [0x10000, 0x20000, 0x00a329c0648769a73afac7f9381e08fb43dbea70]
+                         <*> v .:? "sender"         .!= NE.fromList [0x10000, 0x20000, 0x00a329c0648769a73afac7f9381e08fb43dbea70]
                          <*> v .:? "balanceAddr"    .!= 0xffffffff
                          <*> v .:? "balanceContract".!= 0
                          <*> v .:? "prefix"         .!= "echidna_"

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -9,7 +9,7 @@ module Echidna.Solidity where
 
 import Control.Lens
 import Control.Exception          (Exception)
-import Control.Monad              (liftM2, mapM_, when, unless)
+import Control.Monad              (liftM2, when, unless)
 import Control.Monad.Catch        (MonadThrow(..))
 import Control.Monad.IO.Class     (MonadIO(..))
 import Control.Monad.Reader       (MonadReader)
@@ -42,6 +42,7 @@ import EVM.Types    (Addr)
 import EVM.Concrete (w256)
 
 import qualified Data.ByteString     as BS
+import qualified Data.List.NonEmpty  as NE
 import qualified Data.HashMap.Strict as M
 import qualified Data.Text           as T
 
@@ -75,17 +76,17 @@ instance Show SolException where
 instance Exception SolException
 
 -- | Configuration for loading Solidity for Echidna testing.
-data SolConf = SolConf { _contractAddr    :: Addr     -- ^ Contract address to use
-                       , _deployer        :: Addr     -- ^ Contract deployer address to use
-                       , _sender          :: [Addr]   -- ^ Sender addresses to use
-                       , _balanceAddr     :: Integer  -- ^ Initial balance of deployer and senders
-                       , _balanceContract :: Integer  -- ^ Initial balance of contract to test
-                       , _prefix          :: Text     -- ^ Function name prefix used to denote tests
-                       , _cryticArgs      :: [String] -- ^ Args to pass to crytic
-                       , _solcArgs        :: String   -- ^ Args to pass to @solc@
-                       , _solcLibs        :: [String] -- ^ List of libraries to load, in order.
-                       , _quiet           :: Bool     -- ^ Suppress @solc@ output, errors, and warnings
-                       , _checkAsserts    :: Bool     -- ^ Test if we can cause assertions to fail
+data SolConf = SolConf { _contractAddr    :: Addr             -- ^ Contract address to use
+                       , _deployer        :: Addr             -- ^ Contract deployer address to use
+                       , _sender          :: NE.NonEmpty Addr -- ^ Sender addresses to use
+                       , _balanceAddr     :: Integer          -- ^ Initial balance of deployer and senders
+                       , _balanceContract :: Integer          -- ^ Initial balance of contract to test
+                       , _prefix          :: Text             -- ^ Function name prefix used to denote tests
+                       , _cryticArgs      :: [String]         -- ^ Args to pass to crytic
+                       , _solcArgs        :: String           -- ^ Args to pass to @solc@
+                       , _solcLibs        :: [String]         -- ^ List of libraries to load, in order.
+                       , _quiet           :: Bool             -- ^ Suppress @solc@ output, errors, and warnings
+                       , _checkAsserts    :: Bool             -- ^ Test if we can cause assertions to fail
                        }
 makeLenses ''SolConf
 
@@ -101,7 +102,7 @@ contracts fp = let usual = ["--solc-disable-warnings", "--export-format", "solc"
   q  <- view (hasLens . quiet)
   ls <- view (hasLens . solcLibs)
   c  <- view (hasLens . cryticArgs)
-  let solargs = a ++ linkLibraries ls & (usual ++) . 
+  let solargs = a ++ linkLibraries ls & (usual ++) .
                   (\sa -> if null sa then [] else ["--solc-args", sa])
   maybe (throwM CompileFailure) (pure . toList . fst) =<< liftIO (do
     stderr <- if q then UseHandle <$> openFile "/dev/null" WriteMode else pure Inherit
@@ -109,9 +110,10 @@ contracts fp = let usual = ["--solc-disable-warnings", "--export-format", "solc"
     readSolc "crytic-export/combined_solc.json")
 
 
-addresses :: (MonadReader x m, Has SolConf x) => m [AbiValue]
+addresses :: (MonadReader x m, Has SolConf x) => m (NE.NonEmpty AbiValue)
 addresses = view hasLens <&> \(SolConf ca d ads _ _ _ _ _ _ _ _) ->
-  AbiAddress . fromIntegral <$> nub (ads ++ [ca, d, 0x0])
+  AbiAddress . fromIntegral <$> NE.nub (join ads [ca, d, 0x0])
+  where join (first NE.:| rest) list = first NE.:| (rest ++ list)
 
 populateAddresses :: [Addr] -> Integer -> VM -> VM
 populateAddresses []     _ vm = vm
@@ -141,8 +143,8 @@ linkLibraries ls = "--libraries " ++
 -- usable for Echidna. NOTE: Contract names passed to this function should be prefixed by the
 -- filename their code is in, plus a colon.
 loadSpecified :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x)
-              => Maybe Text -> [SolcContract] -> m (VM, [SolSignature], [Text])
-loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure () in do
+              => Maybe Text -> [SolcContract] -> m (VM, NE.NonEmpty SolSignature, [Text])
+loadSpecified name cs = do
   -- Pick contract to load
   c <- choose cs name
   q <- view (hasLens . quiet)
@@ -154,7 +156,7 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
   -- Local variables
   (SolConf ca d ads bala balc pref _ _ libs _ ch) <- view hasLens
   let bc = c ^. creationCode
-      blank = populateAddresses (ads |> d) bala (vmForEthrunCreation bc)
+      blank = populateAddresses ((NE.toList ads) |> d) bala (vmForEthrunCreation bc)
             & env . EVM.contracts %~ sans 0x3be95e4159a131e56a84657c4ad4d43ec7cd865d -- fixes weird nonce issues
       abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c ^. abiMap)
       con = view constructorInputs c
@@ -165,13 +167,17 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
   ls <- mapM (choose cs . Just . T.pack) libs
 
   -- Make sure everything is ready to use, then ship it
-  mapM_ (uncurry ensure) $ [(abi, NoFuncs), (funs, OnlyTests)]
-                        ++ if ch then [] else [(tests, NoTests)] -- ABI checks
-  ensure bc (NoBytecode $ c ^. contractName)                     -- Bytecode check
+  when (abi == []) $ throwM NoFuncs                             -- < ABI checks
+  neFuns <- maybe (throwM OnlyTests) pure (NE.nonEmpty funs)    -- <
+  when (not ch && tests == []) $ throwM NoTests                 -- <
+  when (bc == mempty) $ throwM (NoBytecode $ c ^. contractName) -- Bytecode check
+
   case find (not . null . snd) tests of
-    Just (t,_) -> throwM $ TestArgsFound t                       -- Test args check
-    Nothing    -> loadLibraries ls addrLibrary d blank >>= fmap (, fallback : funs, fst <$> tests) .
-      execStateT (execTx $ Tx (Right bc) d ca 0xffffffff 0 (w256 $ fromInteger balc) (0, 0))
+    Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check
+    Nothing    -> do
+      vm <- loadLibraries ls addrLibrary d blank
+      let transaction = Tx (Right bc) d ca 0xffffffff 0 (w256 $ fromInteger balc) (0, 0)
+      (fmap (, fallback NE.<| neFuns, fst <$> tests) . execStateT (execTx transaction)) vm
 
   where choose []    _        = throwM NoContracts
         choose (c:_) Nothing  = return c
@@ -188,16 +194,18 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
 --             => FilePath -> Maybe Text -> m (VM, [SolSignature], [Text])
 --loadSolidity fp name = contracts fp >>= loadSpecified name
 loadWithCryticCompile :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x)
-             => FilePath -> Maybe Text -> m (VM, [SolSignature], [Text])
+             => FilePath -> Maybe Text -> m (VM, NE.NonEmpty SolSignature, [Text])
 loadWithCryticCompile fp name = contracts fp >>= loadSpecified name
+
 
 -- | Given the results of 'loadSolidity', assuming a single-contract test, get everything ready
 -- for running a 'Campaign' against the tests found.
 prepareForTest :: (MonadReader x m, Has SolConf x)
-               => (VM, [SolSignature], [Text]) -> m (VM, World, [SolTest])
+               => (VM, NE.NonEmpty SolSignature, [Text]) -> m (VM, World, [SolTest])
 prepareForTest (v, a, ts) = view hasLens <&> \(SolConf _ _ s _ _ _ _ _ _ _ ch) ->
-  (v, World s [(r, a)], fmap Left (zip ts $ repeat r) ++ if ch then Right <$> drop 1 a else []) where
+  (v, World s ((r, a) NE.:| []), fmap Left (zip ts $ repeat r) ++ if ch then Right <$> drop 1 a' else []) where
     r = v ^. state . contract
+    a' = NE.toList a
 
 -- | Basically loadSolidity, but prepares the results to be passed directly into
 -- a testing function.

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -156,7 +156,7 @@ loadSpecified name cs = do
   -- Local variables
   (SolConf ca d ads bala balc pref _ _ libs _ ch) <- view hasLens
   let bc = c ^. creationCode
-      blank = populateAddresses ((NE.toList ads) |> d) bala (vmForEthrunCreation bc)
+      blank = populateAddresses (NE.toList ads |> d) bala (vmForEthrunCreation bc)
             & env . EVM.contracts %~ sans 0x3be95e4159a131e56a84657c4ad4d43ec7cd865d -- fixes weird nonce issues
       abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c ^. abiMap)
       con = view constructorInputs c
@@ -167,9 +167,9 @@ loadSpecified name cs = do
   ls <- mapM (choose cs . Just . T.pack) libs
 
   -- Make sure everything is ready to use, then ship it
-  when (abi == []) $ throwM NoFuncs                             -- < ABI checks
+  when (null abi) $ throwM NoFuncs                              -- < ABI checks
   neFuns <- maybe (throwM OnlyTests) pure (NE.nonEmpty funs)    -- <
-  when (not ch && tests == []) $ throwM NoTests                 -- <
+  when (not ch && null tests) $ throwM NoTests                  -- <
   when (bc == mempty) $ throwM (NoBytecode $ c ^. contractName) -- Bytecode check
 
   case find (not . null . snd) tests of

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -19,17 +19,16 @@ import Control.Monad.Reader.Class (MonadReader)
 import Control.Monad.State.Strict (MonadState, State, evalStateT, runState)
 import Data.Aeson (ToJSON(..), object)
 import Data.ByteString (ByteString)
-import Data.Either (either, lefts)
+import Data.Either (either)
 import Data.Has (Has(..))
 import Data.List (intercalate)
-import Data.Set (Set)
 import EVM
 import EVM.ABI (abiCalldata, abiValueType)
 import EVM.Concrete (Word(..), w256)
 import EVM.Types (Addr)
 
 import qualified Control.Monad.State.Strict as S (state)
-import qualified Data.Set as S
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Vector as V
 
@@ -85,19 +84,19 @@ level (elemOf each 0 -> True) = (0,0)
 level x                       = x
 
 -- | A contract is just an address with an ABI (for our purposes).
-type ContractA = (Addr, [SolSignature])
+type ContractA = (Addr, NE.NonEmpty SolSignature)
 
 -- | The world is made our of humans with an address, and contracts with an address + ABI.
-data World = World { _senders   :: [Addr]
-                   , _receivers :: [ContractA]
+data World = World { _senders   :: NE.NonEmpty Addr
+                   , _receivers :: NE.NonEmpty ContractA
                    }
 makeLenses ''World
 
 -- | Given generators for an origin, destination, value, and function call, generate a call
 -- transaction. Note: This doesn't generate @CREATE@s because I don't know how to do that at random.
-genTxWith :: (MonadRandom m, MonadState x m, Has World x, MonadThrow m) 
-          => ([Addr] -> m Addr)                       -- ^ Sender generator
-          -> ([ContractA] -> m ContractA)             -- ^ Receiver generator
+genTxWith :: (MonadRandom m, MonadState x m, Has World x, MonadThrow m)
+          => (NE.NonEmpty Addr -> m Addr)             -- ^ Sender generator
+          -> (NE.NonEmpty ContractA -> m ContractA)   -- ^ Receiver generator
           -> (Addr -> ContractA -> m SolCall)         -- ^ Call generator
           -> m Word                                   -- ^ Gas generator
           -> m Word                                   -- ^ Gas price generator
@@ -115,7 +114,7 @@ genTx = use (hasLens :: Lens' y World) >>= evalStateT genTxM . (defaultDict,)
 -- | Generate a random 'Transaction' with either synthesis or mutation of dictionary entries.
 genTxM :: (MonadRandom m, MonadReader x m, Has TxConf x, MonadState y m, Has GenDict y, Has World y, MonadThrow m) => m Tx
 genTxM = view hasLens >>= \(TxConf _ g maxGp t b) -> genTxWith
-  (rElem "sender list") (rElem "recipient list")                             -- src and dst
+  rElem rElem                                                                -- src and dst
   (const $ genInteractionsM . snd)                                           -- call itself
   (pure g) (inRange maxGp) (\_ _ _ -> pure 0)                                -- gas, gasprice, value
   (level <$> liftM2 (,) (inRange t) (inRange b))                             -- delay
@@ -134,16 +133,6 @@ shrinkTx (Tx c s d g gp (C _ v) (C _ t, C _ b)) = let
   c' = either (fmap Left . shrinkAbiCall) (fmap Right . pure) c
   lower x = w256 . fromIntegral <$> getRandomR (0 :: Integer, fromIntegral x) in
     liftM5 Tx c' (pure s) (pure d) (pure g) (lower gp) <*> lower v <*> fmap level (liftM2 (,) (lower t) (lower b))
-
--- | Given a 'Set' of 'Transaction's, generate a similar 'Transaction' at random.
-spliceTxs :: (MonadRandom m, MonadReader x m, Has TxConf x, MonadState y m, Has World y, MonadThrow m) => Set Tx -> m Tx
-spliceTxs ts = let l = S.toList ts; (cs, ss) = unzip $ (\(Tx c s _ _ _ _ _) -> (c,s)) <$> l in
-  view (hasLens . txGas) >>= \g ->
-    genTxWith (const . rElem "sender list" $ ss) (rElem "recipient list")
-              (\_ _ -> mutateAbiCall =<< rElem "past calls" (lefts cs)) (pure g) (pure 0)
-              (\ _ _ (n,_) -> let valOf (Tx c _ _ _ _ v _) = if elem n $ c ^? _Left . _1 then v else 0
-                              in rElem "values" $ valOf <$> l)
-              (pure (0, 0))
 
 -- | Lift an action in the context of a component of some 'MonadState' to an action in the
 -- 'MonadState' itself.

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -15,6 +15,8 @@ import Echidna.Solidity
 import Echidna.Campaign
 import Echidna.UI
 
+import qualified Data.List.NonEmpty as NE
+
 data Options = Options
   { filePath         :: FilePath
   , selectedContract :: Maybe String
@@ -47,5 +49,5 @@ main = do Options f c conf <- execParser opts
             cs       <- contracts f
             ads      <- addresses
             (v,w,ts) <- loadSpecified (pack <$> c) cs >>= prepareForTest
-            ui v w ts (Just $ mkGenDict (dictFreq $ view cConf cfg)  (extractConstants cs ++ ads) [] g (returnTypes cs))
+            ui v w ts (Just $ mkGenDict (dictFreq $ view cConf cfg) (extractConstants cs ++ NE.toList ads) [] g (returnTypes cs))
           if not . isSuccess $ cpg then exitWith $ ExitFailure 1 else exitSuccess

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -200,7 +200,7 @@ runContract fp c =
     (v,w,ts) <- loadSolTests fp Nothing
     cs  <- contracts fp
     ads <- addresses
-    campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ (NE.toList ads)) [] g (returnTypes cs))
+    campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ NE.toList ads) [] g (returnTypes cs))
 
 getResult :: Text -> Campaign -> Maybe TestState
 getResult t = fmap snd <$> find ((t ==) . either fst (("ASSERTION " <>) . fst) . fst) . view tests

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -22,6 +22,8 @@ import Data.List (find)
 import EVM.ABI (AbiValue(..))
 import System.Directory (withCurrentDirectory)
 
+import qualified Data.List.NonEmpty   as NE
+
 main :: IO ()
 main = withCurrentDirectory "./examples/solidity" . defaultMain $
          testGroup "Echidna" [ configTests
@@ -119,7 +121,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       , ("echidna_revert_is_false didn't shrink to f(-1)",
          solvedWith ("f", [AbiInt 256 (-1)]) "echidna_fails_on_revert")
       ]
-  
+
   , testContract "basic/nearbyMining.sol" (Just "coverage/test.yaml")
       [ ("echidna_findNearby passed", solved "echidna_findNearby") ]
 
@@ -137,13 +139,13 @@ integrationTests = testGroup "Solidity Integration Testing"
   , testContract "basic/contractAddr.sol" Nothing
       [ ("echidna_address failed",                 solved      "echidna_address") ]
   , testContract "basic/contractAddr.sol" (Just "basic/contractAddr.yaml")
-      [ ("echidna_address failed",                 passed      "echidna_address") ]      
+      [ ("echidna_address failed",                 passed      "echidna_address") ]
   , testContract "basic/constants.sol"    Nothing
       [ ("echidna_found failed",                   solved      "echidna_found") ]
   , testContract "basic/constants2.sol"   Nothing
       [ ("echidna_found32 failed",                 solved      "echidna_found32") ]
   , testContract "basic/constants3.sol"   Nothing
-      [ ("echidna_found_sender failed",            solved      "echidna_found_sender") ] 
+      [ ("echidna_found_sender failed",            solved      "echidna_found_sender") ]
   , testContract "basic/rconstants.sol"   Nothing
       [ ("echidna_found failed",                   solved      "echidna_found") ]
 -- single.sol is really slow and kind of unstable. it also messes up travis.
@@ -164,9 +166,9 @@ integrationTests = testGroup "Solidity Integration Testing"
   , testContract "basic/darray.sol"       Nothing
       [ ("echidna_darray passed",                  solved      "echidna_darray")
       , ("echidna_darray didn't shrink optimally", solvedLen 1 "echidna_darray") ]
-  , testContract "basic/propGasLimit.sol" (Just "basic/propGasLimit.yaml") 
+  , testContract "basic/propGasLimit.sol" (Just "basic/propGasLimit.yaml")
       [ ("echidna_runForever passed",              solved      "echidna_runForever") ]
-  , testContract "basic/assert.sol"       (Just "basic/assert.yaml") 
+  , testContract "basic/assert.sol"       (Just "basic/assert.yaml")
       [ ("echidna_set0 passed",                    solved      "ASSERTION set0")
       , ("echidna_set1 failed",                    passed      "ASSERTION set1") ]
   , testContract "basic/time.sol"         (Just "basic/time.yaml")
@@ -198,7 +200,7 @@ runContract fp c =
     (v,w,ts) <- loadSolTests fp Nothing
     cs  <- contracts fp
     ads <- addresses
-    campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ ads) [] g (returnTypes cs))
+    campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ (NE.toList ads)) [] g (returnTypes cs))
 
 getResult :: Text -> Campaign -> Maybe TestState
 getResult t = fmap snd <$> find ((t ==) . either fst (("ASSERTION " <>) . fst) . fst) . view tests


### PR DESCRIPTION
This PR removes the necessity to handle an empty list passed to `rElem` function by shrinking the domain to non-empty lists only. I've initially enforced that on type level and guided by the compiler, arrived to the `loadSpecified` function which was already verifying the non-emptiness. It was possible to push this verified precondition in a type safe way to callees.

I've also removed the `spliceTxs` as it was not used anywhere and required a non-empty set type.

Happy Programmer's Day! :)