### PR TITLE
Fix default.yaml config

### DIFF
--- a/examples/solidity/basic/config.yaml
+++ b/examples/solidity/basic/config.yaml
@@ -1,2 +1,1 @@
 testLimit: 100000000
-range: 10

--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -28,7 +28,7 @@ balanceContract: 0
 #solcArgs allows special Args to solc
 solcArgs: ""
 #solcLibs is solc libraries
-solcLibs: ""
+solcLibs: []
 #quiet produces (much) less verbose output
 quiet: False
 #dashboard determines if output is just text or an AFL-like display

--- a/examples/solidity/basic/payable.yaml
+++ b/examples/solidity/basic/payable.yaml
@@ -1,5 +1,4 @@
 testLimit: 10000
-range: 3
 contractAddr: "0x00a329c0648769a73afac7f9381e08fb43dbea72"
 sender: ["0x00a329c0648769a73afac7f9381e08fb43dbea70"]
 #payable: ["f"]

--- a/examples/solidity/coverage/harvey.yaml
+++ b/examples/solidity/coverage/harvey.yaml
@@ -1,5 +1,4 @@
 testLimit: 1000000
 epochs: 100
-range: 1
 printCoverage: true
 outdir: "outdir"

--- a/examples/solidity/tokens/missing_constructor_config.yaml
+++ b/examples/solidity/tokens/missing_constructor_config.yaml
@@ -1,5 +1,4 @@
 testLimit: 10000
-range: 10
 contractAddr: "0x00a329c0648769a73afac7f9381e08fb43dbea72"
 sender: "0x00a329c0648769a73afac7f9381e08fb43dbea70"
 shrinkLimit: 1000

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -16,7 +16,7 @@ import Echidna.Solidity
 import Echidna.Transaction (Tx, call)
 
 import Control.Lens
-import Control.Monad (liftM2)
+import Control.Monad (liftM2, void)
 import Control.Monad.Catch (MonadCatch(..))
 import Control.Monad.Random (getRandom, evalRand, mkStdGen)
 import Control.Monad.Reader (runReaderT)
@@ -32,7 +32,20 @@ import qualified Data.Vector          as V
 
 main :: IO ()
 main = withCurrentDirectory "./examples/solidity" . defaultMain $
-         testGroup "Echidna" [encodingTests, compilationTests, seedTests, integrationTests]
+         testGroup "Echidna" [ configTests
+                             , encodingTests
+                             , compilationTests
+                             , seedTests
+                             , integrationTests
+                             ]
+
+
+-- Configuration Tests
+
+configTests :: TestTree
+configTests = testGroup "Configuration parsing"
+  [ testCase file $ void $ parseConfig file | file <- files ]
+  where files = ["basic/config.yaml", "basic/default.yaml"]
 
 -- Compilation Tests
 


### PR DESCRIPTION
I've discovered that `basic/default.yaml` config won't parse due to `solcLibs` being string. I've changed that to the proper type and created a test to have it in sync, since it seems to be a sample config mentioned in README.

I've added `basic/config.yaml` to tests as well but it looks unused, should this be removed? Rest of configs are already parsed with their sol tests.

Additionally, the range option also is unused but parser accepts all the additional keys as long as the required are present. Maybe it would be good to force the parser to reject a config with extra keys?