### PR TITLE
Fix coverage optimization and configuration

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -25,7 +25,7 @@ import Data.Bool (bool)
 import Data.Either (lefts)
 import Data.Foldable (toList)
 import Data.Map (Map, mapKeys, unionWith)
-import Data.Maybe (fromMaybe, isNothing, mapMaybe, maybeToList)
+import Data.Maybe (fromMaybe, isJust, mapMaybe, maybeToList)
 import Data.Ord (comparing)
 import Data.Has (Has(..))
 import Data.Set (Set, union)
@@ -180,7 +180,8 @@ callseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
 callseq v w ql = do
   -- First, we figure out whether we need to execute with or without coverage optimization, and pick
   -- our execution function appropriately
-  ef <- bool execTx execTxOptC . isNothing . knownCoverage <$> view hasLens
+  coverageEnabled <- isJust . knownCoverage <$> view hasLens
+  let ef = if coverageEnabled then execTxOptC else execTx
   -- Then, we get the current campaign state
   ca <- use hasLens
   -- Then, we generate the actual transaction in the sequence

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -16,6 +16,7 @@ import Data.ByteString.Lazy.Char8 (unpack)
 import Data.Has (Has(..))
 import Data.Aeson
 import Data.Aeson.Lens
+import Data.Functor ((<&>))
 import Data.Text (isPrefixOf)
 import EVM (result)
 import EVM.Concrete (Word(..), Whiff(..))
@@ -68,10 +69,12 @@ instance FromJSON EConfig where
         getWord s d = C Dull . fromIntegral <$> v .:? s .!= (d :: Integer)
         xc = liftM4 TxConf (getWord "propMaxGas" 8000030) (getWord "testMaxGas" 0xffffffff)
                            (getWord "maxTimeDelay" 604800)     (getWord "maxBlockDelay" 60480)
+        coverageParser = v .:? "coverage" <&> \case Just True -> Just mempty
+                                                    _         -> Nothing
         cc = CampaignConf <$> v .:? "testLimit"   .!= 50000
                           <*> v .:? "seqLen"      .!= 100
                           <*> v .:? "shrinkLimit" .!= 5000
-                          <*> pure Nothing
+                          <*> coverageParser
                           <*> v .:? "seed"
         names :: Names
         names Sender = (" from: " ++) . show

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -69,12 +69,12 @@ instance FromJSON EConfig where
         getWord s d = C Dull . fromIntegral <$> v .:? s .!= (d :: Integer)
         xc = liftM4 TxConf (getWord "propMaxGas" 8000030) (getWord "testMaxGas" 0xffffffff)
                            (getWord "maxTimeDelay" 604800)     (getWord "maxBlockDelay" 60480)
-        coverageParser = v .:? "coverage" <&> \case Just True -> Just mempty
-                                                    _         -> Nothing
+        cov = v .:? "coverage" <&> \case Just True -> Just mempty
+                                         _         -> Nothing
         cc = CampaignConf <$> v .:? "testLimit"   .!= 50000
                           <*> v .:? "seqLen"      .!= 100
                           <*> v .:? "shrinkLimit" .!= 5000
-                          <*> coverageParser
+                          <*> cov
                           <*> v .:? "seed"
         names :: Names
         names Sender = (" from: " ++) . show

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 import Hedgehog (MonadGen, withTests, Size(unSize), property, (===), forAll)
 import Hedgehog.Gen (choice, sized, integral, list)
@@ -32,7 +33,24 @@ import qualified Data.Vector          as V
 
 main :: IO ()
 main = withCurrentDirectory "./examples/solidity" . defaultMain $
-         testGroup "Echidna" [encodingTests, compilationTests, seedTests, integrationTests]
+         testGroup "Echidna" [ configTests
+                             , encodingTests
+                             , compilationTests
+                             , seedTests
+                             , integrationTests
+                             ]
+
+configTests :: TestTree
+configTests = testGroup "Configuration tests"
+  [ testCase "parse \"coverage: true\"" $ do
+      config <- parseConfig "coverage/test.yaml"
+      assertCoverage config $ Just mempty
+  , testCase "coverage disabled by default" $
+      assertCoverage defaultConfig Nothing
+  ]
+  where assertCoverage config value = do
+          let CampaignConf{knownCoverage} = view cConf config
+          knownCoverage @?= value
 
 -- Compilation Tests
 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -43,7 +43,7 @@ main = withCurrentDirectory "./examples/solidity" . defaultMain $
 -- Configuration Tests
 
 configTests :: TestTree
-configTests = testGroup "Configuration tests"
+configTests = testGroup "Configuration tests" $
   [ testCase file $ void $ parseConfig file | file <- files ] ++
   [ testCase "parse \"coverage: true\"" $ do
       config <- parseConfig "coverage/test.yaml"


### PR DESCRIPTION
This PR fixes 2 things:
1. Wrong execution function choice in `callseq` which resulted in coverage being collected all the time. I believe it could be due to a bit confusing `bool` function. It picked in fact `execTxOptC` when `knownCoverage` was `Nothing`. I've replaced it with a more explicit condition.
2. The `coverage: true` JSON config was not being respected. I've added correct parsing with some tests. This solves: https://github.com/crytic/echidna/issues/208

The test suite is running now in around 100s on my machine vs around 140s before the fix. Also `echidna-test` should be faster by default from now on.