### PR TITLE
Measure and display campaign's elapsed time

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
   - stm
   - temporary            >= 1.2.1  && < 1.4
   - text                 >= 1.2.2  && < 1.3
+  - time
   - transformers
   - unliftio
   - unliftio-core


### PR DESCRIPTION
This PR introduces campaign's elapsed time. It is shown after a campaign finishes, does not update in the real time.

This is how it looks like:
```
┌───────────────────────────────────────Echidna───────────────────────────────────────┐
│  echidna_sometimesfalse: failed!💥
│    Call sequence:                                                                   │
│      set0(0)                                                                        │
│      set1(0)                                                                        │
│                                                                                     │
│  echidna_alwaystrue: passed! 🎉
│  echidna_revert_always: passed! 🎉
├─────────────────────────────────────────────────────────────────────────────────────┤
│  Unique instructions: 244                                                           │
│  Unique codehashes: 1                                                               │
├─────────────────────────────────────────────────────────────────────────────────────┤
│  Time elapsed: 84.371095542s                                                        │
└─────────────────────────────────────────────────────────────────────────────────────┘
Campaign complete, C-c or esc to print report
```

```
Analyzing contract: /ctf/echidna/flags.sol:Test
echidna_sometimesfalse: failed!💥
  Call sequence:
    set0(0)
    set1(0)

echidna_alwaystrue: passed! 🎉
echidna_revert_always: passed! 🎉

Unique instructions: 244
Unique codehashes: 1
Time elapsed: 84.371095542s
Seed: -978742334553793422
```