### PR TITLE
Improve transaction shrinking

### DIFF
--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -138,7 +138,7 @@ shrinkTx tx'@(Tx c _ _ _ gp (C _ v) (C _ t, C _ b)) = let
     , set gasprice' <$> lower gp
     , set delay     <$> fmap level (liftM2 (,) (lower t) (lower b))
     ]
-  in (sequence possibilities >>= uniform) <*> pure tx'
+  in join (uniform possibilities) <*> pure tx'
 
 -- | Lift an action in the context of a component of some 'MonadState' to an action in the
 -- 'MonadState' itself.


### PR DESCRIPTION
I came up with this PR after investigating https://github.com/crytic/echidna/issues/308.

The problem is that all components of a transaction are shrunk at the same time.

In the example from the issue, extracted constants (hence the mentioned probability) were already producing a minimal value for ABI calls and further shrinking of this value no longer made the property to fail. This caused the other shrinkable components (time and block delay) to halt. The problem will generally occur when shrinkage of a components flips a property back to success but there are other shrinkable components.

The fix I've made is to randomly choose a component to shrink so that their shrinking is independent.