### PR TITLE
Expose the dictionary frequency use parameter to allow experimentation

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -60,6 +60,7 @@ data CampaignConf = CampaignConf { testLimit     :: Int
                                    -- ^ If applicable, initially known coverage. If this is 'Nothing',
                                    -- Echidna won't collect coverage information (and will go faster)
                                  , seed          :: Maybe Int
+                                 , dictFreq      :: Float
                                  }
 
 -- | State of a particular Echidna test. N.B.: \"Solved\" means a falsifying call sequence was found.
@@ -215,7 +216,7 @@ campaign u v w ts d = let d' = fromMaybe defaultDict d in fmap (fromMaybe mempty
   execStateT (evalRandT runCampaign g') (Campaign ((,Open (-1)) <$> ts) c d' True) where
     step        = runUpdate (updateTest v Nothing) >> lift u >> runCampaign
     runCampaign = use (hasLens . tests . to (fmap snd)) >>= update
-    update c    = view hasLens >>= \(CampaignConf tl q sl _ _) ->
+    update c    = view hasLens >>= \(CampaignConf tl q sl _ _ _) ->
       if | any (\case Open  n   -> n < tl; _ -> False) c -> callseq v w q >> step
          | any (\case Large n _ -> n < sl; _ -> False) c -> step
          | otherwise                                     -> lift u

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -76,6 +76,8 @@ instance FromJSON EConfig where
                           <*> v .:? "shrinkLimit" .!= 5000
                           <*> cov
                           <*> v .:? "seed"
+                          <*> v .:? "dictFreq"    .!= 0.15
+
         names :: Names
         names Sender = (" from: " ++) . show
         names _      = const ""

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -81,7 +81,7 @@ ppTS :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Test
 ppTS (Failed e)  = pure $ "could not evaluate ☣\n  " ++ show e
 ppTS (Solved l)  = ppFail Nothing l
 ppTS Passed      = pure "passed! 🎉"
-ppTS (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _) ->
+ppTS (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _ _) ->
                      if i >= t then ppTS Passed else pure $ "fuzzing " ++ progress i t
 ppTS (Large n l) = view (hasLens . to shrinkLimit) >>= \m -> ppFail (if n < m then Just (n,m) 
                                                                               else Nothing) l

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Control.Lens (view)
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.Random (getRandom)
 import Data.Text (pack)
@@ -46,5 +47,5 @@ main = do Options f c conf <- execParser opts
             cs       <- contracts f
             ads      <- addresses
             (v,w,ts) <- loadSpecified (pack <$> c) cs >>= prepareForTest
-            ui v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ ads) [] g (returnTypes cs))
+            ui v w ts (Just $ mkGenDict (dictFreq $ view cConf cfg)  (extractConstants cs ++ ads) [] g (returnTypes cs))
           if not . isSuccess $ cpg then exitWith $ ExitFailure 1 else exitSuccess

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -141,7 +141,7 @@ seedTests =
     , testCase "same seeds" $ assertBool "results differ" =<< same 0 0
     ]
     where cfg s = defaultConfig & sConf . quiet .~ True
-                                & cConf .~ CampaignConf 600 20 0 Nothing (Just s)
+                                & cConf .~ CampaignConf 600 20 0 Nothing (Just s) 0.15
           gen s = view tests <$> runContract "basic/flags.sol" (cfg s)
           same s t = liftM2 (==) (gen s) (gen t)
 


### PR DESCRIPTION
The new `dictFreq` parameter (0.0 to 1.0) allows to control how often the dictionary is used during a fuzzing campaign.