### PR TITLE
Abort testing if constructor requires arguments

### DIFF
--- a/examples/solidity/bad/consargs.sol
+++ b/examples/solidity/bad/consargs.sol
@@ -1,0 +1,5 @@
+contract Abstract {
+  constructor(uint x) public {}
+  function f() pure public {}
+  function echidna_f() pure public returns (bool) {return true;}
+}

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -68,7 +68,7 @@ instance Show SolException where
     NoFuncs              -> "ABI is empty, are you sure your constructor is right?"
     NoTests              -> "No tests found in ABI"
     OnlyTests            -> "Only tests and no public functions found in ABI"
-    (ConstructorArgs s)  -> "Constructor arguments are requiered: " ++ s
+    (ConstructorArgs s)  -> "Constructor arguments are required: " ++ s
 
 
 instance Exception SolException

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -55,6 +55,7 @@ data SolException = BadAddr Addr
                   | NoFuncs
                   | NoTests
                   | OnlyTests
+                  | ConstructorArgs String
 
 instance Show SolException where
   show = \case
@@ -67,6 +68,8 @@ instance Show SolException where
     NoFuncs              -> "ABI is empty, are you sure your constructor is right?"
     NoTests              -> "No tests found in ABI"
     OnlyTests            -> "Only tests and no public functions found in ABI"
+    (ConstructorArgs s)  -> "Constructor arguments are requiered: " ++ s
+
 
 instance Exception SolException
 
@@ -153,8 +156,10 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
       blank = populateAddresses (ads |> d) bala (vmForEthrunCreation bc)
             & env . EVM.contracts %~ sans 0x3be95e4159a131e56a84657c4ad4d43ec7cd865d -- fixes weird nonce issues
       abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c ^. abiMap)
+      con = view constructorInputs c
       (tests, funs) = partition (isPrefixOf pref . fst) abi
 
+  when (not . null $ con) (throwM $ ConstructorArgs (show con))
   -- Select libraries
   ls <- mapM (choose cs . Just . T.pack) libs
 

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -159,7 +159,7 @@ loadSpecified name cs = let ensure l e = if l == mempty then throwM e else pure 
       con = view constructorInputs c
       (tests, funs) = partition (isPrefixOf pref . fst) abi
 
-  when (not . null $ con) (throwM $ ConstructorArgs (show con))
+  unless (null con) (throwM $ ConstructorArgs (show con))
   -- Select libraries
   ls <- mapM (choose cs . Just . T.pack) libs
 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -72,6 +72,8 @@ compilationTests = testGroup "Compilation and loading tests"
                                               \case OnlyTests{}        -> True; _ -> False
   , loadFails "bad/testargs.sol"   Nothing    "failed to warn on test args found" $
                                               \case TestArgsFound{}    -> True; _ -> False
+  , loadFails "bad/consargs.sol"   Nothing    "failed to warn on cons args found" $
+                                              \case ConstructorArgs{}  -> True; _ -> False
   ]
 
 loadFails :: FilePath -> Maybe Text -> String -> (SolException -> Bool) -> TestTree


### PR DESCRIPTION
This small PR will be useful to warn users about arguments in the contract constructor.