### PR TITLE
Automatic corpus collection

### DIFF
--- a/examples/solidity/harvey/harvey.yaml
+++ b/examples/solidity/harvey/harvey.yaml
@@ -1,0 +1,2 @@
+testLimit: 10000
+seqLen: 100

--- a/examples/solidity/harvey/harvey.yaml
+++ b/examples/solidity/harvey/harvey.yaml
@@ -1,2 +1,2 @@
-testLimit: 10000
+testLimit: 50000
 seqLen: 100

--- a/examples/solidity/harvey/harvey.yaml
+++ b/examples/solidity/harvey/harvey.yaml
@@ -1,2 +1,0 @@
-testLimit: 50000
-seqLen: 100

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -217,7 +217,7 @@ callseq v w ql tl = do
 
 
 sizeOverTime :: Int -> Int -> Int -> Int
-sizeOverTime p tl ql = if p >= (tl `div` 5) then ql else max 1 $ p * ql `div` (tl `div` 5)
+sizeOverTime p tl ql = if p >= (tl `div` 10) then ql else max 1 $ p * ql `div` (tl `div` 10)
 
 collectCorpus :: (MonadState s m, Has Campaign s) => [(Tx, VMResult)] -> m ()
 collectCorpus res = let rtxs = map fst (filter (\(_, vm) -> classifyRes vm /= ResRevert) res)

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -119,7 +119,7 @@ defaultCampaign = Campaign mempty mempty defaultDict False False mempty
 
 -- | Given a 'Campaign', return the progress of it
 getProgress :: Campaign -> Int
-getProgress (Campaign ts _ _ _ _ _) = foldr1 max $ map ((\case Open i -> i; _ -> 0) . snd) ts 
+getProgress (Campaign ts _ _ _ _ _) = maximum $ map ((\case Open i -> i; _ -> 0) . snd) ts 
 
 -- | Given a 'Campaign', checks if we can attempt any solves or shrinks without exceeding
 -- the limits defined in our 'CampaignConf'.
@@ -197,7 +197,7 @@ callseq v w ql tl = do
   let ef = if coverageEnabled then execTxOptC else execTx
   -- Then, we get the current campaign state
   ca <- use hasLens
-  let ql' = max 1 $ ((getProgress ca) * ql) `div` tl
+  let ql' = max 1 $ getProgress ca * ql `div` tl
   -- Then, we generate the actual transaction in the sequence
   is <- replicateM ql' (evalStateT genTxM (w, ca ^. genDict))
   -- We then run each call sequentially. This gives us the result of each call, plus a new state

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -79,6 +79,7 @@ instance FromJSON EConfig where
                           <*> cov
                           <*> v .:? "seed"
                           <*> v .:? "dictFreq"    .!= 0.15
+                          <*> v .:? "corpusDir"
 
         names :: Names
         names Sender = (" from: " ++) . show

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -14,6 +14,7 @@ import Echidna.Config
 import Echidna.Solidity
 import Echidna.Campaign
 import Echidna.UI
+import Echidna.Transaction
 
 import qualified Data.List.NonEmpty as NE
 
@@ -50,4 +51,5 @@ main = do Options f c conf <- execParser opts
             ads      <- addresses
             (v,w,ts) <- loadSpecified (pack <$> c) cs >>= prepareForTest
             ui v w ts (Just $ mkGenDict (dictFreq $ view cConf cfg) (extractConstants cs ++ NE.toList ads) [] g (returnTypes cs))
+          saveCorpus (corpusDir $ view cConf cfg) (view corpus cpg)
           if not . isSuccess $ cpg then exitWith $ ExitFailure 1 else exitSuccess

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -157,9 +157,9 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_balance failed",                 passed      "echidna_balance") ]
   , testContract "basic/library.sol"      (Just "basic/library.yaml")
       [ ("echidna_library_call failed",            solved      "echidna_library_call") ]
-  , testContract "harvey/foo.sol"         Nothing
+  , testContract "harvey/foo.sol"         (Just "harvey/harvey.yaml")
       [ ("echidna_assert failed",                  solved      "echidna_assert") ]
-  , testContract "harvey/baz.sol"         Nothing
+  , testContract "harvey/baz.sol"         (Just "harvey/harvey.yaml")
       [ ("echidna_all_states failed",              solved      "echidna_all_states") ]
   , testContract "basic/fallback.sol"     Nothing
       [ ("echidna_fallback failed",                solved      "echidna_fallback") ]

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -157,9 +157,9 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_balance failed",                 passed      "echidna_balance") ]
   , testContract "basic/library.sol"      (Just "basic/library.yaml")
       [ ("echidna_library_call failed",            solved      "echidna_library_call") ]
-  , testContract "harvey/foo.sol"         (Just "harvey/harvey.yaml")
+  , testContract "harvey/foo.sol"         Nothing
       [ ("echidna_assert failed",                  solved      "echidna_assert") ]
-  , testContract "harvey/baz.sol"         (Just "harvey/harvey.yaml")
+  , testContract "harvey/baz.sol"         Nothing
       [ ("echidna_all_states failed",              solved      "echidna_all_states") ]
   , testContract "basic/fallback.sol"     Nothing
       [ ("echidna_fallback failed",                solved      "echidna_fallback") ]

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -98,7 +98,7 @@ seedTests =
     , testCase "same seeds" $ assertBool "results differ" =<< same 0 0
     ]
     where cfg s = defaultConfig & sConf . quiet .~ True
-                                & cConf .~ CampaignConf 600 20 0 Nothing (Just s) 0.15
+                                & cConf .~ CampaignConf 600 20 0 Nothing (Just s) 0.15 Nothing
           gen s = view tests <$> runContract "basic/flags.sol" (cfg s)
           same s t = liftM2 (==) (gen s) (gen t)
 


### PR DESCRIPTION
The new config keyword `corpusDir` allows to define a directory that will be used to save all the sequences of transactions that generated new coverage.