### PR TITLE
Increase dictionary frequency usage parameter up to 40%

### DIFF
--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -78,7 +78,7 @@ instance FromJSON EConfig where
                           <*> v .:? "shrinkLimit" .!= 5000
                           <*> cov
                           <*> v .:? "seed"
-                          <*> v .:? "dictFreq"    .!= 0.15
+                          <*> v .:? "dictFreq"    .!= 0.40
 
         names :: Names
         names Sender = (" from: " ++) . show


### PR DESCRIPTION
According to some experiments performed with the [VeriSmart benchmark](https://github.com/kupl/VeriSmart-benchmarks/pull/2), the optimal parameter to maximize coverage discovered in Echidna should be 40% instead of 15%:

![out](https://user-images.githubusercontent.com/31542053/67625392-1b25b080-f814-11e9-88c3-d845cb650a0b.png)

These experiments were performed with 500,000 iterations per contract, repeating each run with different parameters 3 times to obtain stable metrics. 