### PR TITLE
Minor shrinking improvements

### DIFF
--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -131,7 +131,9 @@ canShrinkTx _                                = True
 shrinkTx :: MonadRandom m => Tx -> m Tx
 shrinkTx tx'@(Tx c _ _ _ gp (C _ v) (C _ t, C _ b)) = let
   c' = either (fmap Left . shrinkAbiCall) (fmap Right . pure) c
+  lower 0 = pure $ w256 0
   lower x = w256 . fromIntegral <$> getRandomR (0 :: Integer, fromIntegral x)
+              >>= \r -> uniform [0, r] -- try 0 quicker
   possibilities =
     [ set call      <$> c'
     , set value     <$> lower v


### PR DESCRIPTION
This includes a few shrinking improvements:

1. `AbiInt` and `AbiUInt` shrinking is no longer stuck when there is a last bit on a high position
2. `addChars` function was occasionally adding one byte due to off by one error
3. `0` has a preference when shrinking `value`, `gasprice` and `delay`. Should solve https://github.com/crytic/echidna/issues/308#issuecomment-557922200