### PR TITLE
Fuzz every contract with a known ABI at runtime

### DIFF
--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -41,6 +41,8 @@ cryticArgs: []
 quiet: false
 #initialize the blockchain with some data
 initialize: null
+#whether ot not to use the multi-abi mode of testing
+multi-abi: false
 #checkAsserts checks assertions
 checkAsserts: false
 #dashboard determines if output is just text or an AFL-like display

--- a/examples/solidity/basic/multi-abi.sol
+++ b/examples/solidity/basic/multi-abi.sol
@@ -1,0 +1,15 @@
+contract A{
+    bool public bug = true;
+    function trigger_bug() public{
+        bug = false;
+    }
+}
+contract B{
+    A public a;
+    constructor() public{
+        a = new A();
+    }
+    function echidna_test() public returns(bool){
+        return a.bug();
+    }
+}

--- a/examples/solidity/basic/multi-abi.yaml
+++ b/examples/solidity/basic/multi-abi.yaml
@@ -1,0 +1,1 @@
+multi-abi: true

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -294,11 +294,10 @@ genInteractionsM l = genAbiCallM =<< rElem l
 
 -- | Given a solc bytecode strip off the metadata from the end
 stripBytecodeMetadata :: ByteString -> ByteString
-stripBytecodeMetadata bc = if BS.length cl /= 2
-                           then bc
-                           else if BS.length h >= cl' && (isRight . deserialiseFromBytes decodeTerm $ fromStrict cbor)
-                                then bc'
-                                else bc
+stripBytecodeMetadata bc
+  | BS.length cl /= 2 = bc
+  | BS.length h >= cl' && (isRight . deserialiseFromBytes decodeTerm $ fromStrict cbor) = bc'
+  | otherwise = bc
   where l = BS.length bc
         (h, cl) = BS.splitAt (l - 2) bc
         cl' = fromIntegral . runGet getWord16be . fromStrict $ cl

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -8,14 +8,19 @@
 
 module Echidna.ABI where
 
+import Codec.CBOR.Read (deserialiseFromBytes)
+import Codec.CBOR.Term (decodeTerm)
 import Control.Lens
 import Control.Monad (join, liftM2, liftM3, foldM, replicateM)
 import Control.Monad.Catch (MonadThrow(..))
 import Control.Monad.State.Class (MonadState, gets)
 import Control.Monad.State (evalStateT)
 import Control.Monad.Random.Strict (MonadRandom, getRandom, getRandoms, getRandomR, uniformMay)
+import Data.Binary.Get (runGet, getWord16be)
 import Data.Bool (bool)
 import Data.ByteString (ByteString)
+import Data.ByteString.Lazy (fromStrict)
+import Data.Either (isRight)
 import Data.Foldable (toList)
 import Data.Has (Has(..))
 import Data.Hashable (Hashable(..))
@@ -286,3 +291,15 @@ genAbiCallM = genWithDict (fmap toList . view wholeCalls) (traverse $ traverse g
 genInteractionsM :: (MonadState x m, Has GenDict x, MonadRandom m, MonadThrow m)
                  => NE.NonEmpty SolSignature -> m SolCall
 genInteractionsM l = genAbiCallM =<< rElem l
+
+-- | Given a solc bytecode strip off the metadata from the end
+stripBytecodeMetadata :: ByteString -> ByteString
+stripBytecodeMetadata bc = if BS.length cl /= 2
+                           then bc
+                           else if BS.length h >= cl' && (isRight . deserialiseFromBytes decodeTerm $ fromStrict cbor)
+                                then bc'
+                                else bc
+  where l = BS.length bc
+        (h, cl) = BS.splitAt (l - 2) bc
+        cl' = fromIntegral . runGet getWord16be . fromStrict $ cl
+        (bc', cbor) = BS.splitAt (BS.length h - cl') h

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -191,7 +191,7 @@ callseq v w ql = do
   -- Then, we get the current campaign state
   ca <- use hasLens
   -- Then, we generate the actual transaction in the sequence
-  is <- replicateM ql (evalStateT genTxM (w, ca ^. genDict))
+  is <- replicateM ql (evalStateT (genTxM old) (w, ca ^. genDict))
   -- We then run each call sequentially. This gives us the result of each call, plus a new state
   (res, s) <- runStateT (evalSeq v ef is) (v, ca)
   let new = s ^. _1 . env . EVM.contracts

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -146,6 +146,7 @@ instance FromJSON EConfigWithUsage where
                                  <*> v ..:? "solcLibs"        ..!= []
                                  <*> v ..:? "quiet"           ..!= False
                                  <*> v ..:? "initialize"      ..!= Nothing
+                                 <*> v ..:? "multi-abi"       ..!= False
                                  <*> v ..:? "checkAsserts"    ..!= False)
                     <*> tc
                     <*> xc

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -130,7 +130,7 @@ contracts fp = let usual = ["--solc-disable-warnings", "--export-format", "solc"
     concat <$> sequence (compileOne <$> fps)
 
 addresses :: (MonadReader x m, Has SolConf x) => m (NE.NonEmpty AbiValue)
-addresses = view hasLens <&> \(SolConf ca d ads _ _ _ _ _ _ _ _ _ _) ->
+addresses = view hasLens <&> \SolConf { _contractAddr = ca, _deployer = d, _sender = ads } ->
   AbiAddress . fromIntegral <$> NE.nub (join ads [ca, d, 0x0])
   where join (first NE.:| rest) list = first NE.:| (rest ++ list)
 

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -103,8 +103,9 @@ makeLenses ''SolConf
 -- or a function that could experience an exception
 type SolTest = Either (Text, Addr) SolSignature
 
--- | Given a file, use its extenstion to check if it is a precompiled contract or try to compile it and
--- get a list of its contracts, throwing exceptions if necessary.
+-- | Given a list of files, use its extenstion to check if it is a precompiled
+-- contract or try to compile it and get a list of its contracts, throwing
+-- exceptions if necessary.
 contracts :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x) => NE.NonEmpty FilePath -> m [SolcContract]
 contracts fp = let usual = ["--solc-disable-warnings", "--export-format", "solc"] in do
   mp  <- liftIO $ findExecutable "crytic-compile"

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -175,7 +175,7 @@ loadSpecified name cs = do
 
   -- generate the complete abi mapping
   let abiOf :: SolcContract -> NE.NonEmpty SolSignature
-      abiOf cc = fallback NE.:| (filter (not . isPrefixOf pref . fst) $ elems (cc ^. abiMap) <&> \m -> (m ^. methodName, m ^.. methodInputs . traverse . _2))
+      abiOf cc = fallback NE.:| filter (not . isPrefixOf pref . fst) (elems (cc ^. abiMap) <&> \m -> (m ^. methodName, m ^.. methodInputs . traverse . _2))
       abiMapping = M.fromList $ cs <&> \cc -> (cc ^. runtimeCode, abiOf cc)
 
   let bc = c ^. creationCode

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -174,9 +174,9 @@ loadSpecified name cs = do
   (SolConf ca d ads bala balc pref _ _ libs _ fp ch) <- view hasLens
 
   -- generate the complete abi mapping
-  let abiOf :: SolcContract -> Maybe (NE.NonEmpty SolSignature)
-      abiOf cc = NE.nonEmpty . filter (not . isPrefixOf pref . fst) $ elems (cc ^. abiMap) <&> \m -> (m ^. methodName, m ^.. methodInputs . traverse . _2)
-      abiMapping = M.fromList . catMaybes $ cs <&> \cc -> case abiOf cc of { Nothing -> Nothing; Just x -> Just (c ^. runtimeCode, x) }
+  let abiOf :: SolcContract -> NE.NonEmpty SolSignature
+      abiOf cc = fallback NE.:| (filter (not . isPrefixOf pref . fst) $ elems (cc ^. abiMap) <&> \m -> (m ^. methodName, m ^.. methodInputs . traverse . _2))
+      abiMapping = M.fromList $ cs <&> \cc -> (cc ^. runtimeCode, abiOf cc)
 
   let bc = c ^. creationCode
       abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c ^. abiMap)

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -130,9 +130,7 @@ genTxWith m s r c g gp v t = use hasLens >>= \(World ss mm) ->
       r' = r rs
       c' = join $ liftM2 c s' r'
       rs = NE.fromList . catMaybes $ mkR <$> toList m
-      mkR (a, cc) = case M.lookup (cc ^. bytecode . to stripBytecodeMetadata) mm of
-                         Nothing -> Nothing
-                         Just  x -> Just (a, x)
+      mkR = _2 (flip M.lookup mm . view (bytecode . to stripBytecodeMetadata))
   in
     ((liftM5 Tx (SolCall <$> c') s' (fst <$> r') g gp <*>) =<< liftM3 v s' r' c') <*> t
 

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -130,7 +130,7 @@ genTxWith m s r c g gp v t = use hasLens >>= \(World ss mm) ->
       r' = r rs
       c' = join $ liftM2 c s' r'
       rs = NE.fromList . catMaybes $ mkR <$> toList m
-      mkR (a, cc) = case M.lookup (cc ^. bytecode) mm of
+      mkR (a, cc) = case M.lookup (cc ^. bytecode . to stripBytecodeMetadata) mm of
                          Nothing -> Nothing
                          Just  x -> Just (a, x)
   in

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -20,6 +20,8 @@ import Control.Monad.State.Strict (MonadState, State, evalStateT, runState)
 import Data.Aeson (ToJSON(..), object)
 import Data.ByteString (ByteString)
 import Data.Has (Has(..))
+import Data.Map (Map, toList)
+import Data.Maybe (catMaybes)
 import Data.List (intercalate)
 import EVM hiding (value)
 import EVM.ABI (abiCalldata, abiValueType)
@@ -29,6 +31,7 @@ import EVM.Types (Addr)
 import qualified Control.Monad.State.Strict as S (state)
 import qualified Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Char8 as BSC8
+import qualified Data.HashMap.Strict as M
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -103,16 +106,18 @@ level x                       = x
 -- | A contract is just an address with an ABI (for our purposes).
 type ContractA = (Addr, NE.NonEmpty SolSignature)
 
--- | The world is made our of humans with an address, and contracts with an address + ABI.
-data World = World { _senders   :: NE.NonEmpty Addr
-                   , _receivers :: NE.NonEmpty ContractA
+-- | The world is made our of humans with an address, and a way to map contract
+-- bytecodes to an ABI
+data World = World { _senders         :: NE.NonEmpty Addr
+                   , _bytecodeMapping :: M.HashMap ByteString (NE.NonEmpty SolSignature)
                    }
 makeLenses ''World
 
 -- | Given generators for an origin, destination, value, and function call, generate a call
 -- transaction. Note: This doesn't generate @CREATE@s because I don't know how to do that at random.
 genTxWith :: (MonadRandom m, MonadState x m, Has World x, MonadThrow m)
-          => (NE.NonEmpty Addr -> m Addr)             -- ^ Sender generator
+          => Map Addr Contract                        -- ^ List of contracts
+          -> (NE.NonEmpty Addr -> m Addr)             -- ^ Sender generator
           -> (NE.NonEmpty ContractA -> m ContractA)   -- ^ Receiver generator
           -> (Addr -> ContractA -> m SolCall)         -- ^ Call generator
           -> m Word                                   -- ^ Gas generator
@@ -120,17 +125,29 @@ genTxWith :: (MonadRandom m, MonadState x m, Has World x, MonadThrow m)
           -> (Addr -> ContractA -> SolCall -> m Word) -- ^ Value generator
           -> m (Word, Word)                           -- ^ Delay generator
           -> m Tx
-genTxWith s r c g gp v t = use hasLens >>= \(World ss rs) ->
-  let s' = s ss; r' = r rs; c' = join $ liftM2 c s' r' in
+genTxWith m s r c g gp v t = use hasLens >>= \(World ss mm) ->
+  let s' = s ss
+      r' = r rs
+      c' = join $ liftM2 c s' r'
+      rs = NE.fromList . catMaybes $ mkR <$> toList m
+      mkR (a, cc) = case M.lookup (cc ^. bytecode) mm of
+                         Nothing -> Nothing
+                         Just  x -> Just (a, x)
+  in
     ((liftM5 Tx (SolCall <$> c') s' (fst <$> r') g gp <*>) =<< liftM3 v s' r' c') <*> t
 
 -- | Synthesize a random 'Transaction', not using a dictionary.
-genTx :: forall m x y. (MonadRandom m, MonadReader x m, Has TxConf x, MonadState y m, Has World y, MonadThrow m) => m Tx
-genTx = use (hasLens :: Lens' y World) >>= evalStateT genTxM . (defaultDict,)
+genTx :: forall m x y. (MonadRandom m, MonadReader x m, Has TxConf x, MonadState y m, Has World y, MonadThrow m)
+      => Map Addr Contract
+      -> m Tx
+genTx m = use (hasLens :: Lens' y World) >>= evalStateT (genTxM m) . (defaultDict,)
 
 -- | Generate a random 'Transaction' with either synthesis or mutation of dictionary entries.
-genTxM :: (MonadRandom m, MonadReader x m, Has TxConf x, MonadState y m, Has GenDict y, Has World y, MonadThrow m) => m Tx
-genTxM = view hasLens >>= \(TxConf _ g maxGp t b) -> genTxWith
+genTxM :: (MonadRandom m, MonadReader x m, Has TxConf x, MonadState y m, Has GenDict y, Has World y, MonadThrow m)
+  => Map Addr Contract
+  -> m Tx
+genTxM m = view hasLens >>= \(TxConf _ g maxGp t b) -> genTxWith
+  m
   rElem rElem                                                                -- src and dst
   (const $ genInteractionsM . snd)                                           -- call itself
   (pure g) (inRange maxGp) (\_ _ _ -> pure 0)                                -- gas, gasprice, value

--- a/package.yaml
+++ b/package.yaml
@@ -15,6 +15,7 @@ dependencies:
   - brick
   - base16-bytestring
   - bytestring           >= 0.10.8 && < 0.11
+  - cborg
   - containers           >= 0.5.7  && < 0.6
   - data-dword           >= 0.3.1  && < 0.4
   - data-has

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -25,14 +25,14 @@ import Echidna.UI
 import qualified Data.List.NonEmpty as NE
 
 data Options = Options
-  { filePath         :: FilePath
+  { filePath         :: NE.NonEmpty FilePath
   , selectedContract :: Maybe String
   , configFilepath   :: Maybe FilePath
   }
 
 options :: Parser Options
-options = Options <$> argument str (metavar "FILE"
-                        <> help "Solidity file to analyze")
+options = Options <$> (NE.fromList <$> some (argument str (metavar "FILE"
+                        <> help "Solidity file to analyze")))
                   <*> optional (argument str $ metavar "CONTRACT"
                         <> help "Contract to analyze")
                   <*> optional (option str $ long "config"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -31,11 +31,13 @@ data Options = Options
   }
 
 options :: Parser Options
-options = Options <$> (NE.fromList <$> some (argument str (metavar "FILE"
-                        <> help "Solidity file to analyze")))
-                  <*> optional (argument str $ metavar "CONTRACT"
+options = Options <$> (NE.fromList <$> some (argument str (metavar "FILES"
+                        <> help "Solidity files to analyze")))
+                  <*> optional (option str $ long "contract"
+                        <> metavar "CONTRACT"
                         <> help "Contract to analyze")
                   <*> optional (option str $ long "config"
+                        <> metavar "CONFIG"
                         <> help "Config file")
 
 versionOption :: Parser (a -> a)

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -79,7 +79,7 @@ compilationTests = testGroup "Compilation and loading tests"
 
 loadFails :: FilePath -> Maybe Text -> String -> (SolException -> Bool) -> TestTree
 loadFails fp c e p = testCase fp . catch tryLoad $ assertBool e . p where
-  tryLoad = runReaderT (loadWithCryticCompile fp c >> pure ()) testConfig
+  tryLoad = runReaderT (loadWithCryticCompile (fp NE.:| []) c >> pure ()) testConfig
 
 -- Extraction Tests
 
@@ -217,8 +217,8 @@ runContract :: FilePath -> Maybe Text -> EConfig -> IO Campaign
 runContract fp n c =
   flip runReaderT c $ do
     g <- getRandom
-    (v,w,ts) <- loadSolTests fp n
-    cs  <- Echidna.Solidity.contracts fp
+    (v,w,ts) <- loadSolTests (fp NE.:| []) n
+    cs  <- Echidna.Solidity.contracts (fp NE.:| [])
     ads <- NE.toList <$> addresses
     let ads' = AbiAddress . addressWord160 <$> v ^. env . EVM.contracts . to keys
     campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ ads ++ ads') [] g (returnTypes cs))

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -196,7 +196,7 @@ integrationTests = testGroup "Solidity Integration Testing"
              c <- set (sConf . quiet) True <$> maybe (pure testConfig) (fmap _econfig . parseConfig) cfg
              res <- runContract fp (Just "Foo") c
              assertBool "echidna_test passed" $ solved "echidna_test" res
-  , testContract' "basic/multi-abi.sol" (Just "B") Nothing
+  , testContract' "basic/multi-abi.sol" (Just "B") (Just "basic/multi-abi.yaml")
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "abiv2/Ballot.sol"       Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -198,6 +198,8 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "abiv2/MultiTuple.sol"   Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]
+  , testContract "abiv2/multi-abi.sol"    Nothing
+      [ ("echidna_test passed",                    solved      "echidna_test") ]
   ]
 
 testConfig :: EConfig

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -190,6 +190,8 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_state passed",                   solved      "echidna_state") ]
   , testContract' "basic_multicontract/contracts/Foo.sol" (Just "Foo") (Just "basic_multicontract/echidna_config.yaml")
       [ ("echidna_test passed",                    solved      "echidna_test") ]
+  , testContract "basic/multi-abi.sol"    (Just "B")
+      [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "abiv2/Ballot.sol"       Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "abiv2/Dynamic.sol"      Nothing
@@ -197,8 +199,6 @@ integrationTests = testGroup "Solidity Integration Testing"
   , testContract "abiv2/Dynamic2.sol"     Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "abiv2/MultiTuple.sol"   Nothing
-      [ ("echidna_test passed",                    solved      "echidna_test") ]
-  , testContract "abiv2/multi-abi.sol"    Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   ]
 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -135,7 +135,7 @@ integrationTests = testGroup "Solidity Integration Testing"
   , testContract "basic/nearbyMining.sol" (Just "coverage/test.yaml")
       [ ("echidna_findNearby passed", solved "echidna_findNearby") ]
 
-  , testContract "basic/smallValues.sol" (Just "coverage/test.yaml")
+  , testContract' "basic/smallValues.sol" Nothing (Just "coverage/test.yaml") False
       [ ("echidna_findSmall passed", solved "echidna_findSmall") ]
 
   , testContract "basic/multisender.sol" (Just "basic/multisender.yaml") $
@@ -158,7 +158,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_found_sender failed",            solved      "echidna_found_sender") ]
   , testContract "basic/rconstants.sol"   Nothing
       [ ("echidna_found failed",                   solved      "echidna_found") ]
-  , testContract' "basic/cons-create-2.sol" (Just "C") Nothing
+  , testContract' "basic/cons-create-2.sol" (Just "C") Nothing True
       [ ("echidna_state failed",                   solved      "echidna_state") ]
 -- single.sol is really slow and kind of unstable. it also messes up travis.
 --  , testContract "coverage/single.sol"    (Just "coverage/test.yaml")
@@ -196,7 +196,7 @@ integrationTests = testGroup "Solidity Integration Testing"
              c <- set (sConf . quiet) True <$> maybe (pure testConfig) (fmap _econfig . parseConfig) cfg
              res <- runContract fp (Just "Foo") c
              assertBool "echidna_test passed" $ solved "echidna_test" res
-  , testContract' "basic/multi-abi.sol" (Just "B") (Just "basic/multi-abi.yaml")
+  , testContract' "basic/multi-abi.sol" (Just "B") (Just "basic/multi-abi.yaml") True
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "abiv2/Ballot.sol"       Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]
@@ -213,12 +213,14 @@ testConfig = defaultConfig & sConf . quiet .~ True
                            & cConf .~ (defaultConfig ^. cConf) { testLimit = 10000, shrinkLimit = 2500 }
 
 testContract :: FilePath -> Maybe FilePath -> [(String, Campaign -> Bool)] -> TestTree
-testContract = flip testContract' Nothing
+testContract fp cfg = testContract' fp Nothing cfg True
 
-testContract' :: FilePath -> Maybe Text -> Maybe FilePath -> [(String, Campaign -> Bool)] -> TestTree
-testContract' fp n cfg as = testCase fp $ do
+testContract' :: FilePath -> Maybe Text -> Maybe FilePath -> Bool -> [(String, Campaign -> Bool)] -> TestTree
+testContract' fp n cfg s as = testCase fp $ do
   c <- set (sConf . quiet) True <$> maybe (pure testConfig) (fmap _econfig . parseConfig) cfg
-  res <- runContract fp n c
+  let c' = c & sConf . quiet .~ True
+             & if s then cConf .~ (c ^. cConf) { testLimit = 10000, shrinkLimit = 2500 } else id
+  res <- runContract fp n c'
   mapM_ (\(t,f) -> assertBool t $ f res) as
 
 runContract :: FilePath -> Maybe Text -> EConfig -> IO Campaign

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -190,7 +190,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_state passed",                   solved      "echidna_state") ]
   , testContract' "basic_multicontract/contracts/Foo.sol" (Just "Foo") (Just "basic_multicontract/echidna_config.yaml")
       [ ("echidna_test passed",                    solved      "echidna_test") ]
-  , testContract "basic/multi-abi.sol"    (Just "B")
+  , testContract' "basic/multi-abi.sol" (Just "B") Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "abiv2/Ballot.sol"       Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]


### PR DESCRIPTION
We modify echidna to support multiple contracts on the command line, and it will absorb the ABI of each of these and put them into `World`. Transaction generation then takes the `hevm` mapping of addresses to contracts and `genTx` will map the contracts to bytecodes and lookup the corresponding ABI to obtain the necessary `ContractA`. `callseq` inside `Campaign.hs` just passes the corresponding `VM` contract list.