### PR TITLE
Decouple UI updates from fuzzing

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -14,7 +14,6 @@ module Echidna.Campaign where
 import Control.Lens
 import Control.Monad (liftM3, replicateM, when)
 import Control.Monad.Catch (MonadCatch(..), MonadThrow(..))
-import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Random.Strict (MonadRandom, RandT, evalRandT)
 import Control.Monad.Reader.Class (MonadReader)
 import Control.Monad.State.Strict (MonadState(..), StateT(..), evalStateT, execStateT)
@@ -220,7 +219,7 @@ callseq v w ql = do
 
 -- | Run a fuzzing campaign given an initial universe state, some tests, and an optional dictionary
 -- to generate calls with. Return the 'Campaign' state once we can't solve or shrink anything.
-campaign :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadIO m
+campaign :: ( MonadCatch m, MonadRandom m, MonadReader x m
             , Has SolConf x, Has TestConf x, Has TxConf x, Has CampaignConf x)
          => StateT Campaign m a -- ^ Callback to run after each state update (for instrumentation)
          -> VM                  -- ^ Initial VM state


### PR DESCRIPTION
This PR introduces a few changes:
1. `campaign` function is now instrumented with a simple `IORef` which gets updated on each state step.
2. Ticking thread pushes UI updates at regular intervals of time (100ms), state is fetched from the `IORef`.
3. Without dashboard, main thread now fully sleeps until a campaign is done or timed out.
4. Simplified timeout detection, UI doesn't need to be reinitialized.

Motivation for those changes:
1. Decouple UI updates from fuzzing progress. This lays foundation for an interactive timer to be shown in the UI.
2. Fix the bug when UI goes away and reappears to show the timeout information.