### PR TITLE
Adjust testsuite parameters

### DIFF
--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -35,7 +35,7 @@ import System.Directory           (findExecutable)
 import Echidna.ABI         (SolSignature)
 import Echidna.Exec        (execTx)
 import Echidna.RPC         (loadEthenoBatch)
-import Echidna.Transaction (TxConf, Tx(..), World(..))
+import Echidna.Transaction (TxConf, TxCall(SolCreate), Tx(..), World(..))
 
 import EVM hiding (contracts)
 import qualified EVM (contracts)
@@ -142,7 +142,7 @@ loadLibraries :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x)
               => [SolcContract] -> Addr -> Addr -> VM -> m VM
 loadLibraries []     _  _ vm = return vm
 loadLibraries (l:ls) la d vm = loadLibraries ls (la + 1) d =<< loadRest
-  where loadRest = execStateT (execTx $ Tx (Right $ l ^. creationCode) d la 0xffffffff 0 0 (0,0)) vm
+  where loadRest = execStateT (execTx $ Tx (SolCreate $ l ^. creationCode) d la 0xffffffff 0 0 (0,0)) vm
 
 -- | Generate a string to use as argument in solc to link libraries starting from addrLibrary
 linkLibraries :: [String] -> String
@@ -192,7 +192,7 @@ loadSpecified name cs = do
     Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check
     Nothing    -> do
       vm <- loadLibraries ls addrLibrary d blank
-      let transaction = unless (isJust fp) $ void . execTx $ Tx (Right bc) d ca 0xffffffff 0 (w256 $ fromInteger balc) (0, 0)
+      let transaction = unless (isJust fp) $ void . execTx $ Tx (SolCreate bc) d ca 0xffffffff 0 (w256 $ fromInteger balc) (0, 0)
       (, fallback NE.<| neFuns, fst <$> tests) <$> execStateT transaction vm
 
   where choose []    _        = throwM NoContracts

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -60,7 +60,7 @@ checkETest t = asks getter >>= \(TestConf p s) -> view (hasLens . propGas) >>= \
       matchC sig = not . (BS.isPrefixOf . BS.take 4 $ abiCalldata (encodeSig sig) mempty)
   res <- case t of
     -- If our test is a regular user-defined test, we exec it and check the result
-    Left  (f, a) -> execTx (Tx (Left (f, [])) (s a) a g 0 0 (0, 0)) >> gets (p f . getter)
+    Left  (f, a) -> execTx (Tx (SolCall (f, [])) (s a) a g 0 0 (0, 0)) >> gets (p f . getter)
     -- If our test is an auto-generated assertion test, we check if we failed an assert on that fn
     Right sig    -> (||) <$> fmap matchR       (use $ hasLens . result)
                          <*> fmap (matchC sig) (use $ hasLens . state . calldata)

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -5,7 +5,6 @@ module Echidna.UI.Report where
 
 import Control.Lens
 import Control.Monad.Reader (MonadReader)
-import Data.Either (either)
 import Data.Has (Has(..))
 import Data.List (nub)
 import Data.Map (Map)
@@ -31,7 +30,7 @@ progress n m = "(" ++ show n ++ "/" ++ show m ++ ")"
 
 -- | Given rules for pretty-printing associated address, and whether to print them, pretty-print a 'Transaction'.
 ppTx :: (MonadReader x m, Has Names x, Has TxConf x) => Bool -> Tx -> m String
-ppTx pn (Tx c s r g gp v (t, b)) = let sOf = either ppSolCall (const "<CREATE>") in do
+ppTx pn (Tx c s r g gp v (t, b)) = let sOf = ppTxCall in do
   names <- view hasLens
   tGas  <- view $ hasLens . txGas
   return $ sOf c ++ (if not pn    then "" else names Sender s ++ names Receiver r)

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -12,7 +12,7 @@ import Echidna.ABI (SolCall, mkGenDict)
 import Echidna.Campaign (Campaign(..), CampaignConf(..), TestState(..), campaign, tests)
 import Echidna.Config (EConfig, EConfigWithUsage(..), _econfig, defaultConfig, parseConfig, sConf, cConf)
 import Echidna.Solidity
-import Echidna.Transaction (Tx, call)
+import Echidna.Transaction (TxCall(SolCall), Tx, call)
 
 import Control.Lens
 import Control.Monad (liftM2, void)
@@ -242,4 +242,4 @@ solvedLen i t = (== Just i) . fmap length . solnFor t
 
 -- NOTE: this just verifies a call was found in the solution. Doesn't care about ordering/seq length
 solvedWith :: SolCall -> Text -> Campaign -> Bool
-solvedWith c t = maybe False (any $ (== Left c) . view call) . solnFor t
+solvedWith c t = maybe False (any $ (== SolCall c) . view call) . solnFor t


### PR DESCRIPTION
In an effort to make the testsuite run faster, we turn down `testLimit` by a factor of `5` and `shrinkLimit` by a factor of `2`. This should reduce wasted effort on shrinking unshrinkable results (the shrinker) is pretty efficient and continuous fuzzing of properties that are always `true`, as our test contracts are not that complex.

Merge this after #346.