### PR TITLE
docker updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .stack-work
+.git
 libff

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,23 @@
-FROM ubuntu:bionic
-RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y sudo cmake curl wget libgmp-dev libssl-dev libbz2-dev libreadline-dev software-properties-common locales-all locales libsecp256k1-dev python3.6 python3-setuptools
+FROM ubuntu:bionic AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get install -y sudo cmake curl libgmp-dev libssl-dev libbz2-dev libreadline-dev software-properties-common libsecp256k1-dev
 RUN apt-get update
-RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux
-RUN chmod +x solc-static-linux
-RUN mv solc-static-linux /usr/bin/solc-0.4.25
-RUN wget https://github.com/ethereum/solidity/releases/download/v0.5.7/solc-static-linux
-RUN chmod +x solc-static-linux
-RUN mv solc-static-linux /usr/bin/solc
 RUN curl -sSL https://get.haskellstack.org/ | sh
 COPY . /echidna/
 WORKDIR /echidna
-ENV TRAVIS_OS_NAME linux
-ENV LD_LIBRARY_PATH /usr/local/lib
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10
+ENV LD_LIBRARY_PATH=/usr/local/lib TRAVIS_OS_NAME=linux
 RUN .travis/install-libff.sh
-RUN .travis/install-crytic-compile.sh
 RUN stack upgrade && stack setup && stack install --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
-ENV PATH=$PATH:/root/.local/bin
-RUN update-locale LANG=en_US.UTF-8
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8
+
+FROM ubuntu:bionic AS final
+WORKDIR /root
+COPY --from=builder /root/.local/bin/echidna-test /root/.local/bin/echidna-test
+COPY .travis/install-crytic-compile.sh .travis/install-crytic-compile.sh
+RUN apt-get update && apt-get -y upgrade && apt-get install -y wget git locales-all locales python3.6 python3-setuptools
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10
+RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux && chmod +x solc-static-linux && mv solc-static-linux /usr/bin/solc-0.4.25
+RUN wget https://github.com/ethereum/solidity/releases/download/v0.5.7/solc-static-linux && chmod +x solc-static-linux && mv solc-static-linux /usr/bin/solc
+ENV TRAVIS_OS_NAME=linux
+RUN .travis/install-crytic-compile.sh
+RUN update-locale LANG=en_US.UTF-8 && locale-gen en_US.UTF-8
+ENV PATH=$PATH:/root/.local/bin LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ docker build -t echidna .
 for example
 
 ```
-$ docker run -t -v `pwd`:/src echidna echidna-test /src/examples/solidity/basic/flags.sol
+$ docker run -it -v `pwd`:/src echidna echidna-test /src/examples/solidity/basic/flags.sol
 ```
 
 


### PR DESCRIPTION
this should prevent docker from caching the results of `apt-get update` so `apt-get install` will not 404

this also drastically reduces the size of the docker layer produced by the build, by using multi-stage builds and avoiding the installation of stack and its build artifacts

the latest dockerhub container is 4.77GiB on my machine. a local build with this dockerfile yields a container size of 476MiB.