### PR TITLE
Full support for printing and parsing transactions as JSON

### DIFF
--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -96,8 +96,8 @@ instance ToJSON Word where
 instance FromJSON Word where
   parseJSON = withText "Word" $ maybe (M.fail "could not parse Word") pure . readMaybe . T.unpack
 
-$(deriveJSON defaultOptions ''EVM.ABI.AbiType)
-$(deriveJSON defaultOptions ''EVM.ABI.AbiValue)
+$(deriveJSON defaultOptions ''AbiType)
+$(deriveJSON defaultOptions ''AbiValue)
 $(deriveJSON defaultOptions ''TxCall)
 $(deriveJSON defaultOptions ''Tx)
 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -274,8 +274,8 @@ instance Arbitrary EVM.Concrete.Word where
 
 instance Arbitrary TxCall where
   arbitrary = do 
-                s <- arbitrary :: Gen String
-                cs <- arbitrary :: Gen [AbiValue]
+                s <- arbitrary
+                cs <- arbitrary
                 return $ SolCall (pack s, cs)
 
 instance Arbitrary Tx where

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -273,28 +273,20 @@ instance Arbitrary EVM.Concrete.Word where
   arbitrary = arbitrary >>= (return . fromInteger)
 
 instance Arbitrary TxCall where
-  arbitrary = do
-              s <- arbitrary :: Gen String
-              cs <- arbitrary :: Gen [AbiValue]
-              return $ SolCall (pack s, cs)
+  arbitrary = do 
+                s <- arbitrary :: Gen String
+                cs <- arbitrary :: Gen [AbiValue]
+                return $ SolCall (pack s, cs)
 
 instance Arbitrary Tx where
-  arbitrary = do
-               t <- arbitrary :: Gen TxCall
-               s <- arbitrary :: Gen Addr
-               d <- arbitrary :: Gen Addr
-               g <- arbitrary :: Gen EVM.Concrete.Word
-               gp <- arbitrary :: Gen EVM.Concrete.Word
-               v <- arbitrary :: Gen EVM.Concrete.Word
-               dl <- arbitrary :: Gen (EVM.Concrete.Word, EVM.Concrete.Word)
-               return $ Tx t s d g gp v dl
+  arbitrary = let a :: Arbitrary a => Gen a
+                  a = arbitrary in 
+                Tx <$> a <*> a <*> a <*> a <*> a <*> a <*> a
 
 encodingJSONTests :: TestTree
 encodingJSONTests =
   testGroup "Tx JSON encoding"
     [ testProperty "decode . encode = id" $ property $ do
         t <- arbitrary :: Gen Tx
-        let jt = encode t
-        let t' = decode jt :: Maybe Tx
-        return $ t' === Just t
+        return $ decode (encode t) === Just t
     ]

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -278,19 +278,19 @@ instance Arbitrary EVM.Concrete.Word where
 
 instance Arbitrary TxCall where
   arbitrary = do
-              s <- (arbitrary :: Gen String)
-              cs <- (arbitrary :: Gen [AbiValue])
+              s <- arbitrary :: Gen String
+              cs <- arbitrary :: Gen [AbiValue]
               return $ SolCall (pack s, cs)
 
 instance Arbitrary Tx where
   arbitrary = do
-               t <- (arbitrary :: Gen TxCall)
-               s <- (arbitrary :: Gen Addr)
-               d <- (arbitrary :: Gen Addr)
-               g <- (arbitrary :: Gen EVM.Concrete.Word)
-               gp <- (arbitrary :: Gen EVM.Concrete.Word)
-               v <- (arbitrary :: Gen EVM.Concrete.Word)
-               dl <- (arbitrary :: Gen (EVM.Concrete.Word, EVM.Concrete.Word))
+               t <- arbitrary :: Gen TxCall
+               s <- arbitrary :: Gen Addr
+               d <- arbitrary :: Gen Addr
+               g <- arbitrary :: Gen EVM.Concrete.Word
+               gp <- arbitrary :: Gen EVM.Concrete.Word
+               v <- arbitrary :: Gen EVM.Concrete.Word
+               dl <- arbitrary :: Gen (EVM.Concrete.Word, EVM.Concrete.Word)
                return $ Tx t s d g gp v dl
 
 encodingJSONTests :: TestTree
@@ -298,7 +298,7 @@ encodingJSONTests =
   testGroup "Tx JSON encoding"
     [ testProperty "decode . encode = id" $ property $ do
         t <- arbitrary :: Gen Tx
-        let jt = (encode t)
-        let t' = (decode jt) :: Maybe Tx
-        return $ t' === (Just t)
+        let jt = encode t
+        let t' = decode jt :: Maybe Tx
+        return $ t' === Just t
     ]

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -267,14 +267,10 @@ solvedWith c t = maybe False (any $ (== SolCall c) . view call) . solnFor t
 -- Encoding JSON tests
 
 instance Arbitrary Addr where
-  arbitrary = do
-               n <- arbitrary
-               return $ fromInteger n
+  arbitrary = arbitrary >>= (return . fromInteger)
 
 instance Arbitrary EVM.Concrete.Word where
-  arbitrary = do
-               n <- arbitrary
-               return $ fromInteger n
+  arbitrary = arbitrary >>= (return . fromInteger)
 
 instance Arbitrary TxCall where
   arbitrary = do


### PR DESCRIPTION
This PR is the first step to allow Echidna to save and load list of transaction as JSON.