### PR TITLE
Support to collect, save and load a corpus of transactions in JSON

### DIFF
--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -60,3 +60,5 @@ maxBlockDelay: 60480
 #maximum number of blocks elapsed between generated txs; default is expected increment in one week
 # timeout:
 #campaign timeout (in seconds)
+#directory to save the corpus; by default is disabled  
+corpusDir: nill

--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -61,4 +61,4 @@ maxBlockDelay: 60480
 # timeout:
 #campaign timeout (in seconds)
 #directory to save the corpus; by default is disabled  
-corpusDir: nill
+corpusDir: null

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -218,8 +218,6 @@ callseq v w ql = do
   coverageEnabled <- isJust . knownCoverage <$> view hasLens
   let ef = if coverageEnabled then execTxOptC else execTx
       old = v ^. env . EVM.contracts
-  -- Reset the new coverage flag
-  hasLens . newCoverage .= False
   -- Then, we get the current campaign state
   ca <- use hasLens
   -- Then, we generate the actual transaction in the sequence
@@ -234,6 +232,9 @@ callseq v w ql = do
   -- Save the global campaign state (also vm state, but that gets reset before it's used)
   hasLens .= snd s
   when (s ^. _2 . newCoverage) $ addToCorpus res
+  -- Reset the new coverage flag
+  hasLens . newCoverage .= False
+  -- Keep track of the number of calls to `callseq`
   hasLens . ncallseqs += 1  
   -- Now we try to parse the return values as solidity constants, and add then to the 'GenDict'
   types <- use $ hasLens . rTypes

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -193,16 +193,16 @@ addToCorpus :: (MonadState s m, Has Campaign s) => [(Tx, VMResult)] -> m ()
 addToCorpus res = let rtxs = map fst res --(filter (\(_, vm) -> classifyRes vm /= ResRevert) res)
                     in unless (null rtxs) $ hasLens . corpus %= (rtxs:)
 
--- | Generate a new sequences of transactions, either using the corpus or randomly
+-- | Generate a new sequences of transactions, either using the corpus or with randomly created transactions
 randseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
            , Has GenDict y, Has TxConf x, Has TestConf x, Has CampaignConf x, Has Campaign y)
         => Int -> Map Addr Contract -> World -> m [Tx]
 randseq ql o w = do ca <- use hasLens
-                    let gts = ca ^. corpus
-                        p   = ca ^. ncallseqs 
-                    if (length gts > p) then 
+                    let corpus = ca ^. corpus  
+                        p      = ca ^. ncallseqs 
+                    if (length corpus > p) then -- Replay the transactions in the corpus, if we are executing the first iterations
                       return $ gts !! p
-                    else 
+                    else                        -- Randomly generate new transactions 
                       replicateM ql (evalStateT (genTxM o) (w, ca ^. genDict))
 
 -- | Given an initial 'VM' and 'World' state and a number of calls to generate, generate that many calls,

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -184,14 +184,15 @@ execTxOptC t = do
   res <- execTxWith vmExcept (usingCoverage $ pointCoverage (hasLens . coverage)) t
   hasLens . coverage %= unionWith union og
   grew <- (== LT) . comparing coveragePoints og <$> use (hasLens . coverage)
-  when grew $ hasLens . genDict %= gaddCalls ([t ^. call] ^.. traverse . _SolCall)
-  when grew $ hasLens . newCoverage .= True
+  when grew $ do
+    hasLens . genDict %= gaddCalls ([t ^. call] ^.. traverse . _SolCall)
+    hasLens . newCoverage .= True
   return res
 
 -- | Given a list of transactions in the corpus, save them discarding reverted transactions
 addToCorpus :: (MonadState s m, Has Campaign s) => [(Tx, VMResult)] -> m ()
-addToCorpus res = let rtxs = map fst res
-                    in unless (null rtxs) $ hasLens . corpus %= (rtxs:)
+addToCorpus res = unless (null rtxs) $ hasLens . corpus %= (rtxs:) where
+  rtxs = map fst res
 
 -- | Generate a new sequences of transactions, either using the corpus or with randomly created transactions
 randseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -222,7 +222,6 @@ callseq v w ql = do
   -- Then, we get the current campaign state
   ca <- use hasLens
   -- Then, we generate the actual transaction in the sequence
-  --is <- replicateM ql (evalStateT (genTxM old) (w, ca ^. genDict))
   is <- randseq ql old w
   -- We then run each call sequentially. This gives us the result of each call, plus a new state
   (res, s) <- runStateT (evalSeq v ef is) (v, ca)

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -198,10 +198,10 @@ randseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
            , Has GenDict y, Has TxConf x, Has TestConf x, Has CampaignConf x, Has Campaign y)
         => Int -> Map Addr Contract -> World -> m [Tx]
 randseq ql o w = do ca <- use hasLens
-                    let corpus = ca ^. corpus  
-                        p      = ca ^. ncallseqs 
-                    if (length corpus > p) then -- Replay the transactions in the corpus, if we are executing the first iterations
-                      return $ gts !! p
+                    let txs = ca ^. corpus  
+                        p   = ca ^. ncallseqs 
+                    if length txs > p then -- Replay the transactions in the corpus, if we are executing the first iterations
+                      return $ txs !! p
                     else                        -- Randomly generate new transactions 
                       replicateM ql (evalStateT (genTxM o) (w, ca ^. genDict))
 

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -120,6 +120,7 @@ instance FromJSON EConfigWithUsage where
                                   <*> cov
                                   <*> v ..:? "seed"
                                   <*> v ..:? "dictFreq"    ..!= 0.40
+                                  <*> v ..:? "corpusDir"   ..!= Nothing
                 names :: Names
                 names Sender = (" from: " ++) . show
                 names _      = const ""

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -13,7 +13,7 @@ module Echidna.Transaction where
 import Prelude hiding (Word)
 
 import Control.Lens
-import Control.Monad (join, liftM2, liftM3, liftM5, when)
+import Control.Monad (join, liftM2, liftM3, liftM5, unless)
 import Control.Monad.Catch (MonadThrow,  bracket)
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader)
@@ -233,7 +233,7 @@ setupTx (Tx c s r g gp v (t, b)) = liftSH . sequence_ $
 saveTxs :: Maybe FilePath -> [[Tx]] -> IO ()
 saveTxs (Just d) txs = mapM_ (\v -> do let fn = d ++ "/" ++ (show . hash . show) v ++ ".txt"
                                        b <- doesFileExist fn
-                                       when (not b) $ encodeFile fn (sv v)
+                                       unless b $ encodeFile fn (sv v)
                                ) txs
                              where sv = toJSON
 saveTxs Nothing  _   = return ()

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -14,7 +14,7 @@ import Prelude hiding (Word)
 
 import Control.Lens
 import Control.Monad (join, liftM2, liftM3, liftM5, unless)
-import Control.Monad.Catch (MonadThrow,  bracket)
+import Control.Monad.Catch (MonadThrow, bracket)
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader)
 import Control.Monad.State.Strict (MonadState, State, evalStateT, runState)
@@ -234,30 +234,31 @@ saveTxs :: Maybe FilePath -> [[Tx]] -> IO ()
 saveTxs (Just d) txs = mapM_ (\v -> do let fn = d ++ "/" ++ (show . hash . show) v ++ ".txt"
                                        b <- doesFileExist fn
                                        unless b $ encodeFile fn (sv v)
-                               ) txs
+                             ) txs
                              where sv = toJSON
 saveTxs Nothing  _   = return ()
 
 listDirectory :: FilePath -> IO [FilePath]
-listDirectory path =
-  Prelude.filter f <$> getDirectoryContents path
+listDirectory path = Prelude.filter f <$> getDirectoryContents path
   where f filename = filename /= "." && filename /= ".."
 
 withCurrentDirectory :: FilePath  -- ^ Directory to execute in
                      -> IO a      -- ^ Action to be executed
                      -> IO a
 withCurrentDirectory dir action =
-  bracket getCurrentDirectory setCurrentDirectory $ \ _ -> do
+  bracket getCurrentDirectory setCurrentDirectory $ \_ -> do
     setCurrentDirectory dir
     action
 
 loadTxs :: Maybe FilePath -> IO [[Tx]]
-loadTxs (Just d) = do fs <- listDirectory d
-                      xs <- mapM makeRelativeToCurrentDirectory fs
-                      mtxs <- withCurrentDirectory d (mapM readCall xs)
-                      let txs = catMaybes mtxs
-                      putStrLn ("Loaded total of " ++ show (length xs) ++ " transactions from " ++ d)
-                      return txs
-                    where readCall f = do !buf <- LBS.readFile f
-                                          return (decode buf :: Maybe [Tx]) 
+loadTxs (Just d) = do 
+  fs <- listDirectory d
+  xs <- mapM makeRelativeToCurrentDirectory fs
+  mtxs <- withCurrentDirectory d (mapM readCall xs)
+  let txs = catMaybes mtxs
+  putStrLn ("Loaded total of " ++ show (length xs) ++ " transactions from " ++ d)
+  return txs
+  where readCall f = do !buf <- LBS.readFile f
+                        return (decode buf :: Maybe [Tx]) 
+
 loadTxs Nothing  = return [] 

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -254,6 +254,6 @@ loadTxs (Just d) = do
   txs <- catMaybes <$> withCurrentDirectory d css
   putStrLn ("Loaded total of " ++ show (length txs) ++ " transactions from " ++ d)
   return txs
-  where readCall f = (BS.readFile f) >>= return . decodeStrict
+  where readCall f = decodeStrict <$> BS.readFile f
 
 loadTxs Nothing  = pure [] 

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -61,14 +61,14 @@ ppTS :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Test
 ppTS (Failed e)  = pure $ "could not evaluate ☣\n  " ++ show e
 ppTS (Solved l)  = ppFail Nothing l
 ppTS Passed      = pure "passed! 🎉"
-ppTS (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _ _ _) ->
+ppTS (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _ _ _ _) ->
                      if i >= t then ppTS Passed else pure $ "fuzzing " ++ progress i t
 ppTS (Large n l) = view (hasLens . to shrinkLimit) >>= \m -> ppFail (if n < m then Just (n,m)
                                                                               else Nothing) l
 
 -- | Pretty-print the status of all 'SolTest's in a 'Campaign'.
 ppTests :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Campaign -> m String
-ppTests (Campaign ts _ _) = unlines . catMaybes <$> mapM pp ts where
+ppTests (Campaign ts _ _ _ _ _) = unlines . catMaybes <$> mapM pp ts where
   pp (Left  (n, _), s)      = Just .                    ((T.unpack n ++ ": ") ++) <$> ppTS s
   pp (Right _,      Open _) = pure Nothing
   pp (Right (n, _), s)      = Just . (("assertion in " ++ T.unpack n ++ ": ") ++) <$> ppTS s

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -61,14 +61,14 @@ ppTS :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Test
 ppTS (Failed e)  = pure $ "could not evaluate ☣\n  " ++ show e
 ppTS (Solved l)  = ppFail Nothing l
 ppTS Passed      = pure "passed! 🎉"
-ppTS (Open i)    = view hasLens >>= \(CampaignConf {testLimit = t}) ->
+ppTS (Open i)    = view hasLens >>= \(CampaignConf { testLimit = t }) ->
                      if i >= t then ppTS Passed else pure $ "fuzzing " ++ progress i t
 ppTS (Large n l) = view (hasLens . to shrinkLimit) >>= \m -> ppFail (if n < m then Just (n,m)
                                                                               else Nothing) l
 
 -- | Pretty-print the status of all 'SolTest's in a 'Campaign'.
 ppTests :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Campaign -> m String
-ppTests (Campaign {_tests=ts}) = unlines . catMaybes <$> mapM pp ts where
+ppTests (Campaign { _tests = ts }) = unlines . catMaybes <$> mapM pp ts where
   pp (Left  (n, _), s)      = Just .                    ((T.unpack n ++ ": ") ++) <$> ppTS s
   pp (Right _,      Open _) = pure Nothing
   pp (Right (n, _), s)      = Just . (("assertion in " ++ T.unpack n ++ ": ") ++) <$> ppTS s

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -55,8 +55,8 @@ ppGasOne (f, (g, xs)) = let pxs = mapM (ppTx $ length (nub $ view src <$> xs) /=
 
 -- | Pretty-print the gas usage information a 'Campaign' has obtained.
 ppGasInfo :: (MonadReader x m, Has Names x, Has TxConf x) => Campaign -> m String
-ppGasInfo (Campaign { _gasInfo = gi } ) | gi == mempty = pure ""
-ppGasInfo (Campaign { _gasInfo = gi } ) = (fmap $ intercalate "") (mapM ppGasOne $ sortOn (\(_, (n, _)) -> n) $ toList gi)
+ppGasInfo Campaign { _gasInfo = gi } | gi == mempty = pure ""
+ppGasInfo Campaign { _gasInfo = gi } = (fmap $ intercalate "") (mapM ppGasOne $ sortOn (\(_, (n, _)) -> n) $ toList gi)
 
 -- | Pretty-print the status of a solved test.
 ppFail :: (MonadReader x m, Has Names x, Has TxConf x) => Maybe (Int, Int) -> [Tx] -> m String
@@ -72,14 +72,14 @@ ppTS :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Test
 ppTS (Failed e)  = pure $ "could not evaluate ☣\n  " ++ show e
 ppTS (Solved l)  = ppFail Nothing l
 ppTS Passed      = pure "passed! 🎉"
-ppTS (Open i)    = view hasLens >>= \(CampaignConf { testLimit = t }) ->
+ppTS (Open i)    = view hasLens >>= \CampaignConf { testLimit = t } ->
                      if i >= t then ppTS Passed else pure $ "fuzzing " ++ progress i t
 ppTS (Large n l) = view (hasLens . to shrinkLimit) >>= \m -> ppFail (if n < m then Just (n,m)
                                                                               else Nothing) l
 
 -- | Pretty-print the status of all 'SolTest's in a 'Campaign'.
 ppTests :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Campaign -> m String
-ppTests (Campaign { _tests = ts }) = unlines . catMaybes <$> mapM pp ts where
+ppTests Campaign { _tests = ts } = unlines . catMaybes <$> mapM pp ts where
   pp (Left  (n, _), s)      = Just .                    ((T.unpack n ++ ": ") ++) <$> ppTS s
   pp (Right _,      Open _) = pure Nothing
   pp (Right (n, _), s)      = Just . (("assertion in " ++ T.unpack n ++ ": ") ++) <$> ppTS s

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -61,14 +61,14 @@ ppTS :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Test
 ppTS (Failed e)  = pure $ "could not evaluate ☣\n  " ++ show e
 ppTS (Solved l)  = ppFail Nothing l
 ppTS Passed      = pure "passed! 🎉"
-ppTS (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _ _ _ _) ->
+ppTS (Open i)    = view hasLens >>= \(CampaignConf {testLimit = t}) ->
                      if i >= t then ppTS Passed else pure $ "fuzzing " ++ progress i t
 ppTS (Large n l) = view (hasLens . to shrinkLimit) >>= \m -> ppFail (if n < m then Just (n,m)
                                                                               else Nothing) l
 
 -- | Pretty-print the status of all 'SolTest's in a 'Campaign'.
 ppTests :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Campaign -> m String
-ppTests (Campaign ts _ _ _ _ _) = unlines . catMaybes <$> mapM pp ts where
+ppTests (Campaign {_tests=ts}) = unlines . catMaybes <$> mapM pp ts where
   pp (Left  (n, _), s)      = Just .                    ((T.unpack n ++ ": ") ++) <$> ppTS s
   pp (Right _,      Open _) = pure Nothing
   pp (Right (n, _), s)      = Just . (("assertion in " ++ T.unpack n ++ ": ") ++) <$> ppTS s

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -96,7 +96,7 @@ tsWidget :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x)
 tsWidget (Failed e)  = pure (str "could not evaluate", str $ show e)
 tsWidget (Solved l)  = failWidget Nothing l
 tsWidget Passed      = pure (withAttr "success" $ str "PASSED!", emptyWidget)
-tsWidget (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _ _ _ _) ->
+tsWidget (Open i)    = view hasLens >>= \(CampaignConf {testLimit = t}) ->
   if i >= t then
     tsWidget Passed
   else

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -96,7 +96,7 @@ tsWidget :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x)
 tsWidget (Failed e)  = pure (str "could not evaluate", str $ show e)
 tsWidget (Solved l)  = failWidget Nothing l
 tsWidget Passed      = pure (withAttr "success" $ str "PASSED!", emptyWidget)
-tsWidget (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _ _ _) ->
+tsWidget (Open i)    = view hasLens >>= \(CampaignConf t _ _ _ _ _ _ _) ->
   if i >= t then
     tsWidget Passed
   else

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -96,7 +96,7 @@ tsWidget :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x)
 tsWidget (Failed e)  = pure (str "could not evaluate", str $ show e)
 tsWidget (Solved l)  = failWidget Nothing l
 tsWidget Passed      = pure (withAttr "success" $ str "PASSED!", emptyWidget)
-tsWidget (Open i)    = view hasLens >>= \(CampaignConf { testLimit = t }) ->
+tsWidget (Open i)    = view hasLens >>= \CampaignConf { testLimit = t } ->
   if i >= t then
     tsWidget Passed
   else

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -96,7 +96,7 @@ tsWidget :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x)
 tsWidget (Failed e)  = pure (str "could not evaluate", str $ show e)
 tsWidget (Solved l)  = failWidget Nothing l
 tsWidget Passed      = pure (withAttr "success" $ str "PASSED!", emptyWidget)
-tsWidget (Open i)    = view hasLens >>= \(CampaignConf {testLimit = t}) ->
+tsWidget (Open i)    = view hasLens >>= \(CampaignConf { testLimit = t }) ->
   if i >= t then
     tsWidget Passed
   else

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -236,7 +236,7 @@ runContract fp n c =
     cs  <- Echidna.Solidity.contracts (fp NE.:| [])
     ads <- NE.toList <$> addresses
     let ads' = AbiAddress . addressWord160 <$> v ^. env . EVM.contracts . to keys
-    campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ ads ++ ads') [] g (returnTypes cs)) [[]]
+    campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ ads ++ ads') [] g (returnTypes cs)) []
 
 getResult :: Text -> Campaign -> Maybe TestState
 getResult t = fmap snd <$> find ((t ==) . either fst (("ASSERTION " <>) . fst) . fst) . view tests

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -283,10 +283,10 @@ solvedWith c t = maybe False (any $ (== SolCall c) . view call) . solnFor t
 -- Encoding JSON tests
 
 instance Arbitrary Addr where
-  arbitrary = arbitrary >>= (return . fromInteger)
+  arbitrary = fromInteger <$> arbitrary
 
 instance Arbitrary EVM.Concrete.Word where
-  arbitrary = arbitrary >>= (return . fromInteger)
+  arbitrary = fromInteger <$> arbitrary
 
 instance Arbitrary TxCall where
   arbitrary = do 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -55,7 +55,7 @@ configTests = testGroup "Configuration tests" $
   , testCase "defaults.yaml" $ do
       EConfigWithUsage _ bad unset <- parseConfig "basic/default.yaml"
       assertBool ("unused options: " ++ show bad) $ null bad
-      let unset' = unset & sans "seed" & sans "corpusDir"
+      let unset' = unset & sans "seed"
       assertBool ("unset options: " ++ show unset') $ null unset'
   ]
   where files = ["basic/config.yaml", "basic/default.yaml"]

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -55,7 +55,7 @@ configTests = testGroup "Configuration tests" $
   , testCase "defaults.yaml" $ do
       EConfigWithUsage _ bad unset <- parseConfig "basic/default.yaml"
       assertBool ("unused options: " ++ show bad) $ null bad
-      let unset' = unset & sans "seed"
+      let unset' = unset & sans "seed" & sans "corpusDir"
       assertBool ("unset options: " ++ show unset') $ null unset'
   ]
   where files = ["basic/config.yaml", "basic/default.yaml"]
@@ -113,7 +113,7 @@ seedTests =
     , testCase "same seeds" $ assertBool "results differ" =<< same 0 0
     ]
     where cfg s = defaultConfig & sConf . quiet .~ True
-                                & cConf .~ CampaignConf 600 False 20 0 Nothing (Just s) 0.15
+                                & cConf .~ CampaignConf 600 False 20 0 Nothing (Just s) 0.15 Nothing
           gen s = view tests <$> runContract "basic/flags.sol" Nothing (cfg s)
           same s t = liftM2 (==) (gen s) (gen t)
 
@@ -236,7 +236,7 @@ runContract fp n c =
     cs  <- Echidna.Solidity.contracts (fp NE.:| [])
     ads <- NE.toList <$> addresses
     let ads' = AbiAddress . addressWord160 <$> v ^. env . EVM.contracts . to keys
-    campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ ads ++ ads') [] g (returnTypes cs))
+    campaign (pure ()) v w ts (Just $ mkGenDict 0.15 (extractConstants cs ++ ads ++ ads') [] g (returnTypes cs)) [[]]
 
 getResult :: Text -> Campaign -> Maybe TestState
 getResult t = fmap snd <$> find ((t ==) . either fst (("ASSERTION " <>) . fst) . fst) . view tests


### PR DESCRIPTION
The new config keyword `corpusDir` allows to define a directory that will be used to save all the sequences of transactions that generated new coverage. The coverage collection was improved to take into consideration the entire sequence of transactions.