### PR TITLE
Filtering the functions to be called

### DIFF
--- a/examples/solidity/basic/blacklist.yaml
+++ b/examples/solidity/basic/blacklist.yaml
@@ -1,0 +1,1 @@
+filterFunctions: ["set0"] 

--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -60,3 +60,5 @@ maxBlockDelay: 60480
 #maximum number of blocks elapsed between generated txs; default is expected increment in one week
 # timeout:
 #campaign timeout (in seconds)
+ignoreMethods: []
+includeMethods: []

--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -60,5 +60,7 @@ maxBlockDelay: 60480
 #maximum number of blocks elapsed between generated txs; default is expected increment in one week
 # timeout:
 #campaign timeout (in seconds)
-ignoreMethods: []
-includeMethods: []
+# list of methods to filter
+filterFunctions: []
+# by default, blacklist methods in filterFunctions
+filterBlacklist: true

--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -68,3 +68,4 @@ filterFunctions: []
 filterBlacklist: true
 #directory to save the corpus; by default is disabled  
 corpusDir: null
+

--- a/examples/solidity/basic/whitelist.yaml
+++ b/examples/solidity/basic/whitelist.yaml
@@ -1,0 +1,2 @@
+filterBlacklist: false
+filterFunctions: ["set0"] 

--- a/examples/solidity/basic/whitelist_all.yaml
+++ b/examples/solidity/basic/whitelist_all.yaml
@@ -1,0 +1,2 @@
+filterBlacklist: false
+filterFunctions: ["set0", "set1"] 

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -43,6 +43,11 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Vector as V
 
+
+-- | Fallback function is the null string
+fallback :: SolSignature
+fallback = ("",[])
+
 -- | Pretty-print some 'AbiValue'.
 ppAbiValue :: AbiValue -> String
 ppAbiValue (AbiUInt _ n)         = show n

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -147,7 +147,9 @@ instance FromJSON EConfigWithUsage where
                                  <*> v ..:? "quiet"           ..!= False
                                  <*> v ..:? "initialize"      ..!= Nothing
                                  <*> v ..:? "multi-abi"       ..!= False
-                                 <*> v ..:? "checkAsserts"    ..!= False)
+                                 <*> v ..:? "checkAsserts"    ..!= False
+                                 <*> v ..:? "ignoreMethods"   ..!= []
+                                 <*> v ..:? "includeMethods"  ..!= [])
                     <*> tc
                     <*> xc
                     <*> (UIConf <$> v ..:? "dashboard" ..!= True <*> v ..:? "timeout" <*> style)

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -15,6 +15,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader (Reader, ReaderT(..), runReader)
 import Control.Monad.State (StateT(..), runStateT)
 import Control.Monad.Trans (lift)
+import Data.Bool (bool)
 import Data.ByteString.Lazy.Char8 (unpack)
 import Data.Aeson
 import Data.Aeson.Lens
@@ -148,8 +149,7 @@ instance FromJSON EConfigWithUsage where
                                  <*> v ..:? "initialize"      ..!= Nothing
                                  <*> v ..:? "multi-abi"       ..!= False
                                  <*> v ..:? "checkAsserts"    ..!= False
-                                 <*> v ..:? "ignoreMethods"   ..!= []
-                                 <*> v ..:? "includeMethods"  ..!= [])
+                                 <*> (bool Whitelist Blacklist <$> v ..:? "filterBlacklist" ..!= True <*> v ..:? "filterFunctions" ..!= []))
                     <*> tc
                     <*> xc
                     <*> (UIConf <$> v ..:? "dashboard" ..!= True <*> v ..:? "timeout" <*> style)

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -252,7 +252,7 @@ loadWithCryticCompile fp name = contracts fp >>= loadSpecified name
 -- for running a 'Campaign' against the tests found.
 prepareForTest :: (MonadReader x m, Has SolConf x)
                => (VM, NE.NonEmpty SolSignature, [Text], M.HashMap BS.ByteString (NE.NonEmpty SolSignature)) -> m (VM, World, [SolTest])
-prepareForTest (v, a, ts, m) = view hasLens <&> \(SolConf _ _ s _ _ _ _ _ _ _ _ _ ch _ ) ->
+prepareForTest (v, a, ts, m) = view hasLens <&> \SolConf { _sender = s, _checkAsserts = ch } ->
   (v, World s m, fmap Left (zip ts $ repeat r) ++ if ch then Right <$> drop 1 a' else []) where
     r = v ^. state . contract
     a' = NE.toList a

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -81,10 +81,12 @@ instance Show SolException where
     OnlyTests            -> "Only tests and no public functions found in ABI"
     (ConstructorArgs s)  -> "Constructor arguments are required: " ++ s
     NoCryticCompile      -> "crytic-compile not installed or not found in PATH. To install it, run:\n   pip install crytic-compile"
-    InvalidMethodFilters -> "Methods to include and ignore cannot be filtered at the same time. Select only one of them"
+    InvalidMethodFilters -> "List of whitelist methods cannot be empty"
 
 
 instance Exception SolException
+
+data Filter = Blacklist [String] | Whitelist [String]
 
 -- | Configuration for loading Solidity for Echidna testing.
 data SolConf = SolConf { _contractAddr    :: Addr             -- ^ Contract address to use
@@ -100,8 +102,7 @@ data SolConf = SolConf { _contractAddr    :: Addr             -- ^ Contract addr
                        , _initialize      :: Maybe FilePath   -- ^ Initialize world with Etheno txns
                        , _multiAbi        :: Bool             -- ^ Whether or not to use the multi-abi mode
                        , _checkAsserts    :: Bool             -- ^ Test if we can cause assertions to fail
-                       , _ignoreMethods   :: [String]         -- ^ List of method to avoid calling during a campaign
-                       , _includeMethods  :: [String]         -- ^ List of methods to include calling during a campaign 
+                       , _methodFilter    :: Filter           -- ^ List of methods to avoid or include calling during a campaign
                        }
 makeLenses ''SolConf
 
@@ -162,12 +163,10 @@ linkLibraries [] = ""
 linkLibraries ls = "--libraries " ++
   iconcatMap (\i x -> concat [x, ":", show $ addrLibrary + toEnum i, ","]) ls
 
-filterMethods :: MonadThrow m => [String] -> [String] -> [(Text, [AbiType])] -> m [(Text, [AbiType])]
-filterMethods [] [] ms = return ms 
-filterMethods [] ic ms = return $ filter (\(m, _) -> T.unpack m `elem` ic) ms
-filterMethods ig [] ms = return $ filter (\(m, _) -> T.unpack m `notElem` ig) ms
-filterMethods _  _  _  = throwM InvalidMethodFilters 
-
+filterMethods :: MonadThrow m => Filter -> [(Text, [AbiType])] -> m [(Text, [AbiType])]
+filterMethods (Whitelist [])  _ = throwM InvalidMethodFilters 
+filterMethods (Whitelist ic) ms = return $ filter (\(m, _) -> T.unpack m `elem` ic) ms
+filterMethods (Blacklist ig) ms = return $ filter (\(m, _) -> T.unpack m `notElem` ig) ms
 
 -- | Given an optional contract name and a list of 'SolcContract's, try to load the specified
 -- contract, or, if not provided, the first contract in the list, into a 'VM' usable for Echidna
@@ -186,7 +185,7 @@ loadSpecified name cs = do
     unless q . putStrLn $ "Analyzing contract: " <> c ^. contractName . unpacked
 
   -- Local variables
-  (SolConf ca d ads bala balc pref _ _ libs _ fp ma ch igm inm) <- view hasLens
+  (SolConf ca d ads bala balc pref _ _ libs _ fp ma ch fs) <- view hasLens
 
   -- generate the complete abi mapping
   let abiOf :: SolcContract -> NE.NonEmpty SolSignature
@@ -199,7 +198,7 @@ loadSpecified name cs = do
       
 
   -- Filter ABI according to the config options
-  funs' <- filterMethods igm inm funs
+  funs' <- filterMethods fs funs
   
   -- Set up initial VM, either with chosen contract or Etheno initialization file
   -- need to use snd to add to ABI dict
@@ -247,7 +246,7 @@ loadWithCryticCompile fp name = contracts fp >>= loadSpecified name
 -- for running a 'Campaign' against the tests found.
 prepareForTest :: (MonadReader x m, Has SolConf x)
                => (VM, NE.NonEmpty SolSignature, [Text], M.HashMap BS.ByteString (NE.NonEmpty SolSignature)) -> m (VM, World, [SolTest])
-prepareForTest (v, a, ts, m) = view hasLens <&> \(SolConf _ _ s _ _ _ _ _ _ _ _ _ ch _ _) ->
+prepareForTest (v, a, ts, m) = view hasLens <&> \(SolConf _ _ s _ _ _ _ _ _ _ _ _ ch _ ) ->
   (v, World s m, fmap Left (zip ts $ repeat r) ++ if ch then Right <$> drop 1 a' else []) where
     r = v ^. state . contract
     a' = NE.toList a

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -81,12 +81,12 @@ instance Show SolException where
     OnlyTests            -> "Only tests and no public functions found in ABI"
     (ConstructorArgs s)  -> "Constructor arguments are required: " ++ s
     NoCryticCompile      -> "crytic-compile not installed or not found in PATH. To install it, run:\n   pip install crytic-compile"
-    InvalidMethodFilters -> "List of whitelist methods cannot be empty"
+    InvalidMethodFilters -> "Filtering methods whitelisting or blacklisting cannot result empty"
 
 
 instance Exception SolException
 
-data Filter = Blacklist [String] | Whitelist [String]
+data Filter = Blacklist [Text] | Whitelist [Text]
 
 -- | Configuration for loading Solidity for Echidna testing.
 data SolConf = SolConf { _contractAddr    :: Addr             -- ^ Contract address to use
@@ -165,10 +165,10 @@ linkLibraries ls = "--libraries " ++
 
 filterMethods :: MonadThrow m => Filter -> NE.NonEmpty SolSignature -> m (NE.NonEmpty SolSignature)
 filterMethods (Whitelist [])  _ = throwM InvalidMethodFilters 
-filterMethods (Whitelist ic) ms = case NE.filter (\(m, _) -> T.unpack m `elem` ic) ms of
+filterMethods (Whitelist ic) ms = case NE.filter (\(m, _) -> m `elem` ic) ms of
                                        [] -> throwM InvalidMethodFilters
                                        fs -> return $ NE.fromList fs
-filterMethods (Blacklist ig) ms = case NE.filter (\(m, _) -> T.unpack m `notElem` ig) ms of
+filterMethods (Blacklist ig) ms = case NE.filter (\(m, _) -> m `notElem` ig) ms of
                                        [] -> throwM InvalidMethodFilters
                                        fs -> return $ NE.fromList fs
 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -274,8 +274,8 @@ instance Arbitrary EVM.Concrete.Word where
 
 instance Arbitrary TxCall where
   arbitrary = do 
-                s <- arbitrary :: Gen String
-                cs <- arbitrary :: Gen [AbiValue]
+                s <- arbitrary
+                cs <- arbitrary
                 return $ SolCall (pack s, cs)
 
 instance Arbitrary Tx where

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -267,10 +267,10 @@ solvedWith c t = maybe False (any $ (== SolCall c) . view call) . solnFor t
 -- Encoding JSON tests
 
 instance Arbitrary Addr where
-  arbitrary = arbitrary >>= (return . fromInteger)
+  arbitrary = fromInteger <$> arbitrary
 
 instance Arbitrary EVM.Concrete.Word where
-  arbitrary = arbitrary >>= (return . fromInteger)
+  arbitrary = fromInteger <$> arbitrary
 
 instance Arbitrary TxCall where
   arbitrary = do 

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -129,6 +129,21 @@ integrationTests = testGroup "Solidity Integration Testing"
       , ("echidna_sometimesfalse passed",                  solved      "echidna_sometimesfalse")
       , ("echidna_sometimesfalse didn't shrink optimally", solvedLen 2 "echidna_sometimesfalse")
       ]
+  , testContract "basic/flags.sol" (Just "basic/whitelist.yaml")
+      [ ("echidna_alwaystrue failed",                      passed      "echidna_alwaystrue")
+      , ("echidna_revert_always failed",                   passed      "echidna_revert_always")
+      , ("echidna_sometimesfalse passed",                  passed      "echidna_sometimesfalse")
+      ]
+  , testContract "basic/flags.sol" (Just "basic/whitelist_all.yaml")
+      [ ("echidna_alwaystrue failed",                      passed      "echidna_alwaystrue")
+      , ("echidna_revert_always failed",                   passed      "echidna_revert_always")
+      , ("echidna_sometimesfalse passed",                  solved      "echidna_sometimesfalse")
+      ]
+  , testContract "basic/flags.sol" (Just "basic/blacklist.yaml")
+      [ ("echidna_alwaystrue failed",                      passed      "echidna_alwaystrue")
+      , ("echidna_revert_always failed",                   passed      "echidna_revert_always")
+      , ("echidna_sometimesfalse passed",                  passed      "echidna_sometimesfalse")
+      ]
   , testContract "basic/revert.sol" Nothing
       [ ("echidna_fails_on_revert passed", solved "echidna_fails_on_revert")
       , ("echidna_fails_on_revert didn't shrink to one transaction",


### PR DESCRIPTION
This PR adds two new config options:

* `filterBlacklist` to set to blacklist or whitelist functions (`false` by default)
* `filterFunctions`: A list of strings with function names either to blacklist or whitelist, according to the previous config option. (`[]` by default).

This will fix issue #341.