### PR TITLE
Properly handle contract self-destruction

### DIFF
--- a/examples/solidity/basic/killed.sol
+++ b/examples/solidity/basic/killed.sol
@@ -1,20 +1,10 @@
 contract C {
 
-  uint private state = 0;
-  function f(uint x) public {
-    state = x;
-  }
-
-  function killed_if() {
-    require(state > 256);
-    suicide(0x0);
+  function killed_me(address payable x) public {
+      selfdestruct(x);
   }
 
   function echidna_still_alive() public returns (bool) {
-    return true;
-  }
-
-  function echidna_other_prop() public returns (bool) {
     return true;
   }
 

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -71,7 +71,10 @@ execTxWith h m t = do (og :: VM) <- use hasLens
                       res <- m
                       gasOut <- use $ hasLens . state . gas
                       cd  <- use $ hasLens . state . calldata
-                      case (res, t ^. call) of
+                      sd  <- use $ hasLens . tx . substate . selfdestructs
+                      if (t ^. dst) `elem` sd
+                      then h SelfDestruction
+                      else case (res, t ^. call) of
                         (f@Reversion, _)            -> do hasLens .= og
                                                           hasLens . state . calldata .= cd
                                                           hasLens . result ?= f


### PR DESCRIPTION
When a contract self-destructs, Echidna is unable to test any properties. This means that all properties should fail. However, right now, Echidna is not handling this correctly, it [ignores](https://github.com/crytic/echidna/issues/26) the self-destruction in fact. 

This PR stops Echidna, showing that all the properties failed because of a self-destruction.