### PR TITLE
Multiple coverage tracking according to the result of a transaction

### DIFF
--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -85,6 +85,6 @@ ppTests Campaign { _tests = ts } = unlines . catMaybes <$> mapM pp ts where
   pp (Right (n, _), s)      = Just . (("assertion in " ++ T.unpack n ++ ": ") ++) <$> ppTS s
 
 ppCampaign :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Campaign -> m String
-ppCampaign c = (++) <$> liftM2 (++) (ppTests c) (ppGasInfo c) <*> pure (maybe "" ("\n" ++) . ppCoverage $ c ^. coverage)
+ppCampaign c = (++) <$> liftM2 (++) (ppTests c) (ppGasInfo c) <*> pure (maybe "" ("\n" ++) . ppCoverage $ c ^. coverage_nr)
 
 

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -42,7 +42,7 @@ attrs = A.attrMap (V.white `on` V.black)
 -- | Render 'Campaign' progress as a 'Widget'.
 campaignStatus :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x)
                => (Campaign, UIState) -> m (Widget ())
-campaignStatus (c@Campaign{_tests, _coverage}, uiState) = do
+campaignStatus (c@Campaign{_tests, _coverage_nr}, uiState) = do
   done <- isDone c
   case (uiState, done) of
     (Uninitialized, _) -> pure $ mainbox (padLeft (Pad 1) $ str "Starting up, please wait...") emptyWidget
@@ -58,7 +58,7 @@ campaignStatus (c@Campaign{_tests, _coverage}, uiState) = do
       hCenter underneath
     wrapInner inner =
       borderWithLabel (withAttr "bold" $ str title) $
-      summaryWidget _tests _coverage
+      summaryWidget _tests _coverage_nr
       <=>
       hBorderWithLabel (str "Tests")
       <=>


### PR DESCRIPTION
This is POC to fix issue #363 . This PR introduces two coverage maps to keep track of transactions when they revert (or not). This will allow a richer notion of coverage.