### PR TITLE
Basic mutations based on collected corpus

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -235,15 +235,17 @@ addToCorpus res = unless (null rtxs) $ hasLens . corpus %= (rtxs:) where
 seqMutators :: (MonadRandom m) => m (Int -> [[Tx]] -> [Tx] -> m [Tx])
 seqMutators = fromList [(cnm, 1), (apm, 1), (prm, 1)]
   where -- Use the generated random transactions
-        cnm _  _         = return
+        cnm _ _          = return
         -- Append a sequence from the corpus with random ones
-        apm ql ctxs gtxs = do rtxs <- rElem $ NE.fromList ctxs
-                              k <- getRandomR (0, length rtxs - 1 )
-                              return $ take ql $ take k rtxs ++ gtxs
+        apm ql ctxs gtxs = do 
+          rtxs <- (rElem . NE.fromList) ctxs
+          k <- getRandomR (0, length rtxs - 1)
+          return . take ql . take k $ rtxs ++ gtxs
         -- Prepend a sequence from the corpus with random ones
-        prm ql ctxs gtxs = do rtxs <- rElem $ NE.fromList ctxs
-                              k <- getRandomR (0, length rtxs - 1 )
-                              return $ take ql $ take k gtxs ++ rtxs
+        prm ql ctxs gtxs = do 
+          rtxs <- (rElem . NE.fromList) ctxs
+          k <- getRandomR (0, length rtxs - 1)
+          return . take ql . take k $ gtxs ++ rtxs
 
 -- | Generate a new sequences of transactions, either using the corpus or with randomly created transactions
 randseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -38,6 +38,7 @@ import System.Random (mkStdGen)
 import qualified Data.HashMap.Strict as H
 import qualified Data.HashSet as S
 import qualified Data.Foldable as DF
+import qualified Data.List.NonEmpty as NE
 
 import Echidna.ABI
 import Echidna.Exec
@@ -235,14 +236,30 @@ addToCorpus res = unless (null rtxs) $ hasLens . corpus %= (rtxs:) where
 randseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
            , Has GenDict y, Has TxConf x, Has TestConf x, Has CampaignConf x, Has Campaign y)
         => Int -> Map Addr Contract -> World -> m [Tx]
-randseq ql o w = do 
+randseq ql o w = do
   ca <- use hasLens
-  let txs = ca ^. corpus  
-      p   = ca ^. ncallseqs 
-  if length txs > p then -- Replay the transactions in the corpus, if we are executing the first iterations
-    return $ txs !! p
-  else                   -- Randomly generate new transactions 
-    replicateM ql (evalStateT (genTxM o) (w, ca ^. genDict))
+  let ctxs = ca ^. corpus
+      p    = ca ^. ncallseqs
+  if length ctxs > p then -- Replay the transactions in the corpus, if we are executing the first iterations
+    return $ ctxs !! p
+  else
+    do
+      -- Randomly generate new random transactions
+      gtxs <- replicateM ql (evalStateT (genTxM o) (w, ca ^. genDict))
+      n <- getRandomR (0, 2 :: Integer)
+      case (n, ctxs) of
+        -- Use the generated random transactions
+        (_, []) -> return gtxs
+        (0, _ ) -> return gtxs
+        -- Append a sequence from the corpus with random ones
+        (1, _ ) -> do rtxs <- rElem $ NE.fromList ctxs
+                      k <- getRandomR (0, length rtxs - 1 )
+                      return $ take ql $ take k rtxs ++ gtxs
+        -- Prepend a sequence from the corpus with random ones
+        (2, _ ) -> do rtxs <- rElem $ NE.fromList ctxs
+                      k <- getRandomR (0, length rtxs - 1 )
+                      return $ take ql $ take k gtxs ++ rtxs
+        _       -> error "invalid pattern in randseq"
 
 -- | Given an initial 'VM' and 'World' state and a number of calls to generate, generate that many calls,
 -- constantly checking if we've solved any tests or can shrink known solves. Update coverage as a result


### PR DESCRIPTION
This small PR introduces the first mutations based on the collected corpora. The mutations are enabled using `coverage: true` and will randomly splice a sequence of transactions from the corpus with randomly generated ones. 