### PR TITLE
Allow to control corpus mutation constans using a configuration file

### DIFF
--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -68,4 +68,5 @@ filterFunctions: []
 filterBlacklist: true
 #directory to save the corpus; by default is disabled  
 corpusDir: null
-
+# constants for corpus mutations (for experimentation only)
+mutConsts: [1, 1, 1]

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -51,6 +51,8 @@ instance MonadThrow m => MonadThrow (RandT g m) where
 instance MonadCatch m => MonadCatch (RandT g m) where
   catch = liftCatch catch
 
+type MutationConsts = (Integer, Integer, Integer)
+
 -- | Configuration for running an Echidna 'Campaign'.
 data CampaignConf = CampaignConf { testLimit     :: Int
                                    -- ^ Maximum number of function calls to execute while fuzzing
@@ -72,6 +74,7 @@ data CampaignConf = CampaignConf { testLimit     :: Int
                                    -- ^ Frequency for the use of dictionary values in the random transactions
                                  , corpusDir     :: Maybe FilePath
                                    -- ^ Directory to load and save lists of transactions
+                                 , mutConsts     :: MutationConsts
                                  }
 
 -- | State of a particular Echidna test. N.B.: \"Solved\" means a falsifying call sequence was found.
@@ -232,8 +235,8 @@ addToCorpus :: (MonadState s m, Has Campaign s) => [(Tx, (VMResult, Int))] -> m 
 addToCorpus res = unless (null rtxs) $ hasLens . corpus %= (rtxs:) where
   rtxs = map fst res
 
-seqMutators :: (MonadRandom m) => m (Int -> [[Tx]] -> [Tx] -> m [Tx])
-seqMutators = fromList [(cnm, 1), (apm, 1), (prm, 1)]
+seqMutators :: (MonadRandom m) => MutationConsts -> m (Int -> [[Tx]] -> [Tx] -> m [Tx])
+seqMutators (c1, c2, c3) = fromList [(cnm, fromInteger c1), (apm, fromInteger c2), (prm, fromInteger c3)]
   where -- Use the generated random transactions
         cnm _ _          = return
         -- Append a sequence from the corpus with random ones
@@ -253,6 +256,7 @@ randseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
         => Int -> Map Addr Contract -> World -> m [Tx]
 randseq ql o w = do
   ca <- use hasLens
+  cs <- mutConsts <$> view hasLens
   let ctxs = ca ^. corpus
       p    = ca ^. ncallseqs
   if length ctxs > p then -- Replay the transactions in the corpus, if we are executing the first iterations
@@ -262,7 +266,7 @@ randseq ql o w = do
       -- Randomly generate new random transactions
       gtxs <- replicateM ql (evalStateT (genTxM o) (w, ca ^. genDict))
       -- Select a random mutator
-      mut <- seqMutators
+      mut <- seqMutators cs
       case ctxs of
         -- Use the generated random transactions
         [] -> return gtxs
@@ -337,7 +341,7 @@ campaign u v w ts d txs = do
   execStateT (evalRandT runCampaign g') (Campaign ((,Open (-1)) <$> ts) c mempty d' False txs 0) where
     step        = runUpdate (updateTest v Nothing) >> lift u >> runCampaign
     runCampaign = use (hasLens . tests . to (fmap snd)) >>= update
-    update c    = view hasLens >>= \(CampaignConf tl sof _ q sl _ _ _ _) ->
+    update c    = view hasLens >>= \(CampaignConf tl sof _ q sl _ _ _ _ _) ->
       if | sof && any (\case Solved _ -> True; Failed _ -> True; _ -> False) c -> lift u
          | any (\case Open  n   -> n < tl; _ -> False) c                       -> callseq v w q >> step
          | any (\case Large n _ -> n < sl; _ -> False) c                       -> step

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -123,6 +123,8 @@ instance FromJSON EConfigWithUsage where
                                   <*> v ..:? "seed"
                                   <*> v ..:? "dictFreq"    ..!= 0.40
                                   <*> v ..:? "corpusDir"   ..!= Nothing
+                                  <*> v ..:? "mutConsts"   ..!= (1,1,1)
+
                 names :: Names
                 names Sender = (" from: " ++) . show
                 names _      = const ""

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -114,7 +114,7 @@ seedTests =
     , testCase "same seeds" $ assertBool "results differ" =<< same 0 0
     ]
     where cfg s = defaultConfig & sConf . quiet .~ True
-                                & cConf .~ CampaignConf 600 False False 20 0 Nothing (Just s) 0.15 Nothing
+                                & cConf .~ CampaignConf 600 False False 20 0 Nothing (Just s) 0.15 Nothing (1,1,1)
           gen s = view tests <$> runContract "basic/flags.sol" Nothing (cfg s)
           same s t = liftM2 (==) (gen s) (gen t)
 


### PR DESCRIPTION
This small PR allows to control the constants used to select the most likely corpus mutators. The tuning of this parameter is for experimentation only (normal users should not need to modify it)