### PR TITLE
Small refactor for generalized shrinking

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -166,7 +166,7 @@ updateTest v (Just (v', xs)) (n, t) = view (hasLens . to testLimit) >>= \tl -> (
 updateTest v Nothing (n, t) = view (hasLens . to shrinkLimit) >>= \sl -> (n,) <$> case t of
   Large i x | i >= sl -> pure $ Solved x
   Large i x           -> if length x > 1 || any canShrinkTx x
-                           then Large (i + 1) <$> evalStateT (shrinkSeq n x) v
+                           then Large (i + 1) <$> evalStateT (shrinkSeq (checkETest n) x) v
                            else pure $ Solved x
   _                   -> pure t
 

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -71,9 +71,9 @@ checkETest t = asks getter >>= \(TestConf p s) -> view (hasLens . propGas) >>= \
 -- still solves that test.
 shrinkSeq :: ( MonadRandom m, MonadReader x m, MonadThrow m
              , Has SolConf x, Has TestConf x, Has TxConf x, MonadState y m, Has VM y)
-          => SolTest -> [Tx] -> m [Tx]
-shrinkSeq t xs = sequence [shorten, shrunk] >>= uniform >>= ap (fmap . flip bool xs) check where
-  check xs' = do {og <- get; res <- traverse_ execTx xs' >> checkETest t; put og; pure res}
+          => m Bool -> [Tx] -> m [Tx]
+shrinkSeq f xs = sequence [shorten, shrunk] >>= uniform >>= ap (fmap . flip bool xs) check where
+  check xs' = do {og <- get; res <- traverse_ execTx xs' >> f; put og; pure res}
   shrinkSender x = view (hasLens . sender) >>= \l -> case ifind (const (== x ^. src)) l of
     Nothing     -> pure x
     Just (i, _) -> flip (set src) x . fromMaybe (x ^. src) <$> uniformMay (l ^.. folded . indices (< i))


### PR DESCRIPTION
This small PR refactors the `shrinkSeq` function to generalize it. It is the first step to use it in new features (e.g gas-consumption shrinking) .