### PR TITLE
Update README.md for latest truffle syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ we can uncover an integer overflow in the [Metacoin Truffle box](https://github.
 
 ```
 $ cd examples/solidity/truffle/metacoin
-$ echidna-test . TEST
+$ echidna-test . --contract TEST
 ...
 echidna_convert: failed!💥
   Call sequence:


### PR DESCRIPTION
Hello!

The readme is currently out of date for the echidna truffle syntax when running tests. This resulted in me wasting a lot of time until I figured out the solution. This PR addresses this documentation change for running echidna on a truffle project.