### PR TITLE
JSON Output

### DIFF
--- a/examples/solidity/basic/default.yaml
+++ b/examples/solidity/basic/default.yaml
@@ -47,8 +47,6 @@ initialize: null
 multi-abi: false
 #checkAsserts checks assertions
 checkAsserts: false
-#dashboard determines if output is just text or an AFL-like display
-dashboard: true
 #timeout controls test timeout settings
 timeout: null
 #seed not defined by default, is the random seed
@@ -66,7 +64,7 @@ maxBlockDelay: 60480
 filterFunctions: []
 # by default, blacklist methods in filterFunctions
 filterBlacklist: true
-#directory to save the corpus; by default is disabled  
+#directory to save the corpus; by default is disabled
 corpusDir: null
 # constants for corpus mutations (for experimentation only)
 mutConsts: [100, 1, 1]

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -9,16 +9,14 @@
 module Echidna.Config where
 
 import Control.Lens
-import Control.Monad (liftM2, liftM5)
+import Control.Monad (liftM5)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader (Reader, ReaderT(..), runReader)
 import Control.Monad.State (StateT(..), runStateT)
 import Control.Monad.Trans (lift)
 import Data.Bool (bool)
-import Data.ByteString.Lazy.Char8 (unpack)
 import Data.Aeson
-import Data.Aeson.Lens
 import Data.Functor ((<&>))
 import Data.Has (Has(..))
 import Data.HashMap.Strict (keys)
@@ -128,16 +126,12 @@ instance FromJSON EConfigWithUsage where
                 names :: Names
                 names Sender = (" from: " ++) . show
                 names _      = const ""
-                --ppc :: Has (HashSet Text) s => StateT s Y.Parser (Campaign -> Int -> String)
-                ppc = liftM2 (\cf xf c g -> runReader (ppCampaign c) (cf, xf, names) ++ "\nSeed: " ++ show g) cc xc
-                --style :: Has (HashSet Text) s => StateT s Y.Parser (Campaign -> Int -> String)
-                style = v ..:? "format" ..!= ("text" :: String) >>=
-                  \case "text"             -> ppc
-                        "json"             -> pure . flip $ \g ->
-                          unpack . encode . set (_Object . at "seed") (Just . toJSON $ g) . toJSON
-                        "none"             -> pure $ \_ _ -> ""
-                        _                  -> pure $ \_ _ -> M.fail
-                          "unrecognized ui type (should be text, json, or none)" in
+                mode = fromMaybe Interactive <$> (v ..:? "format" >>= \case
+                  Just ("text" :: String) -> pure $ Just $ NonInteractive Text
+                  Just "json" -> pure $ Just $ NonInteractive JSON
+                  Just "none" -> pure $ Just $ NonInteractive None
+                  Nothing -> pure Nothing
+                  _ -> M.fail "unrecognized format type (should be text, json, or none)") in
             EConfig <$> cc
                     <*> pure names
                     <*> (SolConf <$> v ..:? "contractAddr"    ..!= 0x00a329c0648769a73afac7f9381e08fb43dbea72
@@ -156,7 +150,7 @@ instance FromJSON EConfigWithUsage where
                                  <*> (bool Whitelist Blacklist <$> v ..:? "filterBlacklist" ..!= True <*> v ..:? "filterFunctions" ..!= []))
                     <*> tc
                     <*> xc
-                    <*> (UIConf <$> v ..:? "dashboard" ..!= True <*> v ..:? "timeout" <*> style)
+                    <*> (UIConf <$> v ..:? "timeout" <*> mode)
 
 -- | The default config used by Echidna (see the 'FromJSON' instance for values used).
 defaultConfig :: EConfig

--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -82,7 +82,7 @@ instance ToJSON Transaction where
     ]
 
 encodeCampaign :: C.Campaign -> Int -> ByteString
-encodeCampaign C.Campaign{_tests} seed = encode $
+encodeCampaign C.Campaign{_tests} seed = encode
   -- TODO: success and error are hardcoded, add after reworking error reporting
   Top { _success = True
       , _error = Nothing

--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Echidna.Output.JSON where
+
+import Echidna.ABI (ppAbiValue)
+import qualified Echidna.Campaign as C
+import Echidna.Solidity (SolTest)
+import Echidna.Transaction (Tx(..), TxCall(..))
+import Data.Aeson hiding (Error)
+import qualified Data.ByteString.Base16 as BS16
+import Data.ByteString.Lazy (ByteString)
+import Data.Text
+import Data.Text.Encoding (decodeUtf8)
+
+data Top = Top
+  { _success :: Bool
+  , _error :: Maybe String
+  , _tests :: [Test]
+  , seed :: Int
+  }
+
+instance ToJSON Top where
+  toJSON Top{..} = object
+    [ "success" .= _success
+    , "error" .= _error
+    , "tests" .= _tests
+    , "seed" .= seed
+    ]
+
+data Test = Test
+  { contract :: Text
+  , name :: Text
+  , status :: TestStatus
+  , _error :: Maybe String
+  , testType :: TestType
+  , transactions :: Maybe [Transaction]
+  }
+
+instance ToJSON Test where
+  toJSON Test{..} = object
+    [ "contract" .= contract
+    , "name" .= name
+    , "status" .= status
+    , "error" .= _error
+    , "type" .= testType
+    , "transactions" .= transactions
+    ]
+
+data TestType = Property | Assertion
+
+instance ToJSON TestType where
+  toJSON Property = "property"
+  toJSON Assertion = "assertion"
+
+data TestStatus = Fuzzing | Shrinking | Solved | Passed | Error
+
+instance ToJSON TestStatus where
+  toJSON Fuzzing = "fuzzing"
+  toJSON Shrinking = "shrinking"
+  toJSON Solved = "solved"
+  toJSON Passed = "passed"
+  toJSON Error = "error"
+
+
+data Transaction = Transaction
+  { contract :: Text
+  , function :: Text
+  , arguments :: Maybe [String]
+  , gas :: Integer
+  , gasprice :: Integer
+  }
+
+instance ToJSON Transaction where
+  toJSON Transaction{..} = object
+    [ "contract" .= contract
+    , "function" .= function
+    , "arguments" .= arguments
+    , "gas" .= gas
+    , "gasprice" .= gasprice
+    ]
+
+encodeCampaign :: C.Campaign -> Int -> ByteString
+encodeCampaign C.Campaign{_tests} seed = encode $
+  -- TODO: success and error are hardcoded, add after reworking error reporting
+  Top { _success = True
+      , _error = Nothing
+      , _tests = mapTest <$> _tests
+      , seed = seed
+      }
+
+mapTest :: (SolTest, C.TestState) -> Test
+mapTest (solTest, testState) =
+  let (status, transactions, err) = mapTestState testState in
+  Test { contract = "" -- TODO add when mapping is available
+       , name = case solTest of Left (n, _) -> n; Right (n, _) -> n
+       , status = status
+       , _error = err
+       , testType = case solTest of Left _ -> Property; Right _ -> Assertion
+       , transactions = transactions
+       }
+  where
+  mapTestState (C.Open _) = (Fuzzing, Nothing, Nothing)
+  mapTestState C.Passed = (Passed, Nothing, Nothing)
+  mapTestState (C.Solved txs) = (Solved, Just $ mapTx <$> txs, Nothing)
+  mapTestState (C.Large _ txs) = (Shrinking, Just $ mapTx <$> txs, Nothing)
+  mapTestState (C.Failed e) = (Error, Nothing, Just $ show e) -- TODO add (show e)
+
+  mapTx Tx{..} =
+    let (function, args) = mapCall _call in
+    Transaction { contract = "" -- TODO add when mapping is available
+                , function = function
+                , arguments = args
+                , gas = toInteger _gas'
+                , gasprice = toInteger _gasprice'
+                }
+
+  mapCall (SolCreate _) = ("<CREATE>", Nothing)
+  mapCall (SolCall (name, args)) = (name, Just $ ppAbiValue <$> args)
+  mapCall (SolCalldata x) = (decodeUtf8 $ "0x" <> BS16.encode x, Nothing)

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -43,6 +43,12 @@ data UIConf = UIConf { _maxTime       :: Maybe Int
 data OperationMode = Interactive | NonInteractive OutputFormat deriving Show
 data OutputFormat = Text | JSON | None deriving Show
 
+instance Read OutputFormat where
+  readsPrec _ = \case 't':'e':'x':'t':r -> [(Text, r)]
+                      'j':'s':'o':'n':r -> [(JSON, r)]
+                      'n':'o':'n':'e':r -> [(None, r)]
+                      _ -> []
+
 makeLenses ''UIConf
 
 data CampaignEvent = CampaignUpdated Campaign | CampaignTimedout Campaign

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -44,8 +44,8 @@ campaignStatus (c@Campaign{_tests, _coverage}, uiState) = do
   done <- isDone c
   case (uiState, done) of
     (Uninitialized, _) -> pure $ mainbox (padLeft (Pad 1) $ str "Starting up, please wait...") emptyWidget
-    (Timedout, _)      -> mainbox <$> testsWidget _tests <*> pure (str "Timed out, C-c or esc to print report")
-    (_, True)          -> mainbox <$> testsWidget _tests <*> pure (str "Campaign complete, C-c or esc to print report")
+    (Timedout, _)      -> mainbox <$> testsWidget _tests <*> pure (str "Timed out, C-c or esc to exit")
+    (_, True)          -> mainbox <$> testsWidget _tests <*> pure (str "Campaign complete, C-c or esc to exit")
     _                  -> mainbox <$> testsWidget _tests <*> pure emptyWidget
   where
     mainbox :: Widget () -> Widget () -> Widget ()


### PR DESCRIPTION
This adds JSON output as a reliable interface. The `ui` function is reworked and distinguishes interactive and non-interactive mode. Non-interactive mode doesn't require a worker thread now, making it a bit simpler. Additionally, printing report after exiting interactive UI is removed as it contained the same information just less clear. There are a few points marked `TODO` as it was not possible to implement without much more work.