### PR TITLE
Fixed coverage counting when a contract is deployed multiple times

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -31,6 +31,7 @@ import Data.Traversable (traverse)
 import EVM
 import EVM.ABI (getAbi, AbiType(AbiAddressType), AbiValue(AbiAddress))
 import EVM.Types (Addr)
+import EVM.Keccak (keccak)
 import Numeric (showHex)
 import System.Random (mkStdGen)
 
@@ -121,7 +122,7 @@ data Campaign = Campaign { _tests       :: [(SolTest, TestState)]
 instance ToJSON Campaign where
   toJSON (Campaign ts co gi _ _ _ _) = object $ ("tests", toJSON $ mapMaybe format ts)
     : ((if co == mempty then [] else [
-    ("coverage",) . toJSON . mapKeys (`showHex` "") $ DF.toList <$> co]) ++
+    ("coverage",) . toJSON . mapKeys (("0x" ++) . (`showHex` "") . keccak) $ DF.toList <$> co]) ++
        [(("maxgas",) . toJSON . toList) gi | gi /= mempty]) where
         format (Right _,      Open _) = Nothing
         format (Right (n, _), s)      = Just ("assertion in " <> n, toJSON s)

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -24,6 +24,7 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 
 import Echidna.Transaction
+import Echidna.ABI (stripBytecodeMetadata)
 
 -- | Broad categories of execution failures: reversions, illegal operations, and ???.
 data ErrorClass = RevertE | IllegalE | UnknownE
@@ -87,7 +88,7 @@ execTxWith h m t = do (og :: VM) <- use hasLens
 execTx :: (MonadState x m, Has VM x, MonadThrow m) => Tx -> m (VMResult, Int)
 execTx = execTxWith vmExcept $ liftSH exec
 
-type CoverageMap = Map W256 (Set (Int, TxResult))
+type CoverageMap = Map BS.ByteString (Set (Int, TxResult))
 
 -- | Given a way of capturing coverage info, execute while doing so once per instruction.
 usingCoverage :: (MonadState x m, Has VM x) => m () -> m VMResult
@@ -106,8 +107,8 @@ scoveragePoints = sum . fmap (S.size . S.map fst)
 -- | Capture the current PC and codehash. This should identify instructions uniquely (maybe? EVM is weird).
 pointCoverage :: (MonadState x m, Has VM x) => Lens' x CoverageMap -> m ()
 pointCoverage l = use hasLens >>= \v ->
-  l %= M.insertWith (const . S.insert $ (v ^. state . pc, Success)) (fromMaybe (W256 maxBound) $ h v) mempty where
-    h v = v ^? env . contracts . at (v ^. state . contract) . _Just . codehash
+  l %= M.insertWith (const . S.insert $ (v ^. state . pc, Success)) (fromMaybe (BS.empty) $ h v) mempty where
+    h v = stripBytecodeMetadata <$> v ^? env . contracts . at (v ^. state . contract) . _Just . bytecode
 
 traceCoverage :: (MonadState x m, Has VM x, Has [Op] x) => m ()
 traceCoverage = use hasLens >>= \v -> let c = v ^. state . code in hasLens <>= [readOp (BS.index c $ v ^. state . pc) c]

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -107,7 +107,7 @@ scoveragePoints = sum . fmap (S.size . S.map fst)
 -- | Capture the current PC and codehash. This should identify instructions uniquely (maybe? EVM is weird).
 pointCoverage :: (MonadState x m, Has VM x) => Lens' x CoverageMap -> m ()
 pointCoverage l = use hasLens >>= \v ->
-  l %= M.insertWith (const . S.insert $ (v ^. state . pc, Success)) (fromMaybe (BS.empty) $ h v) mempty where
+  l %= M.insertWith (const . S.insert $ (v ^. state . pc, Success)) (fromMaybe BS.empty $ h v) mempty where
     h v = stripBytecodeMetadata <$> v ^? env . contracts . at (v ^. state . contract) . _Just . bytecode
 
 traceCoverage :: (MonadState x m, Has VM x, Has [Op] x) => m ()

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -17,7 +17,6 @@ import Data.Set (Set)
 import EVM
 import EVM.Op (Op(..))
 import EVM.Exec (exec)
-import EVM.Types (W256(..))
 
 import qualified Data.ByteString as BS
 import qualified Data.Map as M

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -103,10 +103,10 @@ coveragePoints = sum . fmap S.size
 scoveragePoints :: CoverageMap -> Int
 scoveragePoints = sum . fmap (S.size . S.map fst)
 
--- | Capture the current PC and codehash. This should identify instructions uniquely (maybe? EVM is weird).
+-- | Capture the current PC and bytecode (without metadata). This should identify instructions uniquely.
 pointCoverage :: (MonadState x m, Has VM x) => Lens' x CoverageMap -> m ()
 pointCoverage l = use hasLens >>= \v ->
-  l %= M.insertWith (const . S.insert $ (v ^. state . pc, Success)) (fromMaybe BS.empty $ h v) mempty where
+  l %= M.insertWith (const . S.insert $ (v ^. state . pc, Success)) (fromMaybe (error "no contract information on coverage") $ h v) mempty where
     h v = stripBytecodeMetadata <$> v ^? env . contracts . at (v ^. state . contract) . _Just . bytecode
 
 traceCoverage :: (MonadState x m, Has VM x, Has [Op] x) => m ()


### PR DESCRIPTION
This PR will fix how coverage is counted when multiple contracts are deployed more than once, to avoid counting several times.