### PR TITLE
Develop and build with Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,6 @@ for example
 $ docker run -it -v `pwd`:/src echidna echidna-test /src/examples/solidity/basic/flags.sol
 ```
 
-Nix users can install the lastest Echidna with:
-```
-nix-env -i -f https://github.com/crytic/echidna/tarball/master
-```
-
 If you'd prefer to build from source, use [Stack](https://docs.haskellstack.org/en/stable/README/).
 `stack install` should build and compile `echidna-test` in `~/.local/bin`.
 You will need to link against libreadline and libsecp256k1 (built with recovery enabled), which should be installed with the package manager of your choosing.
@@ -99,6 +94,11 @@ Additionally, you need to install the latest release of [libff](https://github.c
 Some linux distributions do not ship static libraries for certain things that Haskell needs, e.g. archlinux, which will cause `stack build` to fail with linking errors because we use the `-static` flag. Removing these from `package.yaml` should get everything to build if you are not looking for a static build.
 
 If you're getting errors building related to linking, try tinkering with `--extra-include-dirs` and `--extra-lib-dirs`.
+
+Nix users can install the lastest Echidna with:
+```
+$ nix-env -i -f https://github.com/crytic/echidna/tarball/master
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Invariants are expressed as Solidity functions with names that begin with `echid
 
 ```solidity
 function echidna_check_balance() public returns (bool) {
-    return(balance >= 20); 
+    return(balance >= 20);
 }
 ```
 
@@ -38,7 +38,7 @@ To check these invariants, run:
 $ echidna-test myContract.sol
 ```
 
-An example contract with tests can be found [examples/solidity/basic/flags.sol](examples/solidity/basic/flags.sol). To run it, you should execute: 
+An example contract with tests can be found [examples/solidity/basic/flags.sol](examples/solidity/basic/flags.sol). To run it, you should execute:
 ```
 $ echidna-test examples/solidity/basic/flags.sol
 ```
@@ -87,6 +87,11 @@ for example
 $ docker run -it -v `pwd`:/src echidna echidna-test /src/examples/solidity/basic/flags.sol
 ```
 
+Nix users can install the lastest Echidna with:
+```
+nix-env -i -f https://github.com/crytic/echidna/tarball/master
+```
+
 If you'd prefer to build from source, use [Stack](https://docs.haskellstack.org/en/stable/README/).
 `stack install` should build and compile `echidna-test` in `~/.local/bin`.
 You will need to link against libreadline and libsecp256k1 (built with recovery enabled), which should be installed with the package manager of your choosing.
@@ -94,6 +99,18 @@ Additionally, you need to install the latest release of [libff](https://github.c
 Some linux distributions do not ship static libraries for certain things that Haskell needs, e.g. archlinux, which will cause `stack build` to fail with linking errors because we use the `-static` flag. Removing these from `package.yaml` should get everything to build if you are not looking for a static build.
 
 If you're getting errors building related to linking, try tinkering with `--extra-include-dirs` and `--extra-lib-dirs`.
+
+## Development
+
+It is possible to devlop Echidna with Cabal inside `nix-shell`. Nix will automatically
+install all the dependencies required for development including `crytic-compile` and `solc`.
+A quick way to get GHCi with Echidna ready for work:
+```
+$ git clone https://github.com/crytic/echidna
+$ cd echidna
+$ nix-shell
+[nix-shell]$ cabal new-repl
+```
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you're getting errors building related to linking, try tinkering with `--extr
 
 ## Development
 
-It is possible to devlop Echidna with Cabal inside `nix-shell`. Nix will automatically
+It is possible to develop Echidna with Cabal inside `nix-shell`. Nix will automatically
 install all the dependencies required for development including `crytic-compile` and `solc`.
 A quick way to get GHCi with Echidna ready for work:
 ```

--- a/default.nix
+++ b/default.nix
@@ -61,7 +61,7 @@ in
     then drv.env
     else pkgs.symlinkJoin {
       name = "echidna-${v}-with-deps";
-      paths = [ drv ];
+      paths = [ (pkgs.haskell.lib.justStaticExecutables drv) ];
       buildInputs = [ pkgs.makeWrapper ];
       postBuild = ''
         wrapProgram $out/bin/echidna-test \

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,66 @@
+{ nixpkgs ? import ./nix/dapptools.nix, compiler ? "default", doBenchmark ? false }:
+
+let
+  inherit (nixpkgs) pkgs;
+
+  v = "1.4.0.1";
+
+  crytic-compile = pkgs.python3Packages.callPackage (import ./nix/crytic-compile.nix) {};
+
+  f = { mkDerivation, aeson, ansi-terminal, base, base16-bytestring
+      , binary, brick, bytestring, cborg, containers, data-dword, data-has
+      , deepseq, directory, exceptions, filepath, hashable, hevm, hpack
+      , lens, lens-aeson, megaparsec, MonadRandom, mtl
+      , optparse-applicative, process, random, stdenv, stm, tasty
+      , tasty-hunit, tasty-quickcheck, temporary, text, transformers
+      , unix, unliftio, unliftio-core, unordered-containers, vector
+      , vector-instances, vty, wl-pprint-annotated, word8, yaml
+      , cabal-install
+      }:
+      mkDerivation rec {
+        pname = "echidna";
+        version = v;
+        src = ./.;
+        isLibrary = true;
+        isExecutable = true;
+        libraryHaskellDepends = [
+          aeson ansi-terminal base base16-bytestring binary brick bytestring
+          cborg containers data-dword data-has deepseq directory exceptions filepath
+          hashable hevm lens lens-aeson megaparsec MonadRandom mtl
+          optparse-applicative process random stm temporary text transformers
+          unix unliftio unliftio-core unordered-containers vector
+          vector-instances vty wl-pprint-annotated word8 yaml
+          tasty tasty-hunit tasty-quickcheck
+        ] ++ (if pkgs.lib.inNixShell then testHaskellDepends else []);
+        libraryToolDepends = [ hpack cabal-install ];
+        executableHaskellDepends = libraryHaskellDepends;
+        testHaskellDepends = [
+          tasty tasty-hunit tasty-quickcheck
+        ];
+        executableSystemDepends = [ crytic-compile pkgs.solc-versions.solc_0_5_15 ];
+        preConfigure = "hpack";
+        license = stdenv.lib.licenses.agpl3;
+        doHaddock = false;
+        doCheck = false;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+in
+  if pkgs.lib.inNixShell
+    then drv.env
+    else pkgs.symlinkJoin {
+      name = "echidna-${v}-with-deps";
+      paths = [ drv ];
+      buildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        wrapProgram $out/bin/echidna-test \
+          --prefix PATH : ${pkgs.lib.makeBinPath [ crytic-compile ]} \
+          --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.solc-versions.solc_0_5_15 ]}
+      '';
+    }

--- a/default.nix
+++ b/default.nix
@@ -38,7 +38,11 @@ let
           tasty tasty-hunit tasty-quickcheck
         ];
         executableSystemDepends = [ crytic-compile pkgs.solc-versions.solc_0_5_15 ];
-        preConfigure = "hpack";
+        preConfigure = ''
+          hpack
+          # re-enable dynamic build for Linux
+          sed -i -e 's/os(linux)/false/' echidna.cabal
+        '';
         license = stdenv.lib.licenses.agpl3;
         doHaddock = false;
         doCheck = false;

--- a/default.nix
+++ b/default.nix
@@ -43,6 +43,7 @@ let
           # re-enable dynamic build for Linux
           sed -i -e 's/os(linux)/false/' echidna.cabal
         '';
+        shellHook = "hpack";
         license = stdenv.lib.licenses.agpl3;
         doHaddock = false;
         doCheck = false;

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 let
   inherit (nixpkgs) pkgs;
 
-  v = "1.4.0.1";
+  v = "1.5.0";
 
   crytic-compile = pkgs.python3Packages.callPackage (import ./nix/crytic-compile.nix) {};
 

--- a/nix/crytic-compile.nix
+++ b/nix/crytic-compile.nix
@@ -1,0 +1,15 @@
+{ buildPythonPackage, fetchPypi, python3Packages }:
+
+buildPythonPackage rec {
+  pname = "crytic-compile";
+  version = "0.1.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0s4nr3jrm7665qyd04j3rxij0a58dwrfvc0sn05c7c5zwr0x155s";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ pysha3 setuptools ];
+
+  doCheck = false;
+}

--- a/nix/dapptools.nix
+++ b/nix/dapptools.nix
@@ -1,0 +1,9 @@
+let
+  pkgs = import <nixpkgs> {};
+  src = pkgs.fetchFromGitHub {
+    owner  = "dapphub";
+    repo   = "dapptools";
+    rev    = "af84e2ee0a0654fdaa91186384233cf1731ee7ce";
+    sha256 = "091c313fw32b16mc5hjq1m388694dsqi3l3lasmddahkkp1rf1ak";
+  };
+in import "${src}" {}


### PR DESCRIPTION
This PR introduces Nix build for Echidna along with reproducible one command development environment setup - `nix-shell`. I've been using and testing this setup for months. Build has been successfully tested on macOS, Ubuntu and NixOS.

This doesn't override the current Docker/stack based workflow, just provides a non-conflicting alternative.

Future work will include a `solc-select` equivalent and binary cache to cut the setup time to the minimum.