### PR TITLE
GitHub Actions: macOS: Only install needed packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - os: ubuntu-latest
             apt-get: autoconf automake libtool
           - os: macos-latest
-            brew: autoconf automake libtool
+            brew: automake
 
     steps:
       - name: Get Packages


### PR DESCRIPTION
This PR fixes the CI on macOS, which was failing with the following error:

    Warning: autoconf 2.69 is already installed and up-to-date
    To reinstall 2.69, run `brew reinstall autoconf`
    Error: libtool 2.4.6_1 is already installed
    To upgrade to 2.4.6_2, run `brew upgrade libtool`.