### PR TITLE
Fixed timestamp/blocknumber issue and improved value generation with these values

### DIFF
--- a/examples/solidity/basic/now.sol
+++ b/examples/solidity/basic/now.sol
@@ -1,0 +1,18 @@
+contract C {
+  bool state;
+  uint time;
+
+  function set() public {
+    time = now;
+  }
+
+  function guess(uint x) public {
+    if (x <= time + 1 weeks && x >= time - 1 weeks ) 
+      state = true;
+  }
+
+  function echidna_now() public returns(bool) {
+    return (!state);
+  }
+
+} 

--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -57,6 +57,6 @@ prepareContract cfg fs c g = do
   (v, w, ts) <- prepareForTest p c si
   let ads' = AbiAddress <$> v ^. env . EVM.contracts . to keys
   -- start ui and run tests
-  return (v, w, ts, Just $ mkGenDict df (extractConstants cs ++ NE.toList ads ++ ads') [] g (returnTypes cs), txs)
+  return (v, w, ts, Just $ mkGenDict df (extractConstants cs ++ timeConstants ++ NE.toList ads ++ ads') [] g (returnTypes cs), txs)
   where cd = cfg ^. cConf . corpusDir
         df = cfg ^. cConf . dictFreq

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -235,7 +235,7 @@ loadSpecified name cs = do
     Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check
     Nothing    -> do
       vm <- loadLibraries ls addrLibrary d blank
-      let transaction = unless (isJust fp) $ void . execTx $ Tx (SolCreate bc) d ca 8000030 0 (w256 $ fromInteger balc) (initialTimestamp,initialBlockNumber)
+      let transaction = unless (isJust fp) $ void . execTx $ Tx (SolCreate bc) d ca 8000030 0 (w256 $ fromInteger balc) (initialTimestamp, initialBlockNumber)
       vm' <- execStateT transaction vm
       case currentContract vm' of
         Just _  -> return (vm', neFuns, fst <$> tests, abiMapping)
@@ -297,6 +297,11 @@ mkValidAbiInt i x = if abs x <= 2 ^ (i - 1) - 1 then Just $ AbiInt i x else Noth
 
 mkValidAbiUInt :: Int -> Word256 -> Maybe AbiValue
 mkValidAbiUInt i x = if x <= 2 ^ i - 1 then Just $ AbiUInt i x else Nothing
+
+timeConstants :: [AbiValue]
+timeConstants = concatMap dec [initialTimestamp, initialBlockNumber]
+  where dec i = let l f = f <$> [8,16..256] <*> fmap fromIntegral [i-1..i+1] in
+                catMaybes (l mkValidAbiInt ++ l mkValidAbiUInt)
 
 -- | Given a list of 'SolcContract's, try to parse out string and integer literals
 extractConstants :: [SolcContract] -> [AbiValue]

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -65,10 +65,8 @@ genTxWith m s r c g gp mv t = do
       v' = genValue ps mv
       rs = NE.fromList . catMaybes $ mkR <$> toList m
       mkR = _2 (flip M.lookup mm . view (bytecode . to stripBytecodeMetadata))
-  (tt,tn) <- t
-  let t' = return (initialTimestamp + tt, initialBlockNumber + tn)
   v'' <- v' <$> s' <*> r' <*> c'
-  Tx <$> (SolCall <$> c') <*> s' <*> (fst <$> r') <*> g <*> gp <*> v'' <*> t'
+  Tx <$> (SolCall <$> c') <*> s' <*> (fst <$> r') <*> g <*> gp <*> v'' <*> t
 
 getSignatures :: MonadRandom m => SignatureMap -> Maybe SignatureMap -> m SignatureMap
 getSignatures hmm Nothing = return hmm

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -98,6 +98,8 @@ integrationTests = testGroup "Solidity Integration Testing"
       , ("tests are not empty",                    testsEmpty                  ) ]
   , testContract "basic/time.sol"         (Just "basic/time.yaml")
       [ ("echidna_timepassed passed",              solved      "echidna_timepassed") ]
+  , testContract "basic/now.sol"         Nothing
+      [ ("echidna_now passed",                     solved      "echidna_now") ]
   , testContract "basic/construct.sol"    Nothing
       [ ("echidna_construct passed",               solved      "echidna_construct") ]
   , testContract "basic/gasprice.sol"     Nothing


### PR DESCRIPTION
Fix for #460 and improved value generation with initial timestamp and block numbers. This is not ideal, but it works as a first step. I will improve it in a future PR.