### PR TITLE
GitHub Actions: remove mstksg/setup-stack@v1 action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Stack
-        uses: mstksg/setup-stack@v1
-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
This action is currently broken (see #504, mstksg/setup-stack#7).
Fortunately, it is also not needed anymore as the newer GitHub hosted
environments already come with Stack preinstalled.

Closes: #504