### PR TITLE
fix issue where libraries would get loaded at extreme timestamps and block numbers, also switch to the new hevm stripBytecodeMetadata

### DIFF
--- a/examples/solidity/basic/library.sol
+++ b/examples/solidity/basic/library.sol
@@ -1,23 +1,28 @@
-library Test{
+library Test {
     struct Storage{
         bool flag;
     }
 
-     function set(Storage storage st) public{
+    function set(Storage storage st) public{
         st.flag = true;
     }
 
  }
 
-contract Contract{
+contract Contract {
     using Test for Test.Storage;
     Test.Storage st;
 
-     function set() public{
+    function set() public{
         st.set();
     }
 
-     function echidna_library_call() external view returns (bool) {
+    function echidna_library_call() external view returns (bool) {
         return (!st.flag);
+    }
+
+    function echidna_valid_timestamp() external view returns (bool) {
+        require(block.timestamp >= 1524785992 && block.number >= 4370000);
+        return (block.timestamp <= 1524785992 + 100 weeks && block.number < 4370000 + 10000000);
     }
 }

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -8,19 +8,14 @@
 
 module Echidna.ABI where
 
-import Codec.CBOR.Read (deserialiseFromBytes)
-import Codec.CBOR.Term (decodeTerm)
 import Control.Lens
 import Control.Monad (join, liftM2, liftM3, foldM, replicateM)
 import Control.Monad.Catch (MonadThrow(..))
 import Control.Monad.State.Class (MonadState, gets)
 import Control.Monad.State (evalStateT)
 import Control.Monad.Random.Strict (MonadRandom, getRandom, getRandoms, getRandomR, uniformMay)
-import Data.Binary.Get (runGet, getWord16be)
 import Data.Bool (bool)
 import Data.ByteString (ByteString)
-import Data.ByteString.Lazy (fromStrict)
-import Data.Either (isRight)
 import Data.Foldable (toList)
 import Data.Has (Has(..))
 import Data.Hashable (Hashable(..))
@@ -308,14 +303,3 @@ genAbiCallM abi = genWithDict (fmap toList . view wholeCalls) (traverse $ traver
 genInteractionsM :: (MonadState x m, Has GenDict x, MonadRandom m, MonadThrow m)
                  => NE.NonEmpty SolSignature -> m SolCall
 genInteractionsM l = genAbiCallM =<< rElem l
-
--- | Given a solc bytecode strip off the metadata from the end
-stripBytecodeMetadata :: ByteString -> ByteString
-stripBytecodeMetadata bc
-  | BS.length cl /= 2 = bc
-  | BS.length h >= cl' && (isRight . deserialiseFromBytes decodeTerm $ fromStrict cbor) = bc'
-  | otherwise = bc
-  where l = BS.length bc
-        (h, cl) = BS.splitAt (l - 2) bc
-        cl' = fromIntegral . runGet getWord16be . fromStrict $ cl
-        (bc', cbor) = BS.splitAt (BS.length h - cl') h

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -16,15 +16,14 @@ import Control.Monad.Reader.Class (MonadReader(..))
 import Control.Monad.State.Strict (MonadState, execStateT, runStateT, get, put)
 import Data.Aeson (FromJSON(..), (.:), withObject, eitherDecodeFileStrict)
 import Data.Binary.Get (runGetOrFail)
-import Data.ByteString.Char8 (ByteString, empty)
+import Data.ByteString.Char8 (ByteString)
 import Data.Has (Has(..))
-import Data.Map (fromList)
 import Data.Maybe (maybe)
 import Data.Text.Encoding (encodeUtf8)
 import EVM
 import EVM.ABI (AbiType(..), getAbi)
 import EVM.Concrete (w256)
-import EVM.Exec (exec, vmForEthrunCreation)
+import EVM.Exec (exec)
 import EVM.Types (Addr, W256)
 import Text.Read (readMaybe)
 
@@ -88,10 +87,9 @@ loadEthenoBatch ts fp = do
        (Left e) -> throwM $ EthenoException e
        (Right (ethenoInit :: [Etheno])) -> do
          -- Execute contract creations and initial transactions,
-         let blank  = vmForEthrunCreation empty & env . contracts .~ fromList []
-             initVM = foldM (execEthenoTxs ts) Nothing ethenoInit
+         let initVM = foldM (execEthenoTxs ts) Nothing ethenoInit
 
-         (addr, vm') <- runStateT initVM blank
+         (addr, vm') <- runStateT initVM initialVM
          case addr of
               Nothing -> throwM $ EthenoException "Could not find a contract with echidna tests"
               Just a  -> execStateT (liftSH . loadContract $ a) vm'

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -23,6 +23,7 @@ import Data.Maybe (catMaybes)
 import EVM hiding (value)
 import EVM.ABI (abiCalldata, abiValueType)
 import EVM.Concrete (Word(..), w256)
+import EVM.Solidity (stripBytecodeMetadata)
 import EVM.Types (Addr)
 
 import qualified System.Directory as SD

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,6 @@ dependencies:
   - brick                <= 0.46
   - base16-bytestring
   - bytestring
-  - cborg
   - containers
   - data-dword
   - data-has

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -80,6 +80,8 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_balance failed",                 passed      "echidna_balance") ]
   , testContract "basic/library.sol"      (Just "basic/library.yaml")
       [ ("echidna_library_call failed",            solved      "echidna_library_call") ]
+  , testContract "basic/library.sol"      (Just "basic/library.yaml")
+      [ ("echidna_valid_timestamp failed",         passed      "echidna_valid_timestamp") ]
   , testContract "basic/fallback.sol"     Nothing
       [ ("echidna_fallback failed",                solved      "echidna_fallback") ]
   , testContract "basic/darray.sol"       Nothing


### PR DESCRIPTION
`loadLibraries` would use `(initialTimestamp, initialBlockNumber)` as the delay property, causing `block . number` and `block . timestamp` to be incremented way more times than desired. we introduce a new `initialVM` that takes care of all this business for us so we can just use `(0, 0)`, as well as extend the timestamp and block number business to the `RPC` (multicontract, we should probably also rename this) module.

hevm-0.37 contains the new `stripBytecodeMetadata` that actually works and is a copy of the version i introduced a while back, so we remove that bit of duplicated code as well.