### PR TITLE
Added explicit delay in shrinking and improved pp functions

### DIFF
--- a/examples/solidity/basic/time.sol
+++ b/examples/solidity/basic/time.sol
@@ -14,4 +14,9 @@ contract Time {
   function echidna_timepassed() public returns (bool) {
     return(start == marked);
   }
+
+  function echidna_moretimepassed() public returns (bool) {
+    return(now < start + 10 weeks );
+  }
+
 }

--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -126,4 +126,5 @@ mapTest (solTest, testState) =
 
   mapCall (SolCreate _) = ("<CREATE>", Nothing)
   mapCall (SolCall (name, args)) = (name, Just $ ppAbiValue <$> args)
+  mapCall NoCall                 = ("*delay*", Nothing)
   mapCall (SolCalldata x) = (decodeUtf8 $ "0x" <> BS16.encode x, Nothing)

--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -126,5 +126,5 @@ mapTest (solTest, testState) =
 
   mapCall (SolCreate _) = ("<CREATE>", Nothing)
   mapCall (SolCall (name, args)) = (name, Just $ ppAbiValue <$> args)
-  mapCall NoCall                 = ("*delay*", Nothing)
+  mapCall NoCall                 = ("*wait*", Nothing)
   mapCall (SolCalldata x) = (decodeUtf8 $ "0x" <> BS16.encode x, Nothing)

--- a/lib/Echidna/Pretty.hs
+++ b/lib/Echidna/Pretty.hs
@@ -20,4 +20,5 @@ ppSolCall (t, vs) = (if t == "" then unpack "*fallback*" else unpack t) ++ "(" +
 ppTxCall :: TxCall -> String
 ppTxCall (SolCreate _)    = "<CREATE>"
 ppTxCall (SolCall x)      = ppSolCall x
+ppTxCall NoCall           = "*wait*"
 ppTxCall (SolCalldata x)  = BSC8.unpack $ "0x" <> BS16.encode x

--- a/lib/Echidna/Types/Random.hs
+++ b/lib/Echidna/Types/Random.hs
@@ -11,4 +11,7 @@ rElem :: MonadRandom m => NonEmpty a -> m a
 rElem l  = (l !!) <$> getRandomR (0, length l - 1)
 
 usuallyRarely :: MonadRandom m => a -> a -> m a
-usuallyRarely u r = weighted [(u, 1000), (r, 1)]
+usuallyRarely u r = weighted [(u, 100), (r, 1)]
+
+usuallyVeryRarely :: MonadRandom m => a -> a -> m a
+usuallyVeryRarely u r = weighted [(u, 1000), (r, 1)]

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -19,6 +19,7 @@ import Echidna.Types.Signature (SolCall)
 data TxCall = SolCreate   ByteString
             | SolCall     SolCall
             | SolCalldata ByteString
+            | NoCall
   deriving (Show, Ord, Eq)
 makePrisms ''TxCall
 $(deriveJSON defaultOptions ''TxCall)

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -18,7 +18,7 @@ import Echidna.ABI (defSeed)
 import Echidna.Exec
 import Echidna.Pretty (ppTxCall)
 import Echidna.Types.Campaign
-import Echidna.Types.Tx (Tx(Tx), TxConf, txGas, src)
+import Echidna.Types.Tx (Tx(Tx), TxCall(..), TxConf, txGas, src)
 
 -- | An address involved with a 'Transaction' is either the sender, the recipient, or neither of those things.
 data Role = Sender | Receiver | Ambiguous
@@ -32,6 +32,10 @@ progress n m = "(" ++ show n ++ "/" ++ show m ++ ")"
 
 -- | Given rules for pretty-printing associated address, and whether to print them, pretty-print a 'Transaction'.
 ppTx :: (MonadReader x m, Has Names x, Has TxConf x) => Bool -> Tx -> m String
+ppTx _ (Tx NoCall _ _ _ _ _ (t, b)) =
+  return $ "*wait*" ++ (if t == 0    then "" else " Time delay: "  ++ show (toInteger t) ++ " seconds")
+                    ++ (if b == 0    then "" else " Block delay: " ++ show (toInteger b))
+
 ppTx pn (Tx c s r g gp v (t, b)) = let sOf = ppTxCall in do
   names <- view hasLens
   tGas  <- view $ hasLens . txGas
@@ -39,8 +43,8 @@ ppTx pn (Tx c s r g gp v (t, b)) = let sOf = ppTxCall in do
                  ++ (if g == tGas then "" else " Gas: "         ++ show g)
                  ++ (if gp == 0   then "" else " Gas price: "   ++ show gp)
                  ++ (if v == 0    then "" else " Value: "       ++ show v)
-                 ++ (if t == 0    then "" else " Time delay: "  ++ show t)
-                 ++ (if b == 0    then "" else " Block delay: " ++ show b)
+                 ++ (if t == 0    then "" else " Time delay: "  ++ show (toInteger t) ++ " seconds")
+                 ++ (if b == 0    then "" else " Block delay: " ++ show (toInteger b))
 
 -- | Pretty-print the coverage a 'Campaign' has obtained.
 ppCoverage :: CoverageMap -> Maybe String


### PR DESCRIPTION
This small PR allows Echidna to use a special transaction to discover during shrinking when a function called is actually useless and only the time/block delay is triggering an failure. It will also improve a little how calls are printed to make them easier to understand.