### PR TITLE
GitHub Actions: fix macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
           brew untap local/homebrew-openssl
           brew untap local/homebrew-python2
 
+      - name: Workaround for actions/cache#403
+        if: runner.os == 'macOS'
+        run: |
+          brew install gnu-tar
+          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
+
       - name: Get Packages
         uses: mstksg/get-package@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
             brew: automake
 
     steps:
+      - name: Workaround for actions/virtual-environments#1811
+        if: runner.os == 'macOS'
+        run: |
+          brew untap local/homebrew-openssl
+          brew untap local/homebrew-python2
+
       - name: Get Packages
         uses: mstksg/get-package@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,21 +42,21 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.local/
-          key: ${{ runner.os }}-local-v1
+          key: ${{ runner.os }}-local-v3
 
       - name: Cache Stack
         id: cache-stack
         uses: actions/cache@v1
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-stack-v1
+          key: ${{ runner.os }}-stack-v3
 
       - name: Cache Cabal
         id: cache-cabal
         uses: actions/cache@v1
         with:
           path: ~/.cabal
-          key: ${{ runner.os }}-cabal-v1
+          key: ${{ runner.os }}-cabal-v3
 
       - name: Build Binaries
         run: |


### PR DESCRIPTION
Currently the CI system fails on macOS with several errors related
to Homebrew and cache corruption. This implements temporal
workarounds for both issues. For more details, see:

 * https://github.com/actions/virtual-environments/issues/1811
 * https://github.com/actions/cache/issues/403

Closes: #525