### PR TITLE
GitHub Actions: improve macOS releases

### DIFF
--- a/.github/scripts/build-macos-release.sh
+++ b/.github/scripts/build-macos-release.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+add_rpath()
+{
+    BINARY="$1"
+    install_name_tool -add_rpath "@executable_path/." "$BINARY"
+}
+
+fix_path()
+{
+    BINARY="$1"
+    MATCH="$2"
+    NEW="$3"
+    OLD=$(otool -L "$BINARY" | grep "$MATCH" | awk '{print $1}')
+    install_name_tool -change "$OLD" "$NEW" "$BINARY"
+    cp -n "$OLD" "$(dirname "$BINARY")/$(basename "$NEW")"
+}
+
+
+BUILD="$(mktemp -d)/echidna-test"
+mkdir -p "$BUILD"
+cp "$HOME/.local/bin/echidna-test" "$BUILD"
+
+BINARY="$BUILD/echidna-test"
+add_rpath "$BINARY"
+fix_path "$BINARY" libsecp256k1 "@rpath/libsecp256k1.dylib"
+fix_path "$BINARY" libff "@rpath/libff.dylib"
+fix_path "$BINARY" libgmp "@rpath/libgmp.dylib"
+fix_path "$BUILD/libff.dylib" libgmp "@rpath/libgmp.dylib"
+fix_path "$BUILD/libsecp256k1.dylib" libgmp "@rpath/libgmp.dylib"
+
+GZIP=-9 tar -czf echidna-test.tar.gz -C "$BUILD/.." echidna-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
           brew untap local/homebrew-openssl
           brew untap local/homebrew-python2
 
+      - name: Workaround for actions/cache#403
+        if: runner.os == 'macOS'
+        run: |
+          brew install gnu-tar
+          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
+
       - name: Get Packages
         uses: mstksg/get-package@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        #  - macos-latest
+          - macos-latest
         include:
           - os: ubuntu-latest
             apt-get: autoconf automake libtool
-        #  - os: macos-latest
-        #    brew: automake
+          - os: macos-latest
+            brew: automake
 
     steps:
       - name: Workaround for actions/virtual-environments#1811

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,12 @@ jobs:
             stack test --ghc-options="-Werror" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib
           done
 
-      - name: Compress binary
+      - name: Amend and compress binaries (macOS)
+        if: runner.os == 'macOS'
+        run: .github/scripts/build-macos-release.sh
+
+      - name: Compress binary (Linux)
+        if: runner.os == 'Linux'
         run: GZIP=-9 tar -czf echidna-test.tar.gz $HOME/.local/bin/echidna-test
 
       - name: Upload artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
         #    brew: automake
 
     steps:
+      - name: Workaround for actions/virtual-environments#1811
+        if: runner.os == 'macOS'
+        run: |
+          brew untap local/homebrew-openssl
+          brew untap local/homebrew-python2
+
       - name: Get Packages
         uses: mstksg/get-package@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,21 +42,21 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.local/
-          key: ${{ runner.os }}-local-v1
+          key: ${{ runner.os }}-local-v3
 
       - name: Cache Stack
         id: cache-stack
         uses: actions/cache@v1
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-stack-v1
+          key: ${{ runner.os }}-stack-v3
 
       - name: Cache Cabal
         id: cache-cabal
         uses: actions/cache@v1
         with:
           path: ~/.cabal
-          key: ${{ runner.os }}-cabal-v1
+          key: ${{ runner.os }}-cabal-v3
 
       - name: Build Binaries
         run: |


### PR DESCRIPTION
Currently, releases for macOS are not very portable. The
binaries have hardcoded paths and might not run on other
systems. This commit improves the macOS binary releases
made via GitHub actions by bundling binary copies of libff,
libgmp and libsecp256k1, and by adjusting the rpath and
library names to make echidna run on other systems.