### PR TITLE
Refactor Tx constants to use in deployment and config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+        #  - macos-latest
         include:
           - os: ubuntu-latest
             apt-get: autoconf automake libtool
-          - os: macos-latest
-            brew: automake
+        #  - os: macos-latest
+        #    brew: automake
 
     steps:
       - name: Get Packages

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -33,7 +33,7 @@ import qualified Data.Yaml as Y
 import Echidna.Solidity
 import Echidna.Test
 import Echidna.Types.Campaign (CampaignConf(CampaignConf))
-import Echidna.Types.Tx
+import Echidna.Types.Tx  (TxConf(TxConf), maxGasPerBlock, defaultTimeDelay, defaultBlockDelay)
 import Echidna.UI
 import Echidna.UI.Report
 

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -33,7 +33,7 @@ import qualified Data.Yaml as Y
 import Echidna.Solidity
 import Echidna.Test
 import Echidna.Types.Campaign (CampaignConf(CampaignConf))
-import Echidna.Types.Tx (TxConf(TxConf))
+import Echidna.Types.Tx
 import Echidna.UI
 import Echidna.UI.Report
 
@@ -106,11 +106,11 @@ instance FromJSON EConfigWithUsage where
                         return $ TestConf (\fname -> (== goal fname)  . maybe ResOther classifyRes . view result)
                                           (const psender)
                 getWord s d = C Dull . fromIntegral <$> v ..:? s ..!= (d :: Integer)
-                xc = TxConf <$> getWord "propMaxGas" 8000030
-                            <*> getWord "testMaxGas" 8000030
+                xc = TxConf <$> getWord "propMaxGas" maxGasPerBlock
+                            <*> getWord "testMaxGas" maxGasPerBlock
                             <*> getWord "maxGasprice" 100000000000
-                            <*> getWord "maxTimeDelay" 604800     
-                            <*> getWord "maxBlockDelay" 60480
+                            <*> getWord "maxTimeDelay" defaultTimeDelay     
+                            <*> getWord "maxBlockDelay" defaultBlockDelay
                             <*> getWord "maxValue" 100000000000000000000 -- 100 eth
 
                 cov = v ..:? "coverage" <&> \case Just True -> Just mempty

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -36,7 +36,7 @@ import Echidna.ABI                (encodeSig, hashSig, fallback)
 import Echidna.Exec               (execTx, initialVM)
 import Echidna.RPC                (loadEthenoBatch)
 import Echidna.Types.Signature    (FunctionHash, SolSignature, SignatureMap)
-import Echidna.Types.Tx           (TxConf, TxCall(..), Tx(..), initialTimestamp, initialBlockNumber)
+import Echidna.Types.Tx           (TxConf, TxCall(..), Tx(..), unlimitedGasPerBlock, initialTimestamp, initialBlockNumber)
 import Echidna.Types.World        (World(..))
 import Echidna.Processor
 
@@ -236,7 +236,7 @@ loadSpecified name cs = do
     Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check
     Nothing    -> do
       vm <- loadLibraries ls addrLibrary d blank
-      let transaction = unless (isJust fp) $ void . execTx $ Tx (SolCreate bc) d ca 8000030 0 (w256 $ fromInteger balc) (0, 0)
+      let transaction = unless (isJust fp) $ void . execTx $ Tx (SolCreate bc) d ca unlimitedGasPerBlock 0 (w256 $ fromInteger balc) (0, 0)
       vm' <- execStateT transaction vm
       case currentContract vm' of
         Just _  -> return (vm', neFuns, fst <$> tests, abiMapping)

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -23,6 +23,18 @@ data TxCall = SolCreate   ByteString
 makePrisms ''TxCall
 $(deriveJSON defaultOptions ''TxCall)
 
+maxGasPerBlock :: Integer
+maxGasPerBlock = 12500000 
+
+unlimitedGasPerBlock :: Word
+unlimitedGasPerBlock = 0xffffffff
+
+defaultTimeDelay :: Integer
+defaultTimeDelay = 604800
+
+defaultBlockDelay :: Integer
+defaultBlockDelay = 60480
+
 initialTimestamp :: Word
 initialTimestamp = 1524785992 -- Thu Apr 26 23:39:52 UTC 2018
 

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -24,7 +24,7 @@ makePrisms ''TxCall
 $(deriveJSON defaultOptions ''TxCall)
 
 maxGasPerBlock :: Integer
-maxGasPerBlock = 12500000 
+maxGasPerBlock = 12500000 -- https://cointelegraph.com/news/ethereum-miners-vote-to-increase-gas-limit-causing-community-debate
 
 unlimitedGasPerBlock :: Word
 unlimitedGasPerBlock = 0xffffffff


### PR DESCRIPTION
* Refactor constants to have clear names.
* Increase max gas block from 8000030 to 12500000.
* Use virtually unlimited gas during deployment (as a workaround when users need to deploy large contracts).