### PR TITLE
libff fix in ci tests

### DIFF
--- a/.github/scripts/install-libff.sh
+++ b/.github/scripts/install-libff.sh
@@ -12,6 +12,7 @@ fi
 git clone https://github.com/scipr-lab/libff --recursive
 cd libff
 git submodule init && git submodule update
+git checkout v1.0.0
 
 ARGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DWITH_PROCPS=OFF"
 CXXFLAGS=""


### PR DESCRIPTION
libff re-started its development and we cannot use the main branch anymore.