### PR TITLE
Fix flanky corpus count test

### DIFF
--- a/examples/solidity/coverage/boolean.sol
+++ b/examples/solidity/coverage/boolean.sol
@@ -1,7 +1,7 @@
 contract C {
   uint state = 0;
 
-  function f(bool sel, bool b) public {
+  function f(bool sel, bool b) payable public {
     state = 1;
     if (sel)
       sel = false;

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -138,7 +138,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       ]
   ,  testContract "coverage/boolean.sol"       (Just "coverage/boolean.yaml")
       [ ("echidna_true failed",                    passed     "echidna_true")
-      , ("unexpected corpus count ",               countCorpus 6)]
+      , ("unexpected corpus count ",               countCorpus 5)]
   ,  testContract "basic/payable.sol"     Nothing
       [ ("echidna_payable failed",                 solved      "echidna_payable") ]
   ,  checkConstructorConditions "basic/codesize.sol"


### PR DESCRIPTION
This small change will avoid unexpected fails in the corpus count test (which are caused by bad luck).