### PR TITLE
Use more the values from the dictionary 

### DIFF
--- a/examples/solidity/basic/delay.sol
+++ b/examples/solidity/basic/delay.sol
@@ -1,0 +1,23 @@
+contract C {
+  uint fd;
+  uint ft;
+  uint gd;
+  uint gt;
+
+  function f() public {
+      fd = block.number; 
+      ft = block.timestamp;
+  }
+  function g() payable public {
+      gd = block.number; 
+      gt = block.timestamp;
+  }
+
+  function echidna_block_number() public returns (bool) {
+      return (fd - gd) != 42;
+  }
+
+  function echidna_timestamp() public returns (bool) {
+      return (ft - gt) != 43;
+  }
+} 

--- a/examples/solidity/basic/payable.sol
+++ b/examples/solidity/basic/payable.sol
@@ -3,7 +3,7 @@ contract C {
   uint state = 0;
   uint another_state = 0;
   function payable_function() public payable {
-    if (msg.value > 128)
+    if (msg.value == 129)
         state = msg.value;
   }
 

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -41,6 +41,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Text.Encoding  as TE 
 import qualified Data.Vector as V
+import qualified Data.HashSet as H
 
 import Echidna.Mutator (mutateLL, replaceAt) 
 import Echidna.Types.Random
@@ -125,6 +126,12 @@ gaddCalls c = wholeCalls <>~ hashMapBy (fmap $ fmap abiValueType) c
 
 defaultDict :: GenDict
 defaultDict = mkGenDict 0 [] [] 0 (const Nothing)
+
+dictValues :: GenDict -> [Integer] 
+dictValues g = catMaybes $ concatMap (\(_,h) -> map fromValue $ H.toList h) $ M.toList $ g ^. constants
+  where fromValue (AbiUInt _ n) = Just (toInteger n)
+        fromValue (AbiInt  _ n) = Just (toInteger n)
+        fromValue _             = Nothing
 
 -- This instance is the only way for mkConf to work nicely, and is well-formed.
 {-# ANN module ("HLint: ignore Unused LANGUAGE pragma" :: String) #-}

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -16,6 +16,7 @@ import Control.Monad (liftM3, replicateM, when, (<=<), ap, unless)
 import Control.Monad.Catch (MonadCatch(..), MonadThrow(..))
 import Control.Monad.Random.Strict (MonadRandom, RandT, evalRandT, getRandomR, uniform, uniformMay, fromList)
 import Control.Monad.Reader.Class (MonadReader)
+import Control.Monad.Reader (runReaderT)
 import Control.Monad.State.Strict (MonadState(..), StateT(..), evalStateT, execStateT)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Random.Strict (liftCatch)
@@ -183,12 +184,13 @@ seqMutators (c1, c2, c3) = fromList
           return . take ql $ if flp then take k gtxs ++ rtxs else take k rtxs ++ gtxs
 
 -- | Generate a new sequences of transactions, either using the corpus or with randomly created transactions
-randseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
-           , Has GenDict y, Has TxConf x, Has TestConf x, Has CampaignConf x, Has Campaign y)
+randseq :: ( MonadRandom m, MonadReader x m
+           , Has GenDict x, Has TxConf x, Has TestConf x, Has CampaignConf x, Has Campaign x)
         => Int -> Map Addr Contract -> World -> m [Tx]
 randseq ql o w = do
-  ca <- use hasLens
+  ca <- view hasLens
   cs <- view $ hasLens . mutConsts
+  txConf :: TxConf <- view hasLens
   let ctxs = ca ^. corpus
       p    = ca ^. ncallseqs
   if length ctxs > p then -- Replay the transactions in the corpus, if we are executing the first iterations
@@ -196,7 +198,7 @@ randseq ql o w = do
   else
     do
       -- Randomly generate new random transactions
-      gtxs <- replicateM ql (evalStateT (genTxM o) (w, ca ^. genDict))
+      gtxs <- replicateM ql $ runReaderT (genTxM o) (w, ca ^. genDict, txConf)
       -- Select a random mutator
       mut <- seqMutators cs
       if DS.null ctxs
@@ -217,8 +219,11 @@ callseq v w ql = do
   gasEnabled <- view $ hasLens . estimateGas
   -- Then, we get the current campaign state
   ca <- use hasLens
+  caConf :: CampaignConf <- view hasLens
+  testConf :: TestConf <- view hasLens
+  txConf :: TxConf <- view hasLens
   -- Then, we generate the actual transaction in the sequence
-  is <- randseq ql old w
+  is <- runReaderT (randseq ql old w) (ca ^. genDict, ca, caConf, testConf, txConf)
   -- We then run each call sequentially. This gives us the result of each call, plus a new state
   (res, s) <- runStateT (evalSeq v ef is) (v, ca)
   let new = s ^. _1 . env . EVM.contracts

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -63,7 +63,7 @@ genTxM m = do
   mm <- getSignatures hmm lmm
   let ns = dictValues genDict
   s' <- rElem ss
-  r' <- rElem $ NE.fromList . catMaybes $ (toContractA mm) <$> toList m
+  r' <- rElem $ NE.fromList . catMaybes $ toContractA mm <$> toList m
   c' <- genInteractionsM (snd r')
   v' <- genValue mv ns ps c'
   t' <- (,) <$> genDelay t ns <*> genDelay b ns

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -12,10 +12,10 @@ import Prelude hiding (Word)
 
 import Control.Lens
 import Control.Monad (join, liftM2, unless)
-import Control.Monad.Catch (MonadThrow, bracket)
+import Control.Monad.Catch (bracket)
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader)
-import Control.Monad.State.Strict (MonadState, State, evalStateT, runState, get, put)
+import Control.Monad.State.Strict (MonadState, State, runState, get, put)
 import Data.Aeson (ToJSON(..), decodeStrict, encodeFile)
 import Data.Has (Has(..))
 import Data.Hashable (hash)
@@ -48,68 +48,43 @@ level :: (Num a, Eq a) => (a, a) -> (a, a)
 level (elemOf each 0 -> True) = (0,0)
 level x                       = x
 
--- | Given generators for an origin, destination, value, and function call, generate a call
--- transaction. Note: This doesn't generate @CREATE@s because I don't know how to do that at random.
-genTxWith :: (MonadRandom m, MonadState x m, Has World x, MonadThrow m)
-          => Map Addr Contract                        -- ^ List of contracts
-          -> (NE.NonEmpty Addr -> m Addr)             -- ^ Sender generator
-          -> (NE.NonEmpty ContractA -> m ContractA)   -- ^ Receiver generator
-          -> (Addr -> ContractA -> m SolCall)         -- ^ Call generator
-          -> m Word                                   -- ^ Gas generator
-          -> m Word                                   -- ^ Gas price generator
-          -> ([FunctionHash] -> Addr -> ContractA -> SolCall -> m Word)   -- ^ Value generator
-          -> m (Word, Word)                           -- ^ Delay generator
-          -> m Tx
-genTxWith m s r c g gp vg t = do
-  World ss hmm lmm ps <- use hasLens
-  mm <- getSignatures hmm lmm
-  let s' = s ss
-      r' = r rs
-      c' = join $ liftM2 c s' r'
-      v' = vg ps
-      rs = NE.fromList . catMaybes $ mkR <$> toList m
-      mkR = _2 (flip M.lookup mm . view (bytecode . to stripBytecodeMetadata))
-  v'' <- v' <$> s' <*> r' <*> c'
-  Tx <$> (SolCall <$> c') <*> s' <*> (fst <$> r') <*> g <*> gp <*> v'' <*> t
-
 getSignatures :: MonadRandom m => SignatureMap -> Maybe SignatureMap -> m SignatureMap
 getSignatures hmm Nothing = return hmm
 getSignatures hmm (Just lmm) = usuallyVeryRarely hmm lmm -- once in a while, this will use the low-priority signature for the input generation
 
--- | Synthesize a random 'Transaction', not using a dictionary.
-genTx :: forall m x y. (MonadRandom m, MonadReader x m, Has TxConf x, MonadState y m, Has World y, MonadThrow m)
-      => Map Addr Contract
-      -> m Tx
-genTx m = use (hasLens :: Lens' y World) >>= evalStateT (genTxM m) . (defaultDict,)
-
 -- | Generate a random 'Transaction' with either synthesis or mutation of dictionary entries.
-genTxM :: (MonadRandom m, MonadReader x m, Has TxConf x, MonadState y m, Has GenDict y, Has World y, MonadThrow m)
+genTxM :: (MonadRandom m, MonadReader x m, Has TxConf x, Has GenDict x, Has World x)
   => Map Addr Contract
   -> m Tx
 genTxM m = do
   TxConf _ g gp t b mv <- view hasLens
-  genDict <- use hasLens
+  World ss hmm lmm ps <- view hasLens
+  genDict <- view hasLens
+  mm <- getSignatures hmm lmm
   let ns = dictValues genDict
-  genTxWith
-    m
-    rElem rElem                                                                -- src and dst
-    (const $ genInteractionsM . snd)                                           -- call itself
-    (pure g) (pure gp) (genValue mv ns)                                        -- gas, gasprice, value
-    (level <$> liftM2 (,) (genDelay t ns) (genDelay b ns))                     -- delay
+  s' <- rElem ss
+  r' <- rElem $ NE.fromList . catMaybes $ (toContractA mm) <$> toList m
+  c' <- genInteractionsM (snd r')
+  v' <- genValue mv ns ps c'
+  t' <- (,) <$> genDelay t ns <*> genDelay b ns
+  pure $ Tx (SolCall c') s' (fst r') g gp v' (level t')
+  where
+    toContractA :: SignatureMap -> (Addr, Contract) -> Maybe ContractA
+    toContractA mm (addr, c) =
+      (addr,) <$> M.lookup (stripBytecodeMetadata $ c ^. bytecode) mm
 
-genDelay :: (MonadRandom f) => Word -> [Integer] -> f Word
+genDelay :: MonadRandom m => Word -> [Integer] -> m Word
 genDelay mv ds = do
   let ds' = map (`mod` (fromIntegral mv + 1)) ds
-  g <- oftenUsually randValue $ rElem $ NE.fromList (0:ds')
+  g <- oftenUsually randValue $ rElem (0 NE.:| ds')
   w256 . fromIntegral <$> g
   where randValue = getRandomR (1 :: Integer, fromIntegral mv)
- 
-genValue :: (MonadRandom m) => Word -> [Integer] -> [FunctionHash] -> Addr -> ContractA -> SolCall -> m Word
-genValue mv ds ps _ _ sc =
-  if sig `elem` ps
-  then do
+
+genValue :: MonadRandom m => Word -> [Integer] -> [FunctionHash] -> SolCall -> m Word
+genValue mv ds ps sc =
+  if sig `elem` ps then do
     let ds' = map (`mod` (fromIntegral mv + 1)) ds
-    g <- oftenUsually randValue (rElem $ NE.fromList (0:ds'))
+    g <- oftenUsually randValue $ rElem (0 NE.:| ds')
     fromIntegral <$> g
   else do
     g <- usuallyRarely (pure 0) randValue -- once in a while, this will generate value in a non-payable function
@@ -164,7 +139,7 @@ liftSH = stateST . runState . zoom hasLens
 setupTx :: (MonadState x m, Has VM x) => Tx -> m ()
 setupTx (Tx NoCall _ r _ _ _ (t, b)) = liftSH . sequence_ $
   [ result .= Nothing, state . pc .= 0, state . stack .= mempty, state . memory .= mempty
-  , block . timestamp += litWord t, block . number += b, loadContract r] 
+  , block . timestamp += litWord t, block . number += b, loadContract r]
 
 setupTx (Tx c s r g gp v (t, b)) = liftSH . sequence_ $
   [ result .= Nothing, state . pc .= 0, state . stack .= mempty, state . memory .= mempty, state . gas .= g

--- a/lib/Echidna/Types/Random.hs
+++ b/lib/Echidna/Types/Random.hs
@@ -10,6 +10,9 @@ type Seed = Int
 rElem :: MonadRandom m => NonEmpty a -> m a
 rElem l  = (l !!) <$> getRandomR (0, length l - 1)
 
+oftenUsually :: MonadRandom m => a -> a -> m a
+oftenUsually u r = weighted [(u, 10), (r, 1)]
+
 usuallyRarely :: MonadRandom m => a -> a -> m a
 usuallyRarely u r = weighted [(u, 100), (r, 1)]
 

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -103,6 +103,9 @@ integrationTests = testGroup "Solidity Integration Testing"
       , ("tests are not empty",                    testsEmpty                  ) ]
   , testContract "basic/time.sol"         (Just "basic/time.yaml")
       [ ("echidna_timepassed passed",              solved      "echidna_timepassed") ]
+  , testContract "basic/delay.sol"        Nothing
+      [ ("echidna_block_number passed",            solved    "echidna_block_number") 
+      , ("echidna_timestamp passed",               solved    "echidna_timestamp") ]
   , testContract "basic/now.sol"         Nothing
       [ ("echidna_now passed",                     solved      "echidna_now") ]
   , testContract "basic/construct.sol"    Nothing


### PR DESCRIPTION
This PR allows echidna to use numeric values from the dictionary to generate:

* The amount to pay to payable function.
* The number to increase the blocks number.
* The number of seconds to increase the block timestamp.