### PR TITLE
GitHub Actions: switch to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,12 +15,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: GitHub Login
-        uses: azure/docker-login@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
         with:
-          login-server: ghcr.io
+          version: latest
+          install: true
+
+      - name: GitHub Login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
           username: ${{ secrets.CR_USERNAME }}
           password: ${{ secrets.CR_PAT }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Set Docker Package and Version
         run: |
@@ -44,7 +59,13 @@ jobs:
           echo "VER=$VER" >> $GITHUB_ENV
 
       - name: Docker Build
-        run: docker build -t echidna:$VER .
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          platforms: linux/amd64
+          pull: true
+          tags: echidna:$VER
 
       - name: Push to GitHub Packages
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,9 +18,9 @@ jobs:
       - name: GitHub Login
         uses: azure/docker-login@v1
         with:
-          login-server: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          login-server: ghcr.io
+          username: ${{ secrets.CR_USERNAME }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Set Docker Package and Version
         run: |
@@ -30,10 +30,8 @@ jobs:
             # branch
             if [ "$GITHUB_REF" = "refs/heads/master" ]; then
               VER=latest
-              PKG=echidna
             else
               VER=testing
-              PKG=testing
             fi
           fi
           _=$(echo "$GITHUB_REF" | grep "^refs/tags/")
@@ -41,28 +39,27 @@ jobs:
             # tag
             # refs/tags/v1.X => v1.X
             VER=$(echo "$GITHUB_REF" | sed -e 's/.*\///')
-            PKG=echidna
           fi
           set -e
-          echo "PKG=$PKG" >> $GITHUB_ENV
           echo "VER=$VER" >> $GITHUB_ENV
 
       - name: Docker Build
-        run: docker build -t $PKG:$VER .
+        run: docker build -t echidna:$VER .
 
       - name: Push to GitHub Packages
         run: |
-          docker tag $PKG:$VER docker.pkg.github.com/$GITHUB_REPOSITORY/$PKG:$VER
-          docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$PKG:$VER
+          docker tag echidna:$VER ghcr.io/${{ github.repository_owner }}/echidna:$VER
+          docker push ghcr.io/${{ github.repository_owner }}/echidna:$VER
 
       - name: DockerHub Login
-        uses: azure/docker-login@v1
+        if: ${{ github.repository_owner == 'crytic' }}
+        uses: docker/login-action@v1
         with:
-          login-server: registry.hub.docker.com
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Push to DockerHub
+        if: ${{ github.repository_owner == 'crytic' }}
         run: |
-          docker tag $PKG:$VER registry.hub.docker.com/trailofbits/echidna:$VER
+          docker tag echidna:$VER registry.hub.docker.com/trailofbits/echidna:$VER
           docker push registry.hub.docker.com/trailofbits/echidna:$VER

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,13 @@ jobs:
           username: ${{ secrets.CR_USERNAME }}
           password: ${{ secrets.CR_PAT }}
 
+      - name: DockerHub Login
+        if: ${{ github.repository_owner == 'crytic' }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -58,29 +65,19 @@ jobs:
           set -e
           echo "VER=$VER" >> $GITHUB_ENV
 
-      - name: Docker Build
+      - name: Enable Crytic tag
+        if: ${{ github.repository_owner == 'crytic' }}
+        run: |
+          echo "CRYTIC_TAG=trailofbits/echidna:$VER" >> $GITHUB_ENV
+
+      - name: Docker Build and Push
         uses: docker/build-push-action@v2
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
           platforms: linux/amd64
           pull: true
-          tags: echidna:$VER
-
-      - name: Push to GitHub Packages
-        run: |
-          docker tag echidna:$VER ghcr.io/${{ github.repository_owner }}/echidna:$VER
-          docker push ghcr.io/${{ github.repository_owner }}/echidna:$VER
-
-      - name: DockerHub Login
-        if: ${{ github.repository_owner == 'crytic' }}
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
-      - name: Push to DockerHub
-        if: ${{ github.repository_owner == 'crytic' }}
-        run: |
-          docker tag echidna:$VER registry.hub.docker.com/trailofbits/echidna:$VER
-          docker push registry.hub.docker.com/trailofbits/echidna:$VER
+          push: true
+          tags: |
+           ghcr.io/${{ github.repository_owner }}/echidna:${{ env.VER }}
+           ${{ env.CRYTIC_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,16 @@ FROM ubuntu:bionic AS builder
 ENV LD_LIBRARY_PATH=/usr/local/lib PREFIX=/usr/local HOST_OS=Linux
 RUN apt-get update && apt-get -y upgrade && apt-get install -y sudo git cmake curl libgmp-dev libssl-dev libbz2-dev libreadline-dev software-properties-common libsecp256k1-dev && apt-get clean
 RUN curl -sSL https://get.haskellstack.org/ | sh
-COPY . /echidna/
+RUN stack upgrade && stack setup
+
+COPY package.yaml stack.yaml /echidna/
+ADD .github/scripts /echidna/.github/scripts/
 WORKDIR /echidna
 RUN .github/scripts/install-libff.sh
-RUN stack upgrade && stack setup && stack install --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
+RUN stack build --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib --only-dependencies
+
+COPY . /echidna/
+RUN stack install --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
 
 FROM ubuntu:bionic AS final
 ENV PREFIX=/usr/local HOST_OS=Linux
@@ -15,8 +21,8 @@ RUN update-locale LANG=en_US.UTF-8 && locale-gen en_US.UTF-8
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10
 RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux && chmod +x solc-static-linux && mv solc-static-linux /usr/bin/solc-0.4.25
 RUN wget https://github.com/ethereum/solidity/releases/download/v0.5.7/solc-static-linux && chmod +x solc-static-linux && mv solc-static-linux /usr/bin/solc
-COPY --from=builder /root/.local/bin/echidna-test /root/.local/bin/echidna-test
 COPY .github/scripts/install-crytic-compile.sh .github/scripts/install-crytic-compile.sh
 RUN .github/scripts/install-crytic-compile.sh
+COPY --from=builder /root/.local/bin/echidna-test /root/.local/bin/echidna-test
 ENV PATH=$PATH:/root/.local/bin LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ RUN stack upgrade && stack setup && stack install --extra-include-dirs=/usr/loca
 FROM ubuntu:bionic AS final
 ENV PREFIX=/usr/local HOST_OS=Linux
 WORKDIR /root
-COPY --from=builder /root/.local/bin/echidna-test /root/.local/bin/echidna-test
-COPY .github/scripts/install-crytic-compile.sh .github/scripts/install-crytic-compile.sh
 RUN apt-get update && apt-get -y upgrade && apt-get install -y wget locales-all locales python3.6 python3-pip python3-setuptools && apt-get clean
+RUN update-locale LANG=en_US.UTF-8 && locale-gen en_US.UTF-8
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10
 RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux && chmod +x solc-static-linux && mv solc-static-linux /usr/bin/solc-0.4.25
 RUN wget https://github.com/ethereum/solidity/releases/download/v0.5.7/solc-static-linux && chmod +x solc-static-linux && mv solc-static-linux /usr/bin/solc
+COPY --from=builder /root/.local/bin/echidna-test /root/.local/bin/echidna-test
+COPY .github/scripts/install-crytic-compile.sh .github/scripts/install-crytic-compile.sh
 RUN .github/scripts/install-crytic-compile.sh
-RUN update-locale LANG=en_US.UTF-8 && locale-gen en_US.UTF-8
 ENV PATH=$PATH:/root/.local/bin LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you want to quickly test Echidna in Linux or MacOS, we provide statically lin
 
 ### Docker container
 
-If you prefer to use a pre-built Docker container, log into Github on your local `docker` client and check out our [docker package](https://github.com/crytic/echidna/packages/136575), which are also auto-built via Github Actions.
+If you prefer to use a pre-built Docker container, log into Github on your local `docker` client and check out our [docker package](https://github.com/orgs/crytic/packages/container/package/echidna), which are also auto-built via Github Actions.
 Otherwise, if you want to install the latest released version of Echidna, we recommend using docker:
 
 ```


### PR DESCRIPTION
This PR switches from GitHub Packages Docker to GitHub Container
Registry. See the following document for more details:

    https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images

This change requires enabling the feature on GitHub by completing the
following instructions:

    https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/enabling-improved-container-support

The feature must be also enabled on the organization level.

Then you must also get a Personal Access Token (PAT) with only
`write:packages` scope (`repo` or any additional ones are not needed),
and store it in the repository settings as a secret with
the name `CR_PAT`, together with a `CR_USERNAME` secret. You can read
the document linked above for more details, and then create the token
by going to:

    https://github.com/settings/tokens

Additionally, this change disables pushes to the trailofbits
Docker Hub repository for non-`crytic` owned repositories,
so pushes are not attempted from echidna forks without proper
credentials.

As a final thing, the Dockerfile and actions were slightly reworked to
enable layer caching and speed up the docker image builds.

Closes: #555 