### PR TITLE
Show the user how the properties failed

### DIFF
--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -30,9 +30,9 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Yaml as Y
 
 import Echidna.Solidity
-import Echidna.Test
 import Echidna.Types.Campaign (CampaignConf(CampaignConf))
 import Echidna.Types.Tx  (TxConf(TxConf), maxGasPerBlock, defaultTimeDelay, defaultBlockDelay)
+import Echidna.Types.Test (TestConf(..), CallRes(..), classifyRes)
 import Echidna.UI
 import Echidna.UI.Report
 

--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -111,8 +111,8 @@ mapTest (solTest, testState) =
   where
   mapTestState (C.Open _) = (Fuzzing, Nothing, Nothing)
   mapTestState C.Passed = (Passed, Nothing, Nothing)
-  mapTestState (C.Solved txs) = (Solved, Just $ mapTx <$> txs, Nothing)
-  mapTestState (C.Large _ txs) = (Shrinking, Just $ mapTx <$> txs, Nothing)
+  mapTestState (C.Solved txs _) = (Solved, Just $ mapTx <$> txs, Nothing)
+  mapTestState (C.Large _ txs _) = (Shrinking, Just $ mapTx <$> txs, Nothing)
   mapTestState (C.Failed e) = (Error, Nothing, Just $ show e) -- TODO add (show e)
 
   mapTx Tx{..} =

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -1,0 +1,38 @@
+module Echidna.Types.Test where
+
+import Prelude hiding (Word)
+
+import Data.Text (Text)
+import EVM (VMResult(..), VM)
+import EVM.ABI (AbiValue(..), encodeAbiValue)
+import EVM.Types (Addr)
+
+import Echidna.Exec
+import Echidna.Types.Buffer (viewBuffer)
+
+-- | Configuration for evaluating Echidna tests.
+data TestConf = TestConf { classifier :: Text -> VM -> Bool
+                           -- ^ Given a VM state and test name, check if a test just passed (typically
+                           -- examining '_result'.)
+                         , testSender :: Addr -> Addr
+                           -- ^ Given the address of a test, return the address to send test evaluation
+                           -- transactions from.
+                         }
+
+-- | Possible responses to a call to an Echidna test: @true@, @false@, @REVERT@, and ???.
+data CallRes = ResFalse | ResTrue | ResRevert | ResOther
+  deriving (Eq, Show)
+
+prettyRes :: CallRes -> String
+prettyRes ResTrue   = "returned true"
+prettyRes ResFalse  = "returned false"
+prettyRes ResRevert = "reverted"
+prettyRes ResOther  = "failed with another EVM error (..)"
+
+-- | Given a 'VMResult', classify it assuming it was the result of a call to an Echidna test.
+classifyRes :: VMResult -> CallRes
+classifyRes (VMSuccess b) | viewBuffer b == Just (encodeAbiValue (AbiBool True))  = ResTrue
+                          | viewBuffer b == Just (encodeAbiValue (AbiBool False)) = ResFalse
+                          | otherwise                                             = ResOther
+classifyRes Reversion = ResRevert
+classifyRes _         = ResOther

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -32,9 +32,9 @@ import Echidna.Campaign (campaign)
 import Echidna.ABI
 import qualified Echidna.Output.JSON
 import Echidna.Solidity
-import Echidna.Test
 import Echidna.Types.Campaign
 import Echidna.Types.Tx (Tx, TxConf)
+import Echidna.Types.Test (TestConf(..))
 import Echidna.Types.World (World)
 import Echidna.UI.Report
 import Echidna.UI.Widgets

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -72,16 +72,16 @@ checkConstructorConditions fp as = testCase fp $ do
     (v, w, t) <- loadSolTests (fp :| []) Nothing
     let em = w ^. eventMap
     mapM (\u -> evalStateT (checkETest em u) v) t
-  mapM_ (assertBool as) r
+  mapM_ (assertBool as . fst) r
 
 getResult :: Text -> Campaign -> Maybe TestState
 getResult t = fmap snd <$> find ((t ==) . either fst (("ASSERTION " <>) . fst) . fst) . view tests
 
 solnFor :: Text -> Campaign -> Maybe [Tx]
 solnFor t c = case getResult t c of
-  Just (Large _ s) -> Just s
-  Just (Solved  s) -> Just s
-  _                -> Nothing
+  Just (Large _ s _) -> Just s
+  Just (Solved  s _) -> Just s
+  _                  -> Nothing
 
 solved :: Text -> Campaign -> Bool
 solved t = isJust . solnFor t


### PR DESCRIPTION
This PR will allow the user to see in the UI the reason why a property failed: either the property returned true/false, reverted or there was another error from the EVM. When running `flags.sol` example, it will show this on the terminal:

```
echidna_sometimesfalse: failed!💥 when property returned false
  Call sequence, shrinking (879/5000):
    set0(0)
    set1(0)
```

This includes a small refactoring of the types and functions from Test module.