### PR TITLE
Added funwithnumber example from Sabre

### DIFF
--- a/examples/solidity/research/solcfuzz_funwithnumbers.sol
+++ b/examples/solidity/research/solcfuzz_funwithnumbers.sol
@@ -1,3 +1,5 @@
+// Original example from https://github.com/b-mueller/sabre#example-2-integer-precision-bug
+
 pragma solidity ^0.5.0;
 
 contract FunWithNumbers {
@@ -5,8 +7,8 @@ contract FunWithNumbers {
     uint constant public weiPerEth = 1e18;
     mapping(address => uint) public balances;
 
-    function buyTokens(uint256 msg_value) public payable {
-        uint tokens = msg_value/weiPerEth*tokensPerEth; // convert wei to eth, then multiply by token rate
+    function buyTokens() public payable {
+        uint tokens = msg.value/weiPerEth*tokensPerEth; // convert wei to eth, then multiply by token rate
         balances[msg.sender] += tokens;
     }
 
@@ -35,26 +37,22 @@ contract VerifyFunWithNumbers is FunWithNumbers {
         
         if (address(this).balance > contract_balance_old && balances[msg.sender] <= sender_balance_old) {
             emit AssertionFailed("Invariant violation: Sender token balance must increase when contract account balance increases");
-            assert(false);
         }
         if (balances[msg.sender] > sender_balance_old && contract_balance_old >= address(this).balance) {
             emit AssertionFailed("Invariant violation: Contract account balance must increase when sender token balance increases");
-            assert(false);
         }
         if (address(this).balance < contract_balance_old && balances[msg.sender] >= sender_balance_old) {
             emit AssertionFailed("Invariant violation: Sender token balance must decrease when contract account balance decreases");
-            assert(false);
         }
         if (balances[msg.sender] < sender_balance_old && address(this).balance >= contract_balance_old) {
             emit AssertionFailed("Invariant violation: Contract account balance must decrease when sender token balance decreases");
-            assert(false);
         }
-       
+        
         contract_balance_old = address(this).balance;
     }
 
-    function buyTokens(uint256 msg_value) public payable checkInvariants {
-        super.buyTokens(msg_value);
+    function buyTokens() public payable checkInvariants {
+        super.buyTokens();
     }
             
     function sellTokens(uint tokens) public checkInvariants {

--- a/examples/solidity/research/solcfuzz_funwithnumbers.yaml
+++ b/examples/solidity/research/solcfuzz_funwithnumbers.yaml
@@ -1,3 +1,4 @@
 testLimit: 1000
 coverage: true
 checkAsserts: true
+cryticArgs: ["--solc", "solc-0.5.7"]

--- a/examples/solidity/research/solcfuzz_funwithnumbers.yaml
+++ b/examples/solidity/research/solcfuzz_funwithnumbers.yaml
@@ -1,2 +1,3 @@
+testLimit: 1000
 coverage: true
 checkAsserts: true

--- a/src/test/Tests/Research.hs
+++ b/src/test/Tests/Research.hs
@@ -2,7 +2,7 @@ module Tests.Research (researchTests) where
 
 import Test.Tasty (TestTree, testGroup)
 
-import Common (testContract, solved)
+import Common (testContract, testContract', solved)
 
 researchTests :: TestTree
 researchTests = testGroup "Research-based Integration Testing"
@@ -12,4 +12,8 @@ researchTests = testGroup "Research-based Integration Testing"
       [ ("echidna_all_states failed", solved "echidna_all_states") ]
   , testContract "research/ilf_crowdsale.sol" (Just "research/ilf_crowdsale.yaml")
       [ ("echidna_assert failed", solved "ASSERTION withdraw") ]
+  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just "research/solcfuzz_funwithnumbers.yaml") True
+      [ ("echidna_assert failed", solved "ASSERTION sellTokens"),
+        ("echidna_assert failed", solved "ASSERTION buyTokens")
+      ]
   ]


### PR DESCRIPTION
This example is directly lifted from [a Sabre example](https://github.com/b-mueller/sabre#example-2-integer-precision-bug) and now Echidna can solve it in seconds!

```
Analyzing contract: examples/solidity/research/solcfuzz_funwithnumbers.sol:VerifyFunWithNumbers
assertion in sellTokens: failed!💥  
  Call sequence, shrinking (683/5000):
    buyTokens() Value: 0xe8a9c741ac5a278
    sellTokens(1)

assertion in buyTokens: failed!💥  
  Call sequence, shrinking (696/5000):
    buyTokens() Value: 0x1
```