### PR TITLE
Improves function filtering to be more precise

### DIFF
--- a/examples/solidity/basic/blacklist.yaml
+++ b/examples/solidity/basic/blacklist.yaml
@@ -1,1 +1,1 @@
-filterFunctions: ["set0"] 
+filterFunctions: ["Test.set0(int256)"] 

--- a/examples/solidity/basic/whitelist.yaml
+++ b/examples/solidity/basic/whitelist.yaml
@@ -1,2 +1,2 @@
 filterBlacklist: false
-filterFunctions: ["set0"] 
+filterFunctions: ["Test.set0(int256)"] 

--- a/examples/solidity/basic/whitelist_all.yaml
+++ b/examples/solidity/basic/whitelist_all.yaml
@@ -1,2 +1,2 @@
 filterBlacklist: false
-filterFunctions: ["set0", "set1"] 
+filterFunctions: ["Test.set0(int256)", "Test.set1(int256)"] 

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -92,6 +92,10 @@ signatureCall (t, vs) = (t, map abiValueType vs)
 encodeSig :: SolSignature -> Text
 encodeSig (n, ts) = n <> "(" <> T.intercalate "," (abiTypeSolidity <$> ts) <> ")"
 
+-- | Get the text signature of a solidity method (for later hashing)
+encodeSigWithName :: Text -> SolSignature -> Text
+encodeSigWithName cn (n, ts) = last (T.split (==':') cn) <> "." <> n <> "(" <> T.intercalate "," (abiTypeSolidity <$> ts) <> ")"
+
 -- | Get the signature of a solidity method
 hashSig :: Text -> FunctionHash
 hashSig = abiKeccak . TE.encodeUtf8

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -26,7 +26,7 @@ import System.IO                  (openFile, IOMode(..))
 import System.Exit                (ExitCode(..))
 import System.Directory           (findExecutable)
 
-import Echidna.ABI                (encodeSig, hashSig, fallback, commonTypeSizes, mkValidAbiInt, mkValidAbiUInt)
+import Echidna.ABI                (encodeSig, encodeSigWithName, hashSig, fallback, commonTypeSizes, mkValidAbiInt, mkValidAbiUInt)
 import Echidna.Exec               (execTx, initialVM)
 import Echidna.Events             (EventMap)
 import Echidna.RPC                (loadEthenoBatch)
@@ -165,14 +165,14 @@ linkLibraries [] = ""
 linkLibraries ls = "--libraries " ++
   iconcatMap (\i x -> concat [x, ":", show $ addrLibrary + toEnum i, ","]) ls
 
-filterMethods :: MonadThrow m => Filter -> NE.NonEmpty SolSignature -> m (NE.NonEmpty SolSignature)
-filterMethods f@(Whitelist [])  _ = throwM $ InvalidMethodFilters f
-filterMethods f@(Whitelist ic) ms = case NE.filter (\(m, _) -> m `elem` ic) ms of
-                                         [] -> throwM $ InvalidMethodFilters f
-                                         fs -> return $ NE.fromList fs
-filterMethods f@(Blacklist ig) ms = case NE.filter (\(m, _) -> m `notElem` ig) ms of
-                                         [] -> throwM $ InvalidMethodFilters f
-                                         fs -> return $ NE.fromList fs
+filterMethods :: Text -> Filter -> NE.NonEmpty SolSignature -> NE.NonEmpty SolSignature
+filterMethods _  f@(Whitelist [])  _ = error $ show $ InvalidMethodFilters f
+filterMethods cn f@(Whitelist ic) ms = case NE.filter (\s -> encodeSigWithName cn s `elem` ic) ms of
+                                         [] -> error $ show $ InvalidMethodFilters f
+                                         fs -> NE.fromList fs
+filterMethods cn f@(Blacklist ig) ms = case NE.filter (\s -> encodeSigWithName cn s `notElem` ig) ms of
+                                         [] -> error $ show $ InvalidMethodFilters f
+                                         fs -> NE.fromList fs
 
 abiOf :: Text -> SolcContract -> NE.NonEmpty SolSignature
 abiOf pref cc = fallback NE.:| filter (not . isPrefixOf pref . fst) (elems (cc ^. abiMap) <&> \m -> (m ^. methodName, m ^.. methodInputs . traverse . _2))
@@ -204,11 +204,12 @@ loadSpecified name cs = do
 
 
   -- Filter ABI according to the config options
-  fabiOfc <- filterMethods fs $ abiOf pref c
+  let fabiOfc = filterMethods (c ^. contractName) fs $ abiOf pref c
   -- Filter again for assertions checking if enabled
-  neFuns <- filterMethods fs (fallback NE.:| funs)
+  let neFuns = filterMethods (c ^. contractName) fs (fallback NE.:| funs)
+  
   -- Construct ABI mapping for World
-  let abiMapping = if ma then M.fromList $ cs <&> \cc -> (cc ^. runtimeCode . to stripBytecodeMetadata, abiOf pref cc)
+  let abiMapping = if ma then M.fromList $ cs <&> \cc -> (cc ^. runtimeCode . to stripBytecodeMetadata, filterMethods (cc ^. contractName) fs $ abiOf pref cc)
                          else M.singleton (c ^. runtimeCode . to stripBytecodeMetadata) fabiOfc
 
   -- Set up initial VM, either with chosen contract or Etheno initialization file


### PR DESCRIPTION
This PR fixes issue #569 as well makes filtering more precise using the full name of the contract and its ABI. So instead of filterting `set` from any contract and any number of parameters, this requires the user to specify `Contract.set(uint256)`.