### PR TITLE
Semver integration for improve testing with different solc versions

### DIFF
--- a/examples/solidity/basic/now.sol
+++ b/examples/solidity/basic/now.sol
@@ -3,7 +3,7 @@ contract C {
   uint time;
 
   function set() public {
-    time = now;
+    time = block.timestamp;
   }
 
   function guess(uint x) public {

--- a/examples/solidity/basic/time.sol
+++ b/examples/solidity/basic/time.sol
@@ -3,12 +3,12 @@ contract Time {
   uint marked;
 
   constructor() public {
-    start  = now;
-    marked = now;
+    start  = block.timestamp;
+    marked = block.timestamp;
   }
 
   function mark() public {
-    marked = now;
+    marked = block.timestamp;
   }
 
   function echidna_timepassed() public returns (bool) {
@@ -16,7 +16,7 @@ contract Time {
   }
 
   function echidna_moretimepassed() public returns (bool) {
-    return(now < start + 10 weeks );
+    return(block.timestamp < start + 10 weeks );
   }
 
 }

--- a/examples/solidity/research/ilf_crowdsale.yaml
+++ b/examples/solidity/research/ilf_crowdsale.yaml
@@ -1,4 +1,3 @@
 checkAsserts: true
 maxValue: 10000000000000000000000000
 coverage: true
-#cryticArgs: ["--solc", "solc-0.5.7"]

--- a/examples/solidity/research/ilf_crowdsale.yaml
+++ b/examples/solidity/research/ilf_crowdsale.yaml
@@ -1,4 +1,4 @@
 checkAsserts: true
 maxValue: 10000000000000000000000000
 coverage: true
-cryticArgs: ["--solc", "solc-0.5.7"]
+#cryticArgs: ["--solc", "solc-0.5.7"]

--- a/examples/solidity/research/solcfuzz_funwithnumbers.sol
+++ b/examples/solidity/research/solcfuzz_funwithnumbers.sol
@@ -1,7 +1,5 @@
 // Original example from https://github.com/b-mueller/sabre#example-2-integer-precision-bug
 
-pragma solidity ^0.5.0;
-
 contract FunWithNumbers {
     uint constant public tokensPerEth = 10;
     uint constant public weiPerEth = 1e18;

--- a/examples/solidity/research/solcfuzz_funwithnumbers.yaml
+++ b/examples/solidity/research/solcfuzz_funwithnumbers.yaml
@@ -1,4 +1,4 @@
 testLimit: 1000
 coverage: true
 checkAsserts: true
-cryticArgs: ["--solc", "solc-0.5.7"]
+#cryticArgs: ["--solc", "solc-0.5.7"]

--- a/examples/solidity/research/solcfuzz_funwithnumbers.yaml
+++ b/examples/solidity/research/solcfuzz_funwithnumbers.yaml
@@ -1,4 +1,3 @@
 testLimit: 1000
 coverage: true
 checkAsserts: true
-#cryticArgs: ["--solc", "solc-0.5.7"]

--- a/examples/solidity/research/solcfuzz_registrar.yaml
+++ b/examples/solidity/research/solcfuzz_registrar.yaml
@@ -1,2 +1,1 @@
 checkAsserts: true
-cryticArgs: ["--solc", "solc-0.4.25"]

--- a/package.yaml
+++ b/package.yaml
@@ -36,8 +36,10 @@ dependencies:
   - process
   - random
   - rosezipper
+  - semver
   - sbv
   - stm
+  - split
   - temporary
   - text
   - transformers

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -21,16 +21,15 @@ module Common
 
 import Prelude hiding (lookup)
 
-import Test.Tasty (TestTree, testGroup)
+import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCase, assertBool)
 
 import Control.Lens (view, set, (.~), (^.))
-import Control.Monad (when)
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.Random (getRandom)
 import Control.Monad.State.Strict (evalStateT)
 import Data.Function ((&))
-import Data.List (find, isInfixOf)
+import Data.List (find)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.List.Split (splitOn)
 import Data.Map (lookup, empty)
@@ -65,8 +64,8 @@ withSolcVersion (Just f) t = do
   sv <- readProcess "solc" ["--version"] ""
   let (_:sv':_) = splitOn "Version: " sv
   let (sv'':_) = splitOn "+" sv'
-  case (fromText $ pack sv'') of 
-    Right v' -> if (f v') then t else assertBool "skip" True  
+  case fromText $ pack sv'' of 
+    Right v' -> if f v' then t else assertBool "skip" True  
     Left e   -> error $ show e
 
 type Name = String

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -55,8 +55,8 @@ testConfig = defaultConfig & sConf . quiet .~ True
 type SolcVersion = Version
 type SolcVersionComp = Version -> Bool
 
-solcV :: Int -> Int -> Int -> SolcVersion
-solcV x y z = version x y z [] []
+solcV :: (Int, Int, Int) -> SolcVersion
+solcV (x,y,z) = version x y z [] []
 
 withSolcVersion :: Maybe SolcVersionComp -> IO () -> IO () 
 withSolcVersion Nothing t = t 

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -84,7 +84,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_library_call failed",            solved      "echidna_library_call") ]
   , testContract "basic/library.sol"      (Just "basic/library.yaml")
       [ ("echidna_valid_timestamp failed",         passed      "echidna_valid_timestamp") ]
-  , testContractV "basic/fallback.sol"   (Just (<= solcV 0 5 7)) Nothing 
+  , testContractV "basic/fallback.sol"   (Just (< solcV 0 6 0)) Nothing 
       [ ("echidna_fallback failed",                solved      "echidna_fallback") ]
   , testContract "basic/large.sol"        Nothing
       [ ("echidna_large failed",                   solved      "echidna_large") ]

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -3,7 +3,7 @@ module Tests.Integration (integrationTests) where
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, assertBool)
 
-import Common (runContract, testContract, testContract', checkConstructorConditions, testConfig, passed, solved, solvedLen, solvedWith, solvedWithout, coverageEmpty, testsEmpty, gasInRange, countCorpus)
+import Common (runContract, testContract, testContractV, solcV, testContract', checkConstructorConditions, testConfig, passed, solved, solvedLen, solvedWith, solvedWithout, coverageEmpty, testsEmpty, gasInRange, countCorpus)
 import Control.Lens (set)
 import Control.Monad (when)
 import Data.Functor ((<&>))
@@ -49,7 +49,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       ]
   , testContract "basic/nearbyMining.sol" (Just "coverage/test.yaml")
       [ ("echidna_findNearby passed", solved "echidna_findNearby") ]
-  , testContract' "basic/smallValues.sol" Nothing (Just "coverage/test.yaml") False
+  , testContract' "basic/smallValues.sol" Nothing Nothing (Just "coverage/test.yaml") False
       [ ("echidna_findSmall passed", solved "echidna_findSmall") ]
   , testContract "basic/multisender.sol" (Just "basic/multisender.yaml") $
       [ ("echidna_all_sender passed",                      solved             "echidna_all_sender")
@@ -71,7 +71,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_found_sender failed",            solved      "echidna_found_sender") ]
   , testContract "basic/rconstants.sol"   Nothing
       [ ("echidna_found failed",                   solved      "echidna_found") ]
-  , testContract' "basic/cons-create-2.sol" (Just "C") Nothing True
+  , testContract' "basic/cons-create-2.sol" (Just "C") Nothing Nothing True
       [ ("echidna_state failed",                   solved      "echidna_state") ]
 -- single.sol is really slow and kind of unstable. it also messes up travis.
 --  , testContract "coverage/single.sol"    (Just "coverage/test.yaml")
@@ -84,7 +84,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_library_call failed",            solved      "echidna_library_call") ]
   , testContract "basic/library.sol"      (Just "basic/library.yaml")
       [ ("echidna_valid_timestamp failed",         passed      "echidna_valid_timestamp") ]
-  , testContract "basic/fallback.sol"     Nothing
+  , testContractV "basic/fallback.sol"   (Just (<= solcV 0 5 7)) Nothing 
       [ ("echidna_fallback failed",                solved      "echidna_fallback") ]
   , testContract "basic/large.sol"        Nothing
       [ ("echidna_large failed",                   solved      "echidna_large") ]
@@ -126,7 +126,7 @@ integrationTests = testGroup "Solidity Integration Testing"
              c <- set (sConf . quiet) True <$> maybe (pure testConfig) (fmap _econfig . parseConfig) cfg
              res <- runContract fp (Just "Foo") c
              assertBool "echidna_test passed" $ solved "echidna_test" res
-  , testContract' "basic/multi-abi.sol" (Just "B") (Just "basic/multi-abi.yaml") True
+  , testContract' "basic/multi-abi.sol" (Just "B") Nothing (Just "basic/multi-abi.yaml") True
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "abiv2/Ballot.sol"       Nothing
       [ ("echidna_test passed",                    solved      "echidna_test") ]

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -84,7 +84,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_library_call failed",            solved      "echidna_library_call") ]
   , testContract "basic/library.sol"      (Just "basic/library.yaml")
       [ ("echidna_valid_timestamp failed",         passed      "echidna_valid_timestamp") ]
-  , testContractV "basic/fallback.sol"   (Just (< solcV 0 6 0)) Nothing 
+  , testContractV "basic/fallback.sol"   (Just (< solcV (0,6,0))) Nothing 
       [ ("echidna_fallback failed",                solved      "echidna_fallback") ]
   , testContract "basic/large.sol"        Nothing
       [ ("echidna_large failed",                   solved      "echidna_large") ]

--- a/src/test/Tests/Research.hs
+++ b/src/test/Tests/Research.hs
@@ -10,7 +10,7 @@ researchTests = testGroup "Research-based Integration Testing"
       [ ("echidna_assert failed",     solved "echidna_assert") ]
   , testContract "research/harvey_baz.sol" Nothing
       [ ("echidna_all_states failed", solved "echidna_all_states") ]
-  , testContractV "research/ilf_crowdsale.sol" (Just (< solcV 0 6 0)) (Just "research/ilf_crowdsale.yaml")
+  , testContractV "research/ilf_crowdsale.sol" (Just (\v -> v >= solcV 0 5 0 && v < solcV 0 6 0)) (Just "research/ilf_crowdsale.yaml")
       [ ("echidna_assert failed", solved "ASSERTION withdraw") ]
   , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just (< solcV 0 6 0)) (Just "research/solcfuzz_funwithnumbers.yaml") True
       [ ("echidna_assert failed", solved "ASSERTION sellTokens"),

--- a/src/test/Tests/Research.hs
+++ b/src/test/Tests/Research.hs
@@ -10,9 +10,9 @@ researchTests = testGroup "Research-based Integration Testing"
       [ ("echidna_assert failed",     solved "echidna_assert") ]
   , testContract "research/harvey_baz.sol" Nothing
       [ ("echidna_all_states failed", solved "echidna_all_states") ]
-  , testContractV "research/ilf_crowdsale.sol" (Just $ (< solcV 0 6 0)) (Just "research/ilf_crowdsale.yaml")
+  , testContractV "research/ilf_crowdsale.sol" (Just (< solcV 0 6 0)) (Just "research/ilf_crowdsale.yaml")
       [ ("echidna_assert failed", solved "ASSERTION withdraw") ]
-  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just $ (< solcV 0 6 0)) (Just "research/solcfuzz_funwithnumbers.yaml") True
+  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just (< solcV 0 6 0)) (Just "research/solcfuzz_funwithnumbers.yaml") True
       [ ("echidna_assert failed", solved "ASSERTION sellTokens"),
         ("echidna_assert failed", solved "ASSERTION buyTokens")
       ]

--- a/src/test/Tests/Research.hs
+++ b/src/test/Tests/Research.hs
@@ -2,7 +2,7 @@ module Tests.Research (researchTests) where
 
 import Test.Tasty (TestTree, testGroup)
 
-import Common (testContract, testContract', solved)
+import Common (testContract, testContractV, testContract', solcV, solved)
 
 researchTests :: TestTree
 researchTests = testGroup "Research-based Integration Testing"
@@ -10,9 +10,9 @@ researchTests = testGroup "Research-based Integration Testing"
       [ ("echidna_assert failed",     solved "echidna_assert") ]
   , testContract "research/harvey_baz.sol" Nothing
       [ ("echidna_all_states failed", solved "echidna_all_states") ]
-  , testContract "research/ilf_crowdsale.sol" (Just "research/ilf_crowdsale.yaml")
+  , testContractV "research/ilf_crowdsale.sol" (Just $ (< solcV 0 6 0)) (Just "research/ilf_crowdsale.yaml")
       [ ("echidna_assert failed", solved "ASSERTION withdraw") ]
-  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just "research/solcfuzz_funwithnumbers.yaml") True
+  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just $ (< solcV 0 6 0)) (Just "research/solcfuzz_funwithnumbers.yaml") True
       [ ("echidna_assert failed", solved "ASSERTION sellTokens"),
         ("echidna_assert failed", solved "ASSERTION buyTokens")
       ]

--- a/src/test/Tests/Research.hs
+++ b/src/test/Tests/Research.hs
@@ -10,9 +10,9 @@ researchTests = testGroup "Research-based Integration Testing"
       [ ("echidna_assert failed",     solved "echidna_assert") ]
   , testContract "research/harvey_baz.sol" Nothing
       [ ("echidna_all_states failed", solved "echidna_all_states") ]
-  , testContractV "research/ilf_crowdsale.sol" (Just (\v -> v >= solcV 0 5 0 && v < solcV 0 6 0)) (Just "research/ilf_crowdsale.yaml")
+  , testContractV "research/ilf_crowdsale.sol" (Just (\v -> v >= solcV (0,5,0) && v < solcV (0,6,0))) (Just "research/ilf_crowdsale.yaml")
       [ ("echidna_assert failed", solved "ASSERTION withdraw") ]
-  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just (< solcV 0 6 0)) (Just "research/solcfuzz_funwithnumbers.yaml") True
+  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just (< solcV (0,6,0))) (Just "research/solcfuzz_funwithnumbers.yaml") True
       [ ("echidna_assert failed", solved "ASSERTION sellTokens"),
         ("echidna_assert failed", solved "ASSERTION buyTokens")
       ]


### PR DESCRIPTION
This PR allows to specify which versions of solc can be used for each test (by default, all the versions are used). This is needed for #593 and #571. 