### PR TITLE
Refactor and improve etheno support to be more useful

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -65,7 +65,7 @@ prepareContract cfg fs c g = do
   -- load transactions from init sequence (if any)
   es' <- liftIO $ maybe (return []) loadEtheno it
   let constants' = enhanceConstants si ++ timeConstants ++ largeConstants ++ NE.toList ads ++ ads'
-  let txs = ctxs ++ maybe (return []) (return [extractFromEtheno es' sigs]) it
+  let txs = ctxs ++ maybe [] (const [extractFromEtheno es' sigs]) it
 
   -- start ui and run tests
   return (v, sc, cs, w, ts, Just $ mkGenDict df constants' [] g (returnTypes cs), txs)

--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -59,13 +59,13 @@ prepareContract cfg fs c g = do
   -- load tests
   (v, w, ts) <- prepareForTest p c si
   let ads' = AbiAddress <$> v ^. env . EVM.contracts . to keys
-    -- get signatures
+  -- get signatures
   let sigs = nub $ concatMap (NE.toList . snd) (toList $ w ^. highSignatureMap)
-  liftIO $ print sigs
+  
   -- load transactions from init sequence (if any)
   es' <- liftIO $ maybe (return []) loadEtheno it
   let constants' = enhanceConstants si ++ timeConstants ++ largeConstants ++ NE.toList ads ++ ads'
-  let txs = ctxs ++ [extractFromEtheno es' sigs]
+  let txs = ctxs ++ maybe (return []) (return [extractFromEtheno es' sigs]) it
 
   -- start ui and run tests
   return (v, sc, cs, w, ts, Just $ mkGenDict df constants' [] g (returnTypes cs), txs)

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -9,19 +8,18 @@ import Prelude hiding (Word)
 
 import Control.Exception (Exception)
 import Control.Lens
-import Control.Monad (foldM)
+import Control.Monad (foldM, void)
 import Control.Monad.Catch (MonadThrow, throwM)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader.Class (MonadReader(..))
 import Control.Monad.State.Strict (MonadState, runStateT, get, put)
 import Data.Aeson (FromJSON(..), (.:), withObject, eitherDecodeFileStrict)
-import Data.Binary.Get (runGetOrFail)
 import Data.ByteString.Char8 (ByteString)
 import Data.Has (Has(..))
 import Data.Text.Encoding (encodeUtf8)
 
 import EVM
-import EVM.ABI (AbiType(..), AbiValue(..), decodeAbiValue, getAbi, selector)
+import EVM.ABI (AbiType(..), AbiValue(..), decodeAbiValue, selector)
 import EVM.Concrete (w256)
 import EVM.Exec (exec)
 import EVM.Types (Addr, Buffer(..), W256)
@@ -29,7 +27,7 @@ import Text.Read (readMaybe)
 
 import qualified Control.Monad.Fail as M (MonadFail(..))
 import qualified Data.ByteString.Base16 as BS16 (decode)
-import qualified Data.Text as T (Text, drop, unpack)
+import qualified Data.Text as T (drop, unpack)
 import qualified Data.Vector as V (fromList, toList)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -40,7 +38,7 @@ import Echidna.Transaction
 import Echidna.Types.Signature (SolSignature)
 import Echidna.ABI (encodeSig)
 
-import Echidna.Types.Tx (TxCall(..), Tx(..), TxConf, makeSingleTx, basicTx, createTxWithValue, propGas, unlimitedGasPerBlock)
+import Echidna.Types.Tx (TxCall(..), Tx(..), TxConf, makeSingleTx, createTxWithValue, unlimitedGasPerBlock)
 
 -- | During initialization we can either call a function or create an account or contract
 data Etheno = AccountCreated Addr                                       -- ^ Registers an address with the echidna runtime
@@ -107,76 +105,48 @@ extractFromEtheno ess ss = case ess of
 
 matchSignatureAndCreateTx :: SolSignature -> Etheno -> [Tx]
 matchSignatureAndCreateTx ("", []) _ = [] -- Not sure if we should match this.
-matchSignatureAndCreateTx (s,ts) (FunctionCall a d _ _ bs v) = if BS.take 4 bs == selector (encodeSig (s,ts))
-                                                               then makeSingleTx a d v $ SolCall (s, fromTuple $ decodeAbiValue t (LBS.fromStrict $ BS.drop 4 bs)) 
-                                                               else []
+matchSignatureAndCreateTx (s,ts) (FunctionCall a d _ _ bs v) = 
+  if BS.take 4 bs == selector (encodeSig (s,ts))
+  then makeSingleTx a d v $ SolCall (s, fromTuple $ decodeAbiValue t (LBS.fromStrict $ BS.drop 4 bs)) 
+  else []
   where t = AbiTupleType (V.fromList ts)
         fromTuple (AbiTuple xs) = V.toList xs
         fromTuple _            = []
-
 matchSignatureAndCreateTx _ _                                = [] 
 
 -- | Main function: takes a filepath where the initialization sequence lives and returns
 -- | the initialized VM along with a list of Addr's to put in GenConf
 loadEthenoBatch :: (MonadThrow m, MonadIO m, Has TxConf y, MonadReader y m, M.MonadFail m)
-                => [T.Text] -> FilePath -> m VM
-loadEthenoBatch ts fp = do
+                => FilePath -> m VM
+loadEthenoBatch fp = do
   bs <- liftIO $ eitherDecodeFileStrict fp
 
   case bs of
        (Left e) -> throwM $ EthenoException e
        (Right (ethenoInit :: [Etheno])) -> do
          -- Execute contract creations and initial transactions,
-         let initVM = foldM (execEthenoTxs ts) Nothing ethenoInit
-
+         let initVM = foldM execEthenoTxs () ethenoInit
          (_, vm') <- runStateT initVM initialVM
          return vm'
-         --case addr of
-         --     Nothing -> throwM $ EthenoException "Could not find a contract with echidna tests"
-         --     Just a  -> execStateT (liftSH . loadContract $ a) vm'
 
 -- | Takes a list of Etheno transactions and loads them into the VM, returning the
 -- | address containing echidna tests
 execEthenoTxs :: (MonadState x m, Has VM x, MonadThrow m, Has TxConf y, MonadReader y m, M.MonadFail m)
-              => [T.Text] -> Maybe Addr -> Etheno -> m (Maybe Addr)
-execEthenoTxs ts addr et = do
+              => () -> Etheno -> m ()
+execEthenoTxs _ et = do
   setupEthenoTx et
   sb <- get
   res <- liftSH exec
-  g <- view (hasLens . propGas)
   case (res, et) of
-       (Reversion,   _)               -> put sb >> return addr
+       (_        , AccountCreated _)  -> return ()
+       (Reversion,   _)               -> void $ put sb
        (VMFailure x, _)               -> vmExcept x >> M.fail "impossible"
        (VMSuccess (ConcreteBuffer bc),
         ContractCreated _ ca _ _ _ _) -> do
           hasLens . env . contracts . at ca . _Just . contractcode .= InitCode ""
           liftSH (replaceCodeOfSelf (RuntimeCode bc) >> loadContract ca)
-          og <- get
-          -- See if current contract is the same as echidna test
-          case addr of
-               -- found the tests, so just return the contract
-               Just m  -> return $ Just m
-               -- try to see if this is the contract we wish to test
-               Nothing -> let txs = ts <&> \t -> basicTx t [] ca ca g (0, 0)
-                              -- every test was executed successfully
-                              go []     = return (Just ca)
-                              -- execute x and check if it returned something of the correct type
-                              go (x:xs) = setupTx x >> liftSH exec >>= \case
-                                -- executing the test function succeeded
-                                VMSuccess (ConcreteBuffer r) -> do
-                                  put og
-                                  case runGetOrFail (getAbi . AbiTupleType . V.fromList $ [AbiBoolType]) (r ^. lazy) ^? _Right . _3 of
-                                       -- correct type ==> check the rest of the tests
-                                       Just _  -> go xs
-                                       -- incorrect type ==> bad ABI, this is not the contract we wish to test
-                                       Nothing -> return Nothing
-                                -- some vm failure or reversion, not what we want
-                                -- TODO: this breaks any test that is supposed to revert, maybe add a check here?
-                                _           -> put og >> return Nothing in
-                            -- actually test everything
-                            go txs
-       _                              -> return addr
-
+          return ()
+       _                              -> return ()
 
 -- | For an etheno txn, set up VM to execute txn
 setupEthenoTx :: (MonadState x m, Has VM x) => Etheno -> m ()

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -10,7 +10,7 @@ module Echidna.Solidity where
 import Control.Lens
 import Control.Exception          (Exception)
 import Control.Arrow              (first)
-import Control.Monad              (liftM2, when, unless, void)
+import Control.Monad              (liftM2, when, unless)
 import Control.Monad.Catch        (MonadThrow(..))
 import Control.Monad.IO.Class     (MonadIO(..))
 import Control.Monad.Reader       (MonadReader)
@@ -220,7 +220,7 @@ loadSpecified name cs = do
   -- Set up initial VM, either with chosen contract or Etheno initialization file
   -- need to use snd to add to ABI dict
   blank' <- maybe (pure (initialVM & block . gaslimit .~ fromInteger unlimitedGasPerBlock & block . maxCodeSize .~ w256 (fromInteger mcs)))
-                  (loadEthenoBatch $ fst <$> tests)
+                  loadEthenoBatch
                   fp
   let blank = populateAddresses (NE.toList ads |> d) bala blank'
 
@@ -236,7 +236,7 @@ loadSpecified name cs = do
     Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check
     Nothing    -> do
       vm <- loadLibraries ls addrLibrary d blank
-      let transaction = unless (isJust fp) $ void . execTx $ createTxWithValue bc d ca (fromInteger unlimitedGasPerBlock) (w256 $ fromInteger balc) (0, 0)
+      let transaction = execTx $ createTxWithValue bc d ca (fromInteger unlimitedGasPerBlock) (w256 $ fromInteger balc) (0, 0)
       vm' <- execStateT transaction vm
       case currentContract vm' of
         Just _  -> return (vm', c ^. eventMap, neFuns, fst <$> tests, abiMapping)

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -162,7 +162,7 @@ loadLibraries :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x)
               => [SolcContract] -> Addr -> Addr -> VM -> m VM
 loadLibraries []     _  _ vm = return vm
 loadLibraries (l:ls) la d vm = loadLibraries ls (la + 1) d =<< loadRest
-  where loadRest = execStateT (execTx $ createTx (l ^. creationCode) d la (fromInteger unlimitedGasPerBlock)) vm
+  where loadRest = execStateT (execTx $ createTx (l ^. creationCode) d la (fromInteger unlimitedGasPerBlock) (0, 0)) vm
 
 -- | Generate a string to use as argument in solc to link libraries starting from addrLibrary
 linkLibraries :: [String] -> String
@@ -236,7 +236,7 @@ loadSpecified name cs = do
     Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check
     Nothing    -> do
       vm <- loadLibraries ls addrLibrary d blank
-      let transaction = unless (isJust fp) $ void . execTx $ createTxWithValue bc d ca (fromInteger unlimitedGasPerBlock) (w256 $ fromInteger balc)
+      let transaction = unless (isJust fp) $ void . execTx $ createTxWithValue bc d ca (fromInteger unlimitedGasPerBlock) (w256 $ fromInteger balc) (0, 0)
       vm' <- execStateT transaction vm
       case currentContract vm' of
         Just _  -> return (vm', c ^. eventMap, neFuns, fst <$> tests, abiMapping)

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -80,7 +80,7 @@ checkETest' em t = do
     Left (f, a) -> do
       g <- view (hasLens . propGas)
       sd <- hasSelfdestructed a
-      _  <- execTx $ basicTx f [] (s a) a g
+      _  <- execTx $ basicTx f [] (s a) a g (0, 0)
       b  <- gets $ p f . getter
       put vm -- restore EVM state
       pure $ not sd && b

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -59,7 +59,7 @@ $(deriveJSON defaultOptions ''Tx)
 
 basicTx :: Text         -- | Function name
         -> [AbiValue]   -- | Function args
-        -> Addr         -- | msg.sender
+        -> Addr         -- | Sender
         -> Addr         -- | Destination contract
         -> Word         -- | Gas limit
         -> (Word, Word) -- | Block increment
@@ -68,7 +68,7 @@ basicTx f a s d g = basicTxWithValue f a s d g 0
 
 basicTxWithValue :: Text         -- | Function name
                  -> [AbiValue]   -- | Function args
-                 -> Addr         -- | msg.sender
+                 -> Addr         -- | Sender
                  -> Addr         -- | Destination contract
                  -> Word         -- | Gas limit
                  -> Word         -- | Value
@@ -84,11 +84,11 @@ createTx :: ByteString   -- | Constructor bytecode
          -> Tx
 createTx bc s d g = createTxWithValue bc s d g 0
 
-createTxWithValue :: ByteString  -- | Constructor bytecode
-                  -> Addr        -- | Creator
-                  -> Addr        -- | Destination address
-                  -> Word        -- | Gas limit
-                  -> Word        -- | Value
+createTxWithValue :: ByteString   -- | Constructor bytecode
+                  -> Addr         -- | Creator
+                  -> Addr         -- | Destination address
+                  -> Word         -- | Gas limit
+                  -> Word         -- | Value
                   -> (Word, Word) -- | Block increment
                   -> Tx
 createTxWithValue bc s d g = Tx (SolCreate bc) s d g 0

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -9,9 +9,9 @@ import Data.Aeson.TH (deriveJSON, defaultOptions)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
 import EVM (VMResult(..), Error(..))
+import EVM.Concrete (Word, w256)
+import EVM.Types (Addr, W256)
 import EVM.ABI (AbiValue)
-import EVM.Concrete (Word)
-import EVM.Types (Addr)
 
 import Echidna.Orphans.JSON ()
 import Echidna.Types.Signature (SolCall)
@@ -57,27 +57,30 @@ data Tx = Tx { _call  :: TxCall       -- | Call
 makeLenses ''Tx
 $(deriveJSON defaultOptions ''Tx)
 
-basicTx :: Text       -- | Function name
-        -> [AbiValue] -- | Function args
-        -> Addr       -- | msg.sender
-        -> Addr       -- | Destination contract
-        -> Word       -- | Gas limit
+basicTx :: Text         -- | Function name
+        -> [AbiValue]   -- | Function args
+        -> Addr         -- | msg.sender
+        -> Addr         -- | Destination contract
+        -> Word         -- | Gas limit
+        -> (Word, Word) -- | Block increment
         -> Tx
 basicTx f a s d g = basicTxWithValue f a s d g 0
 
-basicTxWithValue :: Text       -- | Function name
-                 -> [AbiValue] -- | Function args
-                 -> Addr       -- | msg.sender
-                 -> Addr       -- | Destination contract
-                 -> Word       -- | Gas limit
-                 -> Word       -- | Value
+basicTxWithValue :: Text         -- | Function name
+                 -> [AbiValue]   -- | Function args
+                 -> Addr         -- | msg.sender
+                 -> Addr         -- | Destination contract
+                 -> Word         -- | Gas limit
+                 -> Word         -- | Value
+                 -> (Word, Word) -- | Block increment
                  -> Tx
-basicTxWithValue f a s d g v = Tx (SolCall (f, a)) s d g 0 v (0, 0)
+basicTxWithValue f a s d g = Tx (SolCall (f, a)) s d g 0
 
-createTx :: ByteString  -- | Constructor bytecode
-         -> Addr        -- | Creator
-         -> Addr        -- | Destination address
-         -> Word        -- | Gas limit
+createTx :: ByteString   -- | Constructor bytecode
+         -> Addr         -- | Creator
+         -> Addr         -- | Destination address
+         -> Word         -- | Gas limit
+         -> (Word, Word) -- | Block increment
          -> Tx
 createTx bc s d g = createTxWithValue bc s d g 0
 
@@ -86,8 +89,9 @@ createTxWithValue :: ByteString  -- | Constructor bytecode
                   -> Addr        -- | Destination address
                   -> Word        -- | Gas limit
                   -> Word        -- | Value
+                  -> (Word, Word) -- | Block increment
                   -> Tx
-createTxWithValue bc s d g v = Tx (SolCreate bc) s d g 0 v (0, 0)
+createTxWithValue bc s d g = Tx (SolCreate bc) s d g 0
 
 data TxResult = Success
               | ErrorBalanceTooLow 
@@ -150,3 +154,7 @@ getResult (VMFailure PrecompileFailure)         = ErrorPrecompileFailure
 getResult (VMFailure UnexpectedSymbolicArg)     = ErrorUnexpectedSymbolic
 getResult (VMFailure DeadPath)                  = ErrorDeadPath
 getResult (VMFailure (Choose _))                = ErrorChoose -- not entirely sure what this is
+
+makeSingleTx :: Addr -> Addr -> W256 -> TxCall -> [Tx]
+makeSingleTx a d v (SolCall c) = [Tx (SolCall c) a d (fromInteger maxGasPerBlock) 0 (w256 v) (0, 0)]
+makeSingleTx _ _ _ _           = error "invalid usage of makeSingleTx"


### PR DESCRIPTION
This PR changes the way that etheno is used to mirror the behavior of `dev-auto` (which will be deprecated soon). Changes introduced:

1. Etheno mode now supports block mining event.
2. Etheno mode no longer requires to have an initialization without reverts.
3. The contract with the properties is always deployed before starting the fuzzing campaign (so detection of the contract with properties is no longer necessary).
4. After the initialization is parse, the list of transactions is added to the corpus (minus the `CREATE`). 