### PR TITLE
Coverage filenames now will include the current time to avoid overwritting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Echidna should find a a call sequence that falisfies `echidna_sometimesfalse` an
 
 After finishing a campaign, Echidna can save a coverage maximizing **corpus** in a special directory specified with the `corpusDir` config option. This directory will contain two entries: (1) a directory named `coverage` with JSON files that can be replayed by Echidna and (2) a plain-text file named `covered.txt`, a copy of the source code with coverage annotations.
 
-If you run `examples/solidity/basic/flags.sol` example, Echidna will save a few files in `coverage` and a `covered.txt` file with the following lines:
+If you run `examples/solidity/basic/flags.sol` example, Echidna will save a few files serialized transactions in the `coverage` directory and a `covered.$(date +%s).txt` file with the following lines:
 
 ```
 *r  |  function set0(int val) public returns (bool){

--- a/lib/Echidna/Output/Source.hs
+++ b/lib/Echidna/Output/Source.hs
@@ -11,6 +11,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text, unlines, pack, unpack)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Text.IO (writeFile)
+import Data.Time.Clock.System (getSystemTime, systemSeconds)
 import Data.List (nub)
 
 import EVM.Solidity (SourceCache, SrcMap, SolcContract, sourceLines, sourceFiles, runtimeCode, runtimeSrcmap, creationSrcmap)
@@ -29,9 +30,9 @@ import Echidna.Types.Signature (getBytecodeMetadata)
 type FilePathText = Text
 
 saveCoverage :: Maybe FilePath -> SourceCache -> [SolcContract] -> CoverageMap -> IO ()
-saveCoverage (Just d) sc cs s = let fn = d ++ "/covered.txt"
+saveCoverage (Just d) sc cs s = let fn t = d ++ "/covered." ++ show t ++ ".txt"
                                     cc = ppCoveredCode sc cs s 
-                                in writeFile fn cc
+                                in getSystemTime >>= \t -> writeFile (fn $ systemSeconds t) cc
 saveCoverage Nothing  _  _  _ = pure ()
 
 

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ dependencies:
   - temporary
   - text
   - transformers
+  - time
   - unix
   - unliftio
   - unliftio-core


### PR DESCRIPTION
A small PR to keep old covered.txt files and to able to easily compare how it improved over time.