### PR TITLE
Reworked mutators and tests to be more efficient

### DIFF
--- a/examples/solidity/basic/gasuse.yaml
+++ b/examples/solidity/basic/gasuse.yaml
@@ -1,3 +1,3 @@
-testLimit: 1000
+testLimit: 5000
 testMaxGas: 4294967295
 estimateGas: true

--- a/examples/solidity/basic/now.sol
+++ b/examples/solidity/basic/now.sol
@@ -7,7 +7,7 @@ contract C {
   }
 
   function guess(uint x) public {
-    if (x <= time + 1 weeks && x >= time - 1 weeks ) 
+    if (x <= time + 4 weeks && x >= time - 4 weeks )
       state = true;
   }
 


### PR DESCRIPTION
By default, Echidna spent most of the time without re-using transactions from the corpus. This will fix that.