### PR TITLE
New CLI options: --corpus-dir and --check-asserts

### DIFF
--- a/.github/scripts/install-libff.sh
+++ b/.github/scripts/install-libff.sh
@@ -12,7 +12,7 @@ fi
 git clone https://github.com/scipr-lab/libff --recursive
 cd libff
 git submodule init && git submodule update
-git checkout v1.0.0
+git checkout v0.2.1
 
 ARGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DWITH_PROCPS=OFF"
 CXXFLAGS=""

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Main where
 
-import Control.Lens ((^.), (.~), (&))
+import Control.Lens hiding (argument)
 import Control.Monad (unless)
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.Random (getRandom)
-import Data.Text (pack, unpack)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text, unpack)
 import Data.Version (showVersion)
 import Options.Applicative
 import Paths_echidna (version)
@@ -24,10 +27,12 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as DS
 
 data Options = Options
-  { filePath         :: NE.NonEmpty FilePath
-  , selectedContract :: Maybe String
-  , configFilepath   :: Maybe FilePath
-  , outputFormat     :: Maybe OutputFormat
+  { cliFilePath         :: NE.NonEmpty FilePath
+  , cliSelectedContract :: Maybe Text
+  , cliConfigFilepath   :: Maybe FilePath
+  , cliOutputFormat     :: Maybe OutputFormat
+  , cliCorpusDir        :: Maybe FilePath
+  , cliCheckAsserts     :: Maybe Bool
   }
 
 options :: Parser Options
@@ -42,6 +47,11 @@ options = Options <$> (NE.fromList <$> some (argument str (metavar "FILES"
                   <*> optional (option auto $ long "format"
                         <> metavar "FORMAT"
                         <> help "Output format: json, text, none. Disables interactive UI")
+                  <*> optional (option str $ long "corpus-dir"
+                        <> metavar "PATH"
+                        <> help "Directory to store corpus and coverage data")
+                  <*> optional (switch $ long "check-asserts"
+                        <> help "Check asserts in the code")
 
 versionOption :: Parser (a -> a)
 versionOption = infoOption
@@ -55,15 +65,15 @@ optsParser = info (helper <*> versionOption <*> options) $ fullDesc
 
 main :: IO ()
 main = do
-  opts@(Options f c conf _) <- execParser optsParser
+  opts@Options{..} <- execParser optsParser
   g <- getRandom
-  EConfigWithUsage loadedCfg ks _ <- maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig conf
+  EConfigWithUsage loadedCfg ks _ <- maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig cliConfigFilepath
   let cfg = overrideConfig loadedCfg opts
   unless (cfg ^. sConf . quiet) $ mapM_ (hPutStrLn stderr . ("Warning: unused option: " ++) . unpack) ks
   let cd = cfg ^. cConf . corpusDir
 
   (sc, cs, cpg) <- flip runReaderT cfg $ do
-    (v, sc, cs, w, ts, d, txs) <- prepareContract cfg f (pack <$> c) g
+    (v, sc, cs, w, ts, d, txs) <- prepareContract cfg cliFilePath cliSelectedContract g
     -- start ui and run tests
     r <- ui v w ts d txs
     return (sc, cs, r)
@@ -72,12 +82,26 @@ main = do
   saveTxs cd (snd <$> DS.toList (cpg ^. corpus))
 
   -- save source coverage
-  saveCoverage cd sc cs (cpg ^. coverage) 
+  saveCoverage cd sc cs (cpg ^. coverage)
 
   if not . isSuccess $ cpg then exitWith $ ExitFailure 1 else exitSuccess
-  where overrideConfig cfg (Options _ _ _ fmt) =
-          case maybe (cfg ^. uConf . operationMode) NonInteractive fmt of
-               Interactive -> cfg
-               NonInteractive Text -> cfg & uConf . operationMode .~ NonInteractive Text
-               nonInteractive -> cfg & uConf . operationMode .~ nonInteractive
-                                     & sConf . quiet .~ True
+
+overrideConfig :: EConfig -> Options -> EConfig
+overrideConfig config Options{..} =
+  foldl (\a f -> f a) config [ overrideFormat
+                             , overrideCorpusDir
+                             , overrideCheckAsserts
+                             ]
+  where
+    overrideFormat cfg =
+      case maybe (cfg ^. uConf . operationMode) NonInteractive cliOutputFormat of
+        Interactive -> cfg
+        NonInteractive Text -> cfg & uConf . operationMode .~ NonInteractive Text
+        nonInteractive -> cfg & uConf . operationMode .~ nonInteractive
+                              & sConf . quiet .~ True
+
+    overrideCorpusDir cfg =
+      cfg & cConf . corpusDir %~ (cliCorpusDir <|>)
+
+    overrideCheckAsserts cfg =
+      cfg & sConf . checkAsserts %~ (`fromMaybe` cliCheckAsserts)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -43,7 +43,7 @@ options = Options <$> (NE.fromList <$> some (argument str (metavar "FILES"
                         <> help "Contract to analyze")
                   <*> optional (option str $ long "config"
                         <> metavar "CONFIG"
-                        <> help "Config file")
+                        <> help "Config file (CLI arguments override config options")
                   <*> optional (option auto $ long "format"
                         <> metavar "FORMAT"
                         <> help "Output format: json, text, none. Disables interactive UI")


### PR DESCRIPTION
New CLI options for matching config values. Output from `--help`:
```
Echidna

Usage: echidna-test [--version] FILES [--contract CONTRACT] [--config CONFIG]
                    [--format FORMAT] [--corpus-dir PATH] [--check-asserts]
  EVM property-based testing framework

Available options:
  -h,--help                Show this help text
  --version                Show version
  FILES                    Solidity files to analyze
  --contract CONTRACT      Contract to analyze
  --config CONFIG          Config file
  --format FORMAT          Output format: json, text, none. Disables interactive
                           UI
  --corpus-dir PATH        Directory to store corpus and coverage data
  --check-asserts          Check asserts in the code
```