### PR TITLE
Vyper fixes

### DIFF
--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -106,7 +106,7 @@ usingCoverage cov = maybe (cov >> liftSH exec1 >> usingCoverage cov) pure =<< us
 pointCoverage :: (MonadState x m, Has VM x) => Lens' x CoverageMap -> m ()
 pointCoverage l = do
   v <- use hasLens
-  l %= M.insertWith (const . S.insert $ (v ^. state . pc, fromMaybe (error "no opIx") $ vmOpIx v, Success))
+  l %= M.insertWith (const . S.insert $ (v ^. state . pc, fromMaybe 0 $ vmOpIx v, Success))
                     (fromMaybe (error "no contract information on coverage") $ h v)
                     mempty
   where

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -11,7 +11,7 @@ import Control.Lens
 import Control.Monad.Catch (Exception, MonadThrow(..))
 import Control.Monad.State.Strict (MonadState, execState)
 import Data.Has (Has(..))
-import Data.Maybe (fromMaybe, fromJust)
+import Data.Maybe (fromMaybe)
 import EVM
 import EVM.Op (Op(..))
 import EVM.Exec (exec, vmForEthrunCreation)
@@ -106,7 +106,7 @@ usingCoverage cov = maybe (cov >> liftSH exec1 >> usingCoverage cov) pure =<< us
 pointCoverage :: (MonadState x m, Has VM x) => Lens' x CoverageMap -> m ()
 pointCoverage l = do
   v <- use hasLens
-  l %= M.insertWith (const . S.insert $ (v ^. state . pc, fromJust $ vmOpIx v, Success))
+  l %= M.insertWith (const . S.insert $ (v ^. state . pc, fromMaybe (error "no opIx") $ vmOpIx v, Success))
                     (fromMaybe (error "no contract information on coverage") $ h v)
                     mempty
   where

--- a/lib/Echidna/Types/Signature.hs
+++ b/lib/Echidna/Types/Signature.hs
@@ -36,7 +36,7 @@ getBytecodeMetadata :: ByteString -> ByteString
 getBytecodeMetadata bs =
   let stripCandidates = flip BS.breakSubstring bs <$> knownBzzrPrefixes in
     case find ((/= mempty) . snd) stripCandidates of
-      Nothing -> mempty
+      Nothing     -> bs -- if no metadata is found, return the complete bytecode
       Just (_, m) -> m
 
 knownBzzrPrefixes :: [ByteString]


### PR DESCRIPTION
Vyper support is not working right now in Slither, so this workaround allows to run individual vyper contracts in Echidna. The effectiveness will be reduced, since there is no source code information to enhance the exploration, but at least it runs.