### PR TITLE
Support for loading multiple files with compiled contracts from hardhat/brownie

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -49,7 +49,9 @@ prepareContract cfg fs c g = do
   ctxs <- liftIO $ loadTxs cd
 
   -- compile and load contracts
-  (cs, sc) <- Echidna.Solidity.contracts fs
+  (cs, scs) <- Echidna.Solidity.contracts fs
+  let sc = selectSourceCache c scs
+
   ads <- addresses
   p <- loadSpecified c cs
 

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -114,7 +114,7 @@ readSolcs d = do
   fs <- listDirectory d
   mxs <- mapM (\ f -> readSolc (d ++ "/" ++ f)) fs
   case catMaybes mxs of
-    [] -> error "everythin failed"
+    [] -> return Nothing
     xs -> return $ Just ( unions $ map fst xs, snd $ head xs )
 
 -- | Given a list of files, use its extenstion to check if it is a precompiled

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -18,7 +18,7 @@ import Control.Monad.State.Strict (execStateT)
 import Data.Foldable              (toList)
 import Data.Has                   (Has(..))
 import Data.List                  (find, partition)
-import Data.Map                   (Map, elems, unions)
+import Data.Map                   (Map, keys, elems, unions)
 import Data.Maybe                 (isJust, isNothing, catMaybes)
 import Data.Text                  (Text, isPrefixOf, isSuffixOf, append)
 import Data.Text.Lens             (unpacked)
@@ -108,18 +108,36 @@ data SolConf = SolConf { _contractAddr    :: Addr             -- ^ Contract addr
                        }
 makeLenses ''SolConf
 
-readSolcBatch :: FilePath -> IO (Maybe (Map Text SolcContract, SourceCache))
+-- | List of contract names from every source cache
+type SourceCaches = [([ContractName], SourceCache)]
+
+-- | Given a list of source caches (SourceCaches) and an optional contract name, 
+-- select one that includes that contract (if possible). Otherwise, use the first source
+-- cache available (or fail if it is empty)
+selectSourceCache :: Maybe ContractName -> SourceCaches -> SourceCache
+selectSourceCache (Just c) scs =
+  let r = concatMap (\(cs,sc) -> [sc | isJust $ find (isSuffixOf (":" `append` c)) cs]) scs in
+  case r of
+    (sc:_) -> sc
+    _      -> error "Source cache selection returned no result"
+
+selectSourceCache _ scs =
+  case scs of 
+    (_,sc):_ -> sc
+    _        -> error "Empty source cache"
+
+readSolcBatch :: FilePath -> IO (Maybe (Map Text SolcContract, SourceCaches))
 readSolcBatch d = do
   fs <- listDirectory d
   mxs <- mapM (\f -> readSolc (d ++ "/" ++ f)) fs
   case catMaybes mxs of
     [] -> return Nothing
-    xs -> return $ Just (unions $ map fst xs, snd $ head xs)
+    xs -> return $ Just (unions $ map fst xs, map (first keys) xs)
 
 -- | Given a list of files, use its extenstion to check if it is a precompiled
--- contract or try to compile it and get a list of its contracts, throwing
+-- contract or try to compile it and get a list of its contracts and a list of source cache, throwing
 -- exceptions if necessary.
-contracts :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x) => NE.NonEmpty FilePath -> m ([SolcContract], SourceCache)
+contracts :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x) => NE.NonEmpty FilePath -> m ([SolcContract], SourceCaches)
 contracts fp = let usual = ["--solc-disable-warnings", "--export-format", "solc"] in do
   mp  <- liftIO $ findExecutable "crytic-compile"
   case mp of
@@ -132,7 +150,7 @@ contracts fp = let usual = ["--solc-disable-warnings", "--export-format", "solc"
     let solargs = a ++ linkLibraries ls & (usual ++) .
                   (\sa -> if null sa then [] else ["--solc-args", sa])
         fps = toList fp
-        compileOne :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x) => FilePath -> m ([SolcContract], SourceCache)
+        compileOne :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x) => FilePath -> m ([SolcContract], SourceCaches)
         compileOne x = do
           mSolc <- liftIO $ do
             stderr <- if q then UseHandle <$> openFile "/dev/null" WriteMode else pure Inherit
@@ -144,7 +162,7 @@ contracts fp = let usual = ["--solc-disable-warnings", "--export-format", "solc"
           maybe (throwM SolcReadFailure) (pure . first toList) mSolc
     cps <- mapM compileOne fps
     let (cs, ss) = unzip cps
-    when (length ss > 1) $ liftIO $ putStrLn "WARNING: more than one SourceCache was found after compile. Only the first one will be used."
+    when (length ss > 1) $ liftIO $ putStrLn "WARNING: more than one SourceCaches was found after compile. Only the first one will be used."
     pure (concat cs, head ss)
 
 addresses :: (MonadReader x m, Has SolConf x) => m (NE.NonEmpty AbiValue)


### PR DESCRIPTION
This require latest `dev` revision from crytic-compile and slither to work.