### PR TITLE
Fix source printing and update hevm to 0.47.0

### DIFF
--- a/lib/Echidna/Events.hs
+++ b/lib/Echidna/Events.hs
@@ -26,7 +26,7 @@ extractEvents :: EventMap -> VM -> Events
 extractEvents em vm =
   let forest = traceForest vm
       showTrace trace =
-        let ?context = DappContext { _contextInfo = emptyDapp, _contextEnv = vm ^?! EVM.env } in
+        let ?context = DappContext { _contextInfo = emptyDapp, _contextEnv = vm ^?! EVM.env . EVM.contracts } in
         case view traceData trace of
           EventTrace (Log _ bytes topics) ->
             case maybeLitWord =<< listToMaybe topics of

--- a/lib/Echidna/Output/Source.hs
+++ b/lib/Echidna/Output/Source.hs
@@ -1,26 +1,27 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 
 module Echidna.Output.Source where
 
 import Control.Lens
 import Data.Maybe (fromMaybe, mapMaybe)
-import Data.Text (Text, unlines, pack, unpack)
+import Data.Text (Text, pack, unpack)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Text.IO (writeFile)
 import Data.Time.Clock.System (getSystemTime, systemSeconds)
 import Data.List (nub)
+import Text.Printf (printf)
 
 import EVM.Solidity (SourceCache, SrcMap, SolcContract, sourceLines, sourceFiles, runtimeCode, runtimeSrcmap, creationSrcmap)
 import EVM.Debug (srcMapCodePos)
-import Prelude hiding (unlines, writeFile)
+import Prelude hiding (writeFile)
 
 import qualified Data.Vector as V
 
 import qualified Data.Map as M
 import qualified Data.Set as S
+import qualified Data.Text as T
 
 import Echidna.Types.Coverage (CoverageMap, CoverageInfo)
 import Echidna.Types.Tx (TxResult(..))
@@ -39,59 +40,26 @@ saveCoverage Nothing  _  _  _ = pure ()
 ppCoveredCode :: SourceCache -> [SolcContract] -> CoverageMap -> Text
 ppCoveredCode sc cs s | s == mempty = "Coverage map is empty"
                       | otherwise   =
-  let allLines = M.toList $ sc ^. sourceLines
+  let allFiles = zipWith (\(srcPath, _) srcLines -> (srcPath, V.map decodeUtf8 srcLines))
+                   (sc ^. sourceFiles)
+                   (sc ^. sourceLines)
   -- ^ Collect all the possible lines from all the files
-      findFile k = fst $ M.findWithDefault ("<no source code>", mempty) k (sc ^. sourceFiles)
-  -- ^ Auxiliary function to get the path for each source file
-      covLines = concatMap (srcMapCov sc s) cs
+      covLines = srcMapCov sc s cs
   -- ^ List of covered lines during the fuzzing campaing
-  in unlines $ map snd $ concatMap (\(f,vls) ->
-    (mempty, findFile f) :                                                   -- Add a header for each source file to show its complete path
-      filterLines covLines (map ((findFile f,) . decodeUtf8) $ V.toList vls) -- Show the source code for each file with its covered line.
-                                   ) allLines
-
--- | Filter the lines per file, marking each line
-filterLines :: [Maybe (FilePathText, Int, TxResult)] -> [(FilePathText, Text)] -> [(FilePathText, Text)]
-filterLines []                  ls  = ls
-filterLines (Nothing      : ns) ls  = filterLines ns ls
-filterLines (Just (f,n,r) : ns) ls  = filterLines ns (markLine n r f ls)
+      ppFile (srcPath, srcLines) =
+        let marked = markLines srcLines (fromMaybe M.empty (M.lookup srcPath covLines))
+        in T.unlines (srcPath : V.toList marked)
+  in T.intercalate "\n" $ map ppFile allFiles
 
 -- | Mark one particular line, from a list of lines, keeping the order of them
-markLine :: Int -> TxResult -> FilePathText -> [(FilePathText, Text)] -> [(FilePathText, Text)]
-markLine n r cf ls = case splitAt (n-1) ls of
-  (xs, (f,y):ys) | f == cf -> xs ++ [(cf, pack $ markStringLine r $ unpack y)] ++ ys
-  _                        -> map (\(f,y) -> (f, pack $ checkMarkers $ unpack y)) ls
-
--- | Header preppend to each line
-markerHeader :: String
-markerHeader = "    |"
-
--- | Add space for markers if necessary
-checkMarkers  :: String -> String
-checkMarkers l@(_:_:_:_:'|':_) = l
-checkMarkers l                 = markerHeader ++ l
-
--- | Add a proper marker to a line, and convert it to Text
-markStringLine  :: TxResult -> String -> String
-markStringLine r (' ': ' ': ' ': ' ': '|': l) = getMarker r : ' ' : ' ' : ' ': '|' : l
-markStringLine r (m1 : ' ': ' ': ' ': '|': l) = case getMarker r of
-  m | m1 == m -> m1 : ' ' : ' ' : ' ': '|' : l
-  m           -> m1 :  m  : ' ' : ' ': '|' : l
-
-markStringLine r (m1 : m2 : ' ': ' ': '|': l) = case getMarker r of
-  m | m1 == m -> m1 :  m2  : ' ' : ' ': '|' : l
-  m | m2 == m -> m1 :  m2  : ' ' : ' ': '|' : l
-  m           -> m1 :  m2  : m   : ' ': '|' : l
-
-
-markStringLine r (m1 : m2 : m3 : ' ': '|': l) = case getMarker r of
-  m | m1 == m -> m1 :  m2  : m3 : ' ': '|' : l
-  m | m2 == m -> m1 :  m2  : m3 : ' ': '|' : l
-  m | m3 == m -> m1 :  m2  : m3 : ' ': '|' : l
-  m           -> m1 :  m2  : m3 : m  : '|' : l
-
-markStringLine _ (_: _ : _ : _ : '|':_) = error "impossible to add another marker"
-markStringLine r l = getMarker r : ' ' : ' ' : ' ': '|' : l
+markLines :: V.Vector Text -> M.Map Int [TxResult] -> V.Vector Text
+markLines codeLines resultMap =
+  V.map markLine (V.indexed codeLines)
+  where
+    markLine :: (Int, Text) -> Text
+    markLine (i, codeLine) =
+      let results = fromMaybe [] (M.lookup (i+1) resultMap)
+      in pack $ printf "%-4s| %s" (getMarker <$> results) (unpack codeLine)
 
 -- | Select the proper marker, according to the result of the transaction
 getMarker :: TxResult -> Char
@@ -101,12 +69,19 @@ getMarker ErrorOutOfGas = 'o'
 getMarker _             = 'e'
 
 -- | Given a source cache, a coverage map, a contract returns a list of covered lines
-srcMapCov :: SourceCache -> CoverageMap -> SolcContract -> [Maybe (FilePathText, Int, TxResult)]
-srcMapCov sc s c = nub $                                               -- Deduplicate results
-                   map (srcMapCodePosResult sc) $                      -- Get the filename, number of line and tx result
-                   mapMaybe (srcMapForOpLocation c) $                  -- Get the mapped line and tx result
-                   S.toList $ fromMaybe S.empty $                      -- Convert from Set to list
-                   M.lookup (getBytecodeMetadata $ c ^. runtimeCode) s -- Get the coverage information of the current contract
+srcMapCov :: SourceCache -> CoverageMap -> [SolcContract] -> M.Map FilePathText (M.Map Int [TxResult])
+srcMapCov sc s contracts =
+  M.map (M.fromListWith (++)) $
+  M.fromListWith (++) $
+  map (\(srcPath, line, txResult) -> (srcPath, [(line, [txResult])])) $
+  nub $                                               -- Deduplicate results
+  mapMaybe (srcMapCodePosResult sc) $                 -- Get the filename, number of line and tx result
+  concatMap mapContract contracts
+  where
+    mapContract c =
+      mapMaybe (srcMapForOpLocation c) $                  -- Get the mapped line and tx result
+      S.toList $ fromMaybe S.empty $                      -- Convert from Set to list
+      M.lookup (getBytecodeMetadata $ c ^. runtimeCode) s -- Get the coverage information of the current contract
 
 -- | Given a source cache, a mapped line, return a tuple with the filename, number of line and tx result
 srcMapCodePosResult :: SourceCache -> (SrcMap, TxResult) -> Maybe (Text, Int, TxResult)

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -73,7 +73,7 @@ instance FromJSON Etheno where
          _ -> M.fail "event should be one of \"AccountCreated\", \"ContractCreated\", or \"FunctionCall\""
     where decode x = case BS16.decode . encodeUtf8 . T.drop 2 $ x of
                           Right a -> pure a
-                          Left e -> M.fail $ "could not decode hexstring: " <> e
+                          Left e  -> M.fail $ "could not decode hexstring: " <> e
 
 
 -- | Handler for parsing errors

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -26,7 +26,7 @@ import Text.Read (readMaybe)
 
 import qualified Control.Monad.Fail as M (MonadFail(..))
 import qualified Data.ByteString.Base16 as BS16 (decode)
-import qualified Data.Text as T (drop, unpack)
+import qualified Data.Text as T (drop)
 import qualified Data.Vector as V (fromList, toList)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -72,8 +72,8 @@ instance FromJSON Etheno where
 
          _ -> M.fail "event should be one of \"AccountCreated\", \"ContractCreated\", or \"FunctionCall\""
     where decode x = case BS16.decode . encodeUtf8 . T.drop 2 $ x of
-                          (a, "") -> pure a
-                          _       -> M.fail $ "could not decode hexstring: " <> T.unpack x
+                          Right a -> pure a
+                          Left e -> M.fail $ "could not decode hexstring: " <> e
 
 
 -- | Handler for parsing errors

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -115,6 +115,7 @@ data TxResult = Success
               | ErrorChoose -- not entirely sure what this is
               | ErrorWhiffNotUnique
               | ErrorSMTTimeout
+              | ErrorFFI
   deriving (Eq, Ord, Show)
 $(deriveJSON defaultOptions ''TxResult)
 
@@ -156,7 +157,8 @@ getResult (VMFailure UnexpectedSymbolicArg)     = ErrorUnexpectedSymbolic
 getResult (VMFailure DeadPath)                  = ErrorDeadPath
 getResult (VMFailure (Choose _))                = ErrorChoose -- not entirely sure what this is
 getResult (VMFailure (NotUnique _))             = ErrorWhiffNotUnique
-getResult (VMFailure SMTTimeout)              = ErrorSMTTimeout
+getResult (VMFailure SMTTimeout)                = ErrorSMTTimeout
+getResult (VMFailure (FFI _))                   = ErrorFFI
 
 makeSingleTx :: Addr -> Addr -> W256 -> TxCall -> [Tx]
 makeSingleTx a d v (SolCall c) = [Tx (SolCall c) a d (fromInteger maxGasPerBlock) 0 (w256 v) (0, 0)]

--- a/nix/crytic-compile.nix
+++ b/nix/crytic-compile.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pysha3, setuptools }:
+
+buildPythonPackage rec {
+  pname = "crytic-compile";
+  version = "0.2.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "crytic";
+    repo = "crytic-compile";
+    rev = version;
+    sha256 = "sha256-Kuc7g5+4TIcQTWYjG4uPN0Rxfom/A/xpek5K5ErlbdU=";
+  };
+
+  propagatedBuildInputs = [ pysha3 setuptools ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "crytic_compile" ];
+}

--- a/src/test/Tests/Seed.hs
+++ b/src/test/Tests/Seed.hs
@@ -15,7 +15,7 @@ import Echidna.Mutator.Corpus (defaultMutationConsts)
 seedTests :: TestTree
 seedTests =
   testGroup "Seed reproducibility testing"
-    [ testCase "different seeds" $ assertBool "results are the same" . not =<< same 0 1
+    [ testCase "different seeds" $ assertBool "results are the same" . not =<< same 0 2
     , testCase "same seeds" $ assertBool "results differ" =<< same 0 0
     ]
     where cfg s = defaultConfig & sConf . quiet .~ True

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,28 +1,24 @@
-resolver: lts-16.31
+resolver: lts-17.14
 
 packages:
 - '.'
 
 extra-deps:
 - git: https://github.com/dapphub/dapptools.git
-  commit: 6314bc8e168fce17290a73700a1246f549e2e052
+  commit: 4fe19a0ff493f09de58c13c54cb69d962dd10b82
   subdirs:
   - src/hevm
 
-- cryptonite-0.27
-- ghci-pretty-0.0.2
-- HSH-2.1.3
-- monoidal-containers-0.6.0.1
-- restless-git-0.7
-- s-cargot-0.1.4.0
-- text-format-0.3.2
-- these-1.0.1
-- tree-view-0.5
-- sbv-8.9
-- witherable-0.3.5
-- witherable-class-0
-- github: dmjio/semver-range
-  commit: d8d9db892ddb6ae267c9bcbc4f6602668433f12a
+- base16-bytestring-1.0.1.0@sha256:33b9d57afa334d06485033e930c6b13fc760baf88fd8f715ae2f9a4b46e19a54,2641
+- restless-git-0.7@sha256:346a5775a586f07ecb291036a8d3016c3484ccdc188b574bcdec0a82c12db293,968
+- s-cargot-0.1.4.0@sha256:61ea1833fbb4c80d93577144870e449d2007d311c34d74252850bb48aa8c31fb,3525
+- sbv-8.15@sha256:bc0ea4e3564626030ac2cb21905b97cd9bd25fddcd6d6010834e8cc2ebf79067,29016
+- semver-range-0.2.8@sha256:44918080c220cf67b6e7c8ad16f01f3cfe1ac69d4f72e528e84d566348bb23c3,1941
+- tree-view-0.5.1@sha256:a32b16fdbe24ad21cb6679c2a925bcc7715ae5c5db0ae6b633e35e28e2fefd98,1184
+- witherable-0.4.1@sha256:5b4840efe20d16cab6b13fa2f39ed383703cccbc246f5b710591069fcc6884c0,2249
+- HSH-2.1.3@sha256:71ded11b224f5066373ce985ec63b10c87129850b33916736dd64fa2bea9ea0a,1705
+- indexed-traversable-instances-0.1@sha256:3aaf97040001bbe583e29c2b9c7d41660df265e6565a0d2ac09a3ed5b8bc21be,2874
+- libBF-0.6.2@sha256:7bffc0e4dbc9bd9e851ba5c29255b62fd2c288dbc9a401cd3761b740f013775e,1770
 
 extra-include-dirs:
 - /usr/local/opt/readline/include


### PR DESCRIPTION
Fix to the source printing. the code is also shortened and simplified to handle the coming HTML coverage output.

Before:
```
/Users/artur/projects/echidna/examples/solidity/basic/constants.sol
*r  |contract Constants {
  bool found = false;
  bool found_large = false;

*   |  function find(int i) public {
*   |    if (i == 1447) { found = true; }
*   |    if (i == 133700000000) { found = false; }
*   |    if (i == 11234567890123456789012345678901234560) { found_large = true; }
  }

  function echidna_found() public view returns (bool) {
    return(!found);
  }

  function echidna_found_large() public view returns (bool) {
    return(!found_large);
  }

}

```

After:
```
/Users/artur/projects/echidna/examples/solidity/basic/constants.sol
*r  | contract Constants {
    |   bool found = false;
    |   bool found_large = false;
    |
*   |   function find(int i) public {
*   |     if (i == 1447) { found = true; }
*   |     if (i == 133700000000) { found = false; }
*   |     if (i == 11234567890123456789012345678901234560) { found_large = true; }
    |   }
    |
    |   function echidna_found() public view returns (bool) {
    |     return(!found);
    |   }
    |
    |   function echidna_found_large() public view returns (bool) {
    |     return(!found_large);
    |   }
    |
    | }
    |
```

Additionally, hevm is updated to the latest 0.47.0 along with stack to lts-17.14. The file `nix/crytic-compile.nix` will be removed once slither is fixed in nixpkgs.