### PR TITLE
A small refactoring of execTxWith, contTxWith and getExecResult

### DIFF
--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -72,79 +72,76 @@ instance Exception ExecException
 vmExcept :: MonadThrow m => Error -> m ()
 vmExcept e = throwM $ case VMFailure e of {Illegal -> IllegalExec e; _ -> UnknownFailure e}
 
--- | Given an error handler, an execution function, and a transaction, execute that transaction
--- using the given execution strategy, handling errors with the given handler.
+-- | Given an error handler `onErr`, an execution function `executeTx`, and a transaction `tx`, 
+-- execute that transaction using the given execution strategy, calling `onErr` on errors.
 execTxWith :: (MonadState x m, Has VM x) => (Error -> m ()) -> m VMResult -> Tx -> m (VMResult, Int)
-execTxWith h m t = do
-  sd <- hasSelfdestructed (t ^. dst)
-  if sd then pure (VMFailure (Revert ""), 0)
+execTxWith onErr executeTx tx' = do
+  isSelfDestruct <- hasSelfdestructed (tx' ^. dst)
+  if isSelfDestruct then pure (VMFailure (Revert ""), 0)
   else do
     hasLens . traces .= emptyEvents
-    og <- use hasLens
-    setupTx t
-    gasIn <- use $ hasLens . state . gas
-    res <- m
-    gasOut <- use $ hasLens . state . gas
-    cd <- use $ hasLens . state . calldata
-    case getQuery res of
+    vmBeforeTx <- use hasLens
+    setupTx tx'
+    gasLeftBeforeTx <- use $ hasLens . state . gas
+    vmResult' <- executeTx
+    gasLeftAfterTx <- use $ hasLens . state . gas
+        -- Continue transaction whose execution queried a contract or slot
+    let continueAfterQuery = do
+          -- Run remaining effects
+          vmResult'' <- executeTx
+          -- Correct gas usage
+          gasLeftAfterTx' <- use $ hasLens . state . gas
+          handleErrorsAndConstruction onErr vmResult'' vmBeforeTx tx'
+          return (vmResult'', fromIntegral $ gasLeftBeforeTx - gasLeftAfterTx')
+    case getQuery vmResult' of
       -- A previously unknown contract is required
-      Just (PleaseFetchContract _ _ cont) -> do
+      Just (PleaseFetchContract _ _ continuation) -> do
         -- Use the empty contract
-        hasLens %= execState (cont emptyAccount)
-        contTxWith h m og cd gasIn t
+        hasLens %= execState (continuation emptyAccount)
+        continueAfterQuery
 
       -- A previously unknown slot is required
-      Just (PleaseFetchSlot _ _ cont) -> do
+      Just (PleaseFetchSlot _ _ continuation) -> do
         -- Use the zero slot
-        hasLens %= execState (cont 0)
-        contTxWith h m og cd gasIn t
+        hasLens %= execState (continuation 0)
+        continueAfterQuery
 
       -- No queries to answer
-      _ -> getExecResult h res og cd (fromIntegral $ gasIn - gasOut) t
+      _ -> do
+        handleErrorsAndConstruction onErr vmResult' vmBeforeTx tx'
+        return (vmResult', fromIntegral $ gasLeftBeforeTx - gasLeftAfterTx)
 
-contTxWith :: (MonadState x m, Has VM x)
-           => (Error -> m ())
-           -> m VMResult
-           -> VM
-           -> (Buffer, SymWord)
-           -> EVM.Types.Word
-           -> Tx
-           -> m (VMResult, Int)
-contTxWith h m og cd gasIn t = do
-  -- Run remaining effects
-  res <- m
-  -- Correct gas usage
-  gasOut <- use $ hasLens . state . gas
-  getExecResult h res og cd (fromIntegral $ gasIn - gasOut) t
-
-getExecResult :: (MonadState x m, Has VM x)
-              => (Error -> m ())
-              -> VMResult
-              -> VM
-              -> (Buffer, SymWord)
-              -> Int
-              -> Tx
-              -> m (VMResult, Int)
-getExecResult errHandler res vmBeforeTx cdata gasUsed t = do
-    case (res, t ^. call) of
-      (f@Reversion, _) -> do
+-- | Handles reverts, failures and contract creations that might be the result
+-- (`vmResult`) of executing transaction `tx`.
+handleErrorsAndConstruction :: (MonadState s m, Has VM s)
+                            => (Error -> m ())
+                            -> VMResult
+                            -> VM
+                            -> Tx
+                            -> m ()
+handleErrorsAndConstruction onErr vmResult' vmBeforeTx tx' = do
+    case (vmResult', tx' ^. call) of
+      (Reversion, _) -> do
         tracesBeforeVMReset <- use $ hasLens . traces
         codeContractBeforeVMReset <- use $ hasLens . state . codeContract
-        -- Reset VM to state before the transaction
+        calldataBeforeReset <- use $ hasLens . state . calldata
+        -- If a transaction reverts reset VM to state before the transaction.
         hasLens .= vmBeforeTx
-        -- Undo reset of some of the VM state
-        hasLens . state . calldata .= cdata
-        hasLens . result ?= f
+        -- Undo reset of some of the VM state.
+        -- Otherwise we'd loose all information about the reverted transaction like
+        -- contract address, calldata, result and traces.
+        hasLens . result ?= vmResult'
+        hasLens . state . calldata .= calldataBeforeReset
         hasLens . traces .= tracesBeforeVMReset
         hasLens . state . codeContract .= codeContractBeforeVMReset
-      (VMFailure x, _) -> errHandler x
-      (VMSuccess (ConcreteBuffer bc), SolCreate _) ->
+      (VMFailure x, _) -> onErr x
+      (VMSuccess (ConcreteBuffer bytecode'), SolCreate _) ->
+        -- Handle contract creation.
         hasLens %= execState (do
-          env . contracts . at (t ^. dst) . _Just . contractcode .= InitCode (ConcreteBuffer "")
-          replaceCodeOfSelf (RuntimeCode (ConcreteBuffer bc))
-          loadContract (t ^. dst))
+          env . contracts . at (tx' ^. dst) . _Just . contractcode .= InitCode (ConcreteBuffer "")
+          replaceCodeOfSelf (RuntimeCode (ConcreteBuffer bytecode'))
+          loadContract (tx' ^. dst))
       _ -> pure ()
-    pure (res, fromIntegral gasUsed)
 
 -- | Execute a transaction "as normal".
 execTx :: (MonadState x m, Has VM x, MonadThrow m) => Tx -> m (VMResult, Int)

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -72,7 +72,7 @@ instance Exception ExecException
 vmExcept :: MonadThrow m => Error -> m ()
 vmExcept e = throwM $ case VMFailure e of {Illegal -> IllegalExec e; _ -> UnknownFailure e}
 
--- | Given an error handler `onErr`, an execution function `executeTx`, and a transaction `tx`, 
+-- | Given an error handler `onErr`, an execution strategy `executeTx`, and a transaction `tx`,
 -- execute that transaction using the given execution strategy, calling `onErr` on errors.
 execTxWith :: (MonadState x m, Has VM x) => (Error -> m ()) -> m VMResult -> Tx -> m (VMResult, Int)
 execTxWith onErr executeTx tx' = do

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -290,15 +290,15 @@ prepareForTest :: (MonadReader x m, Has SolConf x)
                -> Maybe ContractName
                -> SlitherInfo
                -> m (VM, World, [EchidnaTest])
-prepareForTest (v, em, a, ts, m) c si = do
+prepareForTest (vm, em, a, ts, m) c si = do
   SolConf{ _sender = s, _testMode = tm } <- view hasLens
-  let r = v ^. state . contract
+  let r = vm ^. state . contract
       a' = NE.toList a
       ps = filterResults c $ payableFunctions si
       as = if isAssertionMode tm then filterResults c $ asserts si else []
       cs = filterResults c $ constantFunctions si
       (hm, lm) = prepareHashMaps cs as m
-  pure (v, World s hm lm ps em, createTests tm ts r a') 
+  pure (vm, World s hm lm ps em, createTests tm ts r a')
 
 -- this limited variant is used only in tests
 prepareForTest' :: (MonadReader x m, Has SolConf x)


### PR DESCRIPTION
Tests pass for me locally.

Major changes:

`getExecResult` was mostly concerned with resetting the VM after failures and handling newly deployed contracts.
For that reason, its name was a bit misleading.
It also passed `gas` from input to output without using it.
I extracted a more focused function `handleErrorsAndConstruction`.

Made `contTxWith` a local function of `execTxWith` where it could use the local context simplifying it.

Expanded some variable names to be more self-explanatory.
