### PR TITLE
GH Actions: Bump cachix/install-nix-action to v16

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build


### PR DESCRIPTION
The `cachix/install-nix-action@v12` action currently in use for the Nix workflows fails to install Nix on the GitHub runners. This PR upgrades the action to the latest version, `v16`, which does not exhibit this issue.