### PR TITLE
Memoize getBytecodeMetadata

### DIFF
--- a/lib/Echidna/Types/Signature.hs
+++ b/lib/Echidna/Types/Signature.hs
@@ -9,6 +9,7 @@ import EVM.ABI (AbiType, AbiValue)
 import EVM.Types (Addr)
 import GHC.Word (Word32)
 
+import qualified Data.Map as M
 import qualified Data.ByteString as BS
 
 -- | Name of the contract
@@ -30,6 +31,8 @@ type SolCall     = (FunctionName, [AbiValue])
 -- | A contract is just an address with an ABI (for our purposes).
 type ContractA = (Addr, NonEmpty SolSignature)
 
+type ByteStringMap = M.Map ByteString ByteString
+
 type SignatureMap = HashMap ByteString (NonEmpty SolSignature)
 
 getBytecodeMetadata :: ByteString -> ByteString
@@ -38,6 +41,12 @@ getBytecodeMetadata bs =
     case find ((/= mempty) . snd) stripCandidates of
       Nothing     -> bs -- if no metadata is found, return the complete bytecode
       Just (_, m) -> m
+
+lookupBytecodeMetadata :: ByteStringMap -> ByteString -> Maybe ByteString
+lookupBytecodeMetadata = (M.!?)
+
+makeBytecodeMemo :: [ByteString] -> ByteStringMap
+makeBytecodeMemo bss = M.fromList $ bss `zip` (getBytecodeMetadata <$> bss)
 
 knownBzzrPrefixes :: [ByteString]
 knownBzzrPrefixes = [


### PR DESCRIPTION
This pull request makes `pointCoverage` (in `Exec.hs`) memoize its calculation of `getBytecodeMetadata`, instead of recalculating it every time. This results in some fairly significant speedups:
- [This](https://github.com/opynfinance/ConvexityProtocol/blob/dev/contracts/echidna/EchidnaOptionsContract.sol) contract ran 6.7x faster on my computer, producing the same output as before.
- [This](https://github.com/makerdao/dss-vest/blob/master/echidna/ChainLog.sol) contract ran 3.8x faster on my computer, producing the same output as before.

Note that memory usage is slightly increased; in these test cases, memory usage went up by 12% and 15% respectively.
Also note that these speedups only happen when coverage is turned on; the coverage-off speed shouldn't be affected.