### PR TITLE
Memoize getBytecodeMetadata; incorporate usingCoverage2

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -44,7 +44,7 @@ import Echidna.Transaction
 import Echidna.Types.Buffer (viewBuffer)
 import Echidna.Types.Campaign
 import Echidna.Types.Coverage (coveragePoints)
-import Echidna.Types.Signature (ByteStringMap, makeBytecodeMemo)
+import Echidna.Types.Signature (makeBytecodeMemo)
 import Echidna.Types.Test (TestState(..), SolTest)
 import Echidna.Types.Tx (TxCall(..), Tx(..), TxConf, getResult, src, call, _SolCall)
 import Echidna.Types.World (World, eventMap)
@@ -158,11 +158,12 @@ updateGasInfo ((t, _):ts) tseq gi = updateGasInfo ts (t:tseq) gi
 
 -- | Execute a transaction, capturing the PC and codehash of each instruction executed, saving the
 -- transaction if it finds new coverage.
-execTxOptC :: (MonadState x m, Has Campaign x, Has VM x, MonadThrow m) => ByteStringMap -> Tx -> m (VMResult, Int)
-execTxOptC bsm t = do
+execTxOptC :: (MonadState x m, Has Campaign x, Has VM x, MonadThrow m) => Tx -> m (VMResult, Int)
+execTxOptC t = do
   let cov = hasLens . coverage
-  og  <- cov <<.= mempty
-  res <- execTxWith vmExcept (usingCoverage2 bsm cov) t
+  og   <- cov <<.= mempty
+  memo <- use $ hasLens . bcMemo
+  res  <- execTxWith vmExcept (execTxWithCov memo cov) t
   let vmr = getResult $ fst res
   -- Update the coverage map with the proper binary according to the vm result
   cov %= mapWithKey (\_ s -> DS.map (set _4 vmr) s)
@@ -192,8 +193,9 @@ randseq ql o w = do
   if length ctxs > p then -- Replay the transactions in the corpus, if we are executing the first iterations
     return . snd $ DS.elemAt p ctxs
   else do
+    memo <- use $ hasLens . bcMemo
     -- Randomly generate new random transactions
-    gtxs <- replicateM ql $ runReaderT (genTxM o) (w, txConf)
+    gtxs <- replicateM ql $ runReaderT (genTxM memo o) (w, txConf)
     -- Generate a random mutator
     cmut <- seqMutators (fromConsts cs)
     -- Fetch the mutator
@@ -207,12 +209,12 @@ randseq ql o w = do
 -- constantly checking if we've solved any tests or can shrink known solves. Update coverage as a result
 callseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
            , Has SolConf x, Has TestConf x, Has TxConf x, Has CampaignConf x, Has Campaign y, Has GenDict y)
-        => ByteStringMap -> VM -> World -> Int -> m ()
-callseq bsm v w ql = do
+        => VM -> World -> Int -> m ()
+callseq v w ql = do
   -- First, we figure out whether we need to execute with or without coverage optimization and gas info,
   -- and pick our execution function appropriately
   coverageEnabled <- isJust <$> view (hasLens . knownCoverage)
-  let ef = if coverageEnabled then execTxOptC bsm else execTx
+  let ef = if coverageEnabled then execTxOptC else execTx
       old = v ^. env . EVM.contracts
   gasEnabled <- view $ hasLens . estimateGas
   -- Then, we get the current campaign state
@@ -279,16 +281,18 @@ campaign u v w ts d txs = do
       False
       (DS.fromList $ map (1,) txs)
       0
+      memo
     )
   where
+    -- "mapMaybe ..." is to get a list of all contracts
+    memo        = makeBytecodeMemo . mapMaybe (viewBuffer . (^. bytecode)) . elems $ (v ^. env . EVM.contracts)
     step        = runUpdate (updateTest w v Nothing) >> lift u >> runCampaign
     runCampaign = use (hasLens . tests . to (fmap snd)) >>= update
-    bsm         = makeBytecodeMemo . mapMaybe (viewBuffer . (^. bytecode)) . elems $ (v ^. env . EVM.contracts)
     update c    = do
       CampaignConf tl sof _ q sl _ _ _ _ _ <- view hasLens
       Campaign { _ncallseqs } <- view hasLens <$> get
       if | sof && any (\case Solved _ -> True; Failed _ -> True; _ -> False) c -> lift u
-         | any (\case Open  n   -> n < tl; _ -> False) c                       -> callseq bsm v w q >> step
+         | any (\case Open  n   -> n < tl; _ -> False) c                       -> callseq v w q >> step
          | any (\case Large n _ -> n < sl; _ -> False) c                       -> step
-         | null c && (q * _ncallseqs) < tl                                     -> callseq bsm v w q >> step
+         | null c && (q * _ncallseqs) < tl                                     -> callseq v w q >> step
          | otherwise                                                           -> lift u

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -17,6 +17,7 @@ import Numeric (showHex)
 
 import Echidna.ABI (GenDict, defaultDict)
 import Echidna.Types.Coverage (CoverageMap)
+import Echidna.Types.Signature (BytecodeMemo)
 import Echidna.Types.Test (SolTest, TestState(..))
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.Corpus
@@ -62,11 +63,13 @@ data Campaign = Campaign { _tests       :: [(SolTest, TestState)]
                            -- ^ List of transactions with maximum coverage
                          , _ncallseqs   :: Int
                            -- ^ Number of times the callseq is called
+                         , _bcMemo        :: BytecodeMemo
+                           -- ^ Stored results of getBytecodeMetadata on all contracts
                          }
 makeLenses ''Campaign
 
 instance ToJSON Campaign where
-  toJSON (Campaign ts co gi _ _ _ _) = object $ ("tests", toJSON $ mapMaybe format ts)
+  toJSON (Campaign ts co gi _ _ _ _ _) = object $ ("tests", toJSON $ mapMaybe format ts)
     : ((if co == mempty then [] else [
     ("coverage",) . toJSON . mapKeys (("0x" <>) . (`showHex` "") . keccak) $ toList <$> co]) ++
        [(("maxgas",) . toJSON . toList) gi | gi /= mempty]) where
@@ -78,4 +81,4 @@ instance Has GenDict Campaign where
   hasLens = genDict
 
 defaultCampaign :: Campaign
-defaultCampaign = Campaign mempty mempty mempty defaultDict False mempty 0
+defaultCampaign = Campaign mempty mempty mempty defaultDict False mempty 0 mempty

--- a/lib/Echidna/Types/Signature.hs
+++ b/lib/Echidna/Types/Signature.hs
@@ -9,6 +9,7 @@ import EVM.ABI (AbiType, AbiValue)
 import EVM.Types (Addr)
 import GHC.Word (Word32)
 
+import qualified Data.Map as M
 import qualified Data.ByteString as BS
 
 -- | Name of the contract
@@ -30,6 +31,8 @@ type SolCall     = (FunctionName, [AbiValue])
 -- | A contract is just an address with an ABI (for our purposes).
 type ContractA = (Addr, NonEmpty SolSignature)
 
+type ByteStringMap = M.Map ByteString ByteString
+
 type SignatureMap = HashMap ByteString (NonEmpty SolSignature)
 
 getBytecodeMetadata :: ByteString -> ByteString
@@ -38,6 +41,12 @@ getBytecodeMetadata bs =
     case find ((/= mempty) . snd) stripCandidates of
       Nothing     -> bs -- if no metadata is found, return the complete bytecode
       Just (_, m) -> m
+
+lookupBytecodeMetadata :: ByteStringMap -> ByteString -> Maybe ByteString
+lookupBytecodeMetadata = (M.!?)
+
+makeBytecodeMemo :: [ByteString] -> ByteStringMap
+makeBytecodeMemo bss = M.fromList $ bss `zip` (getBytecodeMetadata <$> bss)
 
 knownBzzrPrefixes :: [ByteString]
 knownBzzrPrefixes = [


### PR DESCRIPTION
This PR makes `pointCoverage` (in `Exec.hs`) memoize its calculation of `getBytecodeMetadata`, instead of recalculating it every time. In addition, this PR adds a cleaned-up version of [this commit](https://github.com/erivas/echidna/commit/1a4bf8b553aa337c640a2b0c9388515775cbd0e7) by @erivas .

This PR results in some fairly significant speedups:
- [This](https://github.com/opynfinance/ConvexityProtocol/blob/dev/contracts/echidna/EchidnaOptionsContract.sol) contract ran 16x faster on my computer, producing the same output as before.
- [This](https://github.com/makerdao/dss-vest/blob/master/echidna/ChainLog.sol) contract ran 10x faster on my computer, producing the same output as before.

(Note that these speedups only happen when coverage is turned on; the coverage-off speed shouldn't be affected.)

In addition, this PR fixes [this problem](https://github.com/crytic/echidna/issues/322#issuecomment-553521046), where a `for` loop that runs for too long can cause a memory leak.

This PR results in `usingCoverage` and `pointCoverage` being unused functions; I'm not quite sure what should be done about this (whether or not they should be removed, whether `usingCoverage2` should be renamed to just `usingCoverage`).