### PR TITLE
Fix TERMINFO path for Nix release builds

### DIFF
--- a/macos-release.nix
+++ b/macos-release.nix
@@ -12,6 +12,7 @@ in
       macdylibbundler
       darwin.sigtool
       darwin.cctools
+      perl
     ];
   } ''
     mkdir -p $out/bin
@@ -21,6 +22,9 @@ in
       -x $out/bin/echidna-test \
       -d $out/bin \
       -p '@executable_path'
+
+    # fix TERMINFO path in ncurses binary
+    perl -i -pe 's#(${pkgs.ncurses}/share/terminfo)#"/usr/share/terminfo" . "\x0" x (length($1) - 19)#e' $out/bin/libncursesw.6.dylib
 
     # re-sign the binaries since the load paths were modified
     codesign -s - -f $out/bin/*


### PR DESCRIPTION
ncurses in Nix is built with a TERMINFO path that references `/nix`.
This causes the binaries fail when ran on non-nix systems, unless
TERMINFO=/usr/share/terminfo is exported. This patches the binary
to use a more sensible default TERMINFO path.

Closes: #729 