### PR TITLE
stack: fix version number, libBF pin

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@ name: echidna
 author: Trail of Bits <echidna-dev@trailofbits.com>
 maintainer: Trail of Bits <echidna-dev@trailofbits.com>
 
-version: 2.0.0-rc1
+version: 2.0.0
 
 ghc-options: -Wall -fno-warn-orphans -O2 -threaded +RTS -N -RTS
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
 - witherable-0.4.1@sha256:5b4840efe20d16cab6b13fa2f39ed383703cccbc246f5b710591069fcc6884c0,2249
 - HSH-2.1.3@sha256:71ded11b224f5066373ce985ec63b10c87129850b33916736dd64fa2bea9ea0a,1705
 - indexed-traversable-instances-0.1@sha256:3aaf97040001bbe583e29c2b9c7d41660df265e6565a0d2ac09a3ed5b8bc21be,2874
-- libBF-0.6.2@sha256:7bffc0e4dbc9bd9e851ba5c29255b62fd2c288dbc9a401cd3761b740f013775e,1770
+- libBF-0.6.3@sha256:ad38e44a038b8da62c82a58b8a762331097569c27a5978258caed8b28cda73e2,1770
 
 extra-include-dirs:
 - /usr/local/opt/readline/include


### PR DESCRIPTION
This PR fixes the version number on package.yaml, and bumps libBF to 0.6.3, which is needed to build correctly on M1 systems.