### PR TITLE
Check for zero tests when using dapptest mode

### DIFF
--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -204,7 +204,7 @@ loadSpecified name cs = do
   when (null abi) $ throwM NoFuncs                              -- < ABI checks
   when (null tests && isPropertyMode tm)                        -- < Properties checks
     $ throwM NoTests
-  when (null neFuns && isDapptestMode tm)                       -- < Dapptests checks
+  when (null abiMapping && isDapptestMode tm)                   -- < Dapptests checks
     $ throwM NoTests
   when (bc == mempty) $ throwM (NoBytecode $ c ^. contractName) -- Bytecode check
   case find (not . null . snd) tests of

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -202,7 +202,8 @@ loadSpecified name cs = do
 
   -- Make sure everything is ready to use, then ship it
   when (null abi) $ throwM NoFuncs                              -- < ABI checks
-  when (null tests && isPropertyMode tm) $ throwM NoTests       -- < Test checks
+  when (null tests && (isPropertyMode tm || isDapptestMode tm)) 
+    $ throwM NoTests                                            -- < Test checks
   when (bc == mempty) $ throwM (NoBytecode $ c ^. contractName) -- Bytecode check
   case find (not . null . snd) tests of
     Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -202,8 +202,10 @@ loadSpecified name cs = do
 
   -- Make sure everything is ready to use, then ship it
   when (null abi) $ throwM NoFuncs                              -- < ABI checks
-  when (null tests && (isPropertyMode tm || isDapptestMode tm)) 
-    $ throwM NoTests                                            -- < Test checks
+  when (null tests && isPropertyMode tm)                        -- < Properties checks
+    $ throwM NoTests
+  when (null neFuns && isDapptestMode tm)                       -- < Dapptests checks
+    $ throwM NoTests
   when (bc == mempty) $ throwM (NoBytecode $ c ^. contractName) -- Bytecode check
   case find (not . null . snd) tests of
     Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check


### PR DESCRIPTION
A small fix to show a better error when no proper dapptests are defined