### PR TITLE
Allow to use the FFI cheatcode from HEVM in Echidna

### DIFF
--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -106,6 +106,7 @@ instance FromJSON EConfigWithUsage where
                              <*> v ..:? "multi-abi"       ..!= False
                              <*> mode
                              <*> v ..:? "testDestruction" ..!= False
+                             <*> v ..:? "allowFFI"        ..!= False
                              <*> fnFilter
                 names :: Names
                 names Sender = (" from: " ++) . show

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -6,7 +6,7 @@ module Echidna.Exec where
 
 import Control.Lens
 import Control.Monad.Catch (MonadThrow(..))
-import Control.Monad.State.Strict (MonadState (get, put), execState, execState)
+import Control.Monad.State.Strict (MonadState (get, put), execState, execState, MonadIO (liftIO))
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as S
@@ -14,15 +14,11 @@ import Data.Word (Word64)
 
 import EVM
 import EVM.ABI
-import EVM.Concrete (createAddress)
-import EVM.Exec (exec, ethrunAddress)
-import EVM.Expr (litAddr)
+import EVM.Exec (exec, vmForEthrunCreation)
 import EVM.Types (Expr(ConcreteBuf, Lit), hexText)
-import EVM.FeeSchedule
 import Data.Text qualified as T
 import Data.Vector qualified as V
 import System.Process (readProcessWithExitCode)
-import System.IO.Unsafe (unsafePerformIO)
 
 import Echidna.Events (emptyEvents)
 import Echidna.Transaction
@@ -69,7 +65,7 @@ vmExcept e = throwM $ case VMFailure e of {Illegal -> IllegalExec e; _ -> Unknow
 
 -- | Given an error handler `onErr`, an execution strategy `executeTx`, and a transaction `tx`,
 -- execute that transaction using the given execution strategy, calling `onErr` on errors.
-execTxWith :: MonadState s m => Lens' s VM -> (Error -> m ()) -> m VMResult -> Tx -> m (VMResult, Int)
+execTxWith :: (MonadIO m, MonadState s m) => Lens' s VM -> (Error -> m ()) -> m VMResult -> Tx -> m (VMResult, Int)
 execTxWith l onErr executeTx tx' = do
   vm <- use l
   if hasSelfdestructed vm tx'.dst then
@@ -83,7 +79,7 @@ execTxWith l onErr executeTx tx' = do
     gasLeftAfterTx <- use $ l . state . gas
     checkAndHandleQuery l vmBeforeTx vmResult' onErr executeTx tx' gasLeftBeforeTx gasLeftAfterTx
 
-checkAndHandleQuery :: MonadState s m => Lens' s VM -> VM -> VMResult -> (Error -> m ()) -> m VMResult -> Tx -> Word64 -> Word64 -> m (VMResult, Int)
+checkAndHandleQuery :: (MonadIO m, MonadState s m) => Lens' s VM -> VM -> VMResult -> (Error -> m ()) -> m VMResult -> Tx -> Word64 -> Word64 -> m (VMResult, Int)
 checkAndHandleQuery l vmBeforeTx vmResult' onErr executeTx tx' gasLeftBeforeTx gasLeftAfterTx =
         -- Continue transaction whose execution queried a contract or slot
     let continueAfterQuery = do
@@ -108,9 +104,10 @@ checkAndHandleQuery l vmBeforeTx vmResult' onErr executeTx tx' gasLeftBeforeTx g
 
       -- Execute a FFI call
       Just (PleaseDoFFI (cmd : args) continuation) -> do
-        -- WARNING: this uses unsafePerformIO to avoid using IO here explicitely
-        let (_, stdout, _) = unsafePerformIO $ readProcessWithExitCode cmd args ""
-        l %= execState (continuation $ encodeAbiValue $ AbiTuple (V.fromList [AbiBytesDynamic . hexText . T.pack $ stdout]))
+        (_, stdout, _) <- liftIO $ readProcessWithExitCode cmd args ""
+        let encodedResponse = encodeAbiValue $
+              AbiTuple (V.fromList [AbiBytesDynamic . hexText . T.pack $ stdout])
+        l %= execState (continuation encodedResponse)
         continueAfterQuery
 
       -- No queries to answer
@@ -153,7 +150,7 @@ handleErrorsAndConstruction l onErr vmResult' vmBeforeTx tx' = case (vmResult', 
   _ -> pure ()
 
 -- | Execute a transaction "as normal".
-execTx :: (MonadState VM m, MonadThrow m) => Tx -> m (VMResult, Int)
+execTx :: (MonadIO m, MonadState VM m, MonadThrow m) => Tx -> m (VMResult, Int)
 execTx = execTxWith id vmExcept $ fromEVM exec
 
 -- | Execute a transaction, logging coverage at every step.
@@ -190,35 +187,8 @@ execTxWithCov memo = do
       pure $ lookupBytecodeMetadata memo bc
 
 initialVM :: Bool -> VM
-initialVM ffi = vmForEthrunCreation ffi
+initialVM ffi = vmForEthrunCreation mempty
   & block . timestamp .~ Lit initialTimestamp
   & block . number .~ initialBlockNumber
   & env . contracts .~ mempty       -- fixes weird nonce issues
-
-vmForEthrunCreation :: Bool -> VM
-vmForEthrunCreation ffi =
-  makeVm $ VMOpts
-    { vmoptContract = initialContract (InitCode mempty mempty)
-    , vmoptCalldata = mempty
-    , vmoptValue = Lit 0
-    , vmoptStorageBase = Concrete
-    , vmoptAddress = createAddress ethrunAddress 1
-    , vmoptCaller = litAddr ethrunAddress
-    , vmoptOrigin = ethrunAddress
-    , vmoptCoinbase = 0
-    , vmoptNumber = 0
-    , vmoptTimestamp = Lit 0
-    , vmoptBlockGaslimit = 0
-    , vmoptGasprice = 0
-    , vmoptPrevRandao = 42069
-    , vmoptGas = 0xffffffffffffffff
-    , vmoptGaslimit = 0xffffffffffffffff
-    , vmoptBaseFee = 0
-    , vmoptPriorityFee = 0
-    , vmoptMaxCodeSize = 0xffffffff
-    , vmoptSchedule = EVM.FeeSchedule.berlin
-    , vmoptChainId = 1
-    , vmoptCreate = False
-    , vmoptTxAccessList = mempty
-    , vmoptAllowFFI = ffi
-    }
+  & allowFFI .~ ffi

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -108,15 +108,15 @@ matchSignatureAndCreateTx _ _                                = []
 
 -- | Main function: takes a filepath where the initialization sequence lives and returns
 -- | the initialized VM along with a list of Addr's to put in GenConf
-loadEthenoBatch :: FilePath -> IO VM
-loadEthenoBatch fp = do
+loadEthenoBatch :: Bool -> FilePath -> IO VM
+loadEthenoBatch ffi fp = do
   bs <- eitherDecodeFileStrict fp
   case bs of
     Left e -> throwM $ EthenoException e
     Right (ethenoInit :: [Etheno]) -> do
       -- Execute contract creations and initial transactions,
       let initVM = mapM execEthenoTxs ethenoInit
-      execStateT initVM (initialVM False) -- No FFI is allowed here
+      execStateT initVM (initialVM ffi)
 
 initAddress :: MonadState VM m => Addr -> m ()
 initAddress addr = do

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -116,7 +116,7 @@ loadEthenoBatch fp = do
     Right (ethenoInit :: [Etheno]) -> do
       -- Execute contract creations and initial transactions,
       let initVM = mapM execEthenoTxs ethenoInit
-      execStateT initVM initialVM
+      execStateT initVM (initialVM False) -- No FFI is allowed here
 
 initAddress :: MonadState VM m => Addr -> m ()
 initAddress addr = do

--- a/lib/Echidna/Shrink.hs
+++ b/lib/Echidna/Shrink.hs
@@ -4,7 +4,7 @@ import Control.Monad ((<=<))
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader, asks)
-import Control.Monad.State.Strict (MonadState(get, put))
+import Control.Monad.State.Strict (MonadState(get, put), MonadIO)
 import Data.Foldable (traverse_)
 import Data.Set qualified as Set
 import Data.List qualified as List
@@ -21,7 +21,7 @@ import Echidna.Types.Config
 
 -- | Given a call sequence that solves some Echidna test, try to randomly generate a smaller one that
 -- still solves that test.
-shrinkSeq :: (MonadRandom m, MonadReader Env m, MonadThrow m, MonadState VM m)
+shrinkSeq :: (MonadIO m, MonadRandom m, MonadReader Env m, MonadThrow m, MonadState VM m)
           => m (TestValue, Events, TxResult) -> (TestValue, Events, TxResult) -> [Tx] -> m ([Tx], TestValue, Events, TxResult)
 shrinkSeq f (v,es,r) xs = do
   strategies <- sequence [shorten, shrunk]

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -162,7 +162,7 @@ loadSpecified solConf name cs = do
   unless solConf._quiet . putStrLn $ "Analyzing contract: " <> c ^. contractName . unpacked
 
   -- Local variables
-  let SolConf ca d ads bala balc mcs pref _ _ libs _ fp dpc dpb ma tm _ fs = solConf
+  let SolConf ca d ads bala balc mcs pref _ _ libs _ fp dpc dpb ma tm _ ffi fs = solConf
 
   -- generate the complete abi mapping
   let bc = c._creationCode
@@ -182,8 +182,8 @@ loadSpecified solConf name cs = do
 
   -- Set up initial VM, either with chosen contract or Etheno initialization file
   -- need to use snd to add to ABI dict
-  let vm = initialVM & block . gaslimit .~ fromInteger unlimitedGasPerBlock
-                     & block . maxCodeSize .~ fromInteger mcs
+  let vm = initialVM ffi & block . gaslimit .~ fromInteger unlimitedGasPerBlock
+                         & block . maxCodeSize .~ fromInteger mcs
   blank' <- maybe (pure vm) loadEthenoBatch fp
   let blank = populateAddresses (Set.insert d ads) bala blank'
 

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -184,7 +184,7 @@ loadSpecified solConf name cs = do
   -- need to use snd to add to ABI dict
   let vm = initialVM ffi & block . gaslimit .~ fromInteger unlimitedGasPerBlock
                          & block . maxCodeSize .~ fromInteger mcs
-  blank' <- maybe (pure vm) loadEthenoBatch fp
+  blank' <- maybe (pure vm) (loadEthenoBatch ffi) fp
   let blank = populateAddresses (Set.insert d ads) bala blank'
 
   unless (null con || isJust fp) (throwM $ ConstructorArgs (show con))

--- a/lib/Echidna/Types/Solidity.hs
+++ b/lib/Echidna/Types/Solidity.hs
@@ -77,6 +77,7 @@ data SolConf = SolConf { _contractAddr    :: Addr             -- ^ Contract addr
                        , _multiAbi        :: Bool             -- ^ Whether or not to use the multi-abi mode
                        , _testMode        :: String           -- ^ Testing mode
                        , _testDestruction :: Bool             -- ^ Whether or not to add a property to detect contract destruction
+                       , _allowFFI        :: Bool             -- ^ Whether or not to allow FFI hevm cheatcode
                        , _methodFilter    :: Filter           -- ^ List of methods to avoid or include calling during a campaign
                        }
 makeLenses ''SolConf

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -13,6 +13,7 @@ import Tests.Research (researchTests)
 import Tests.Values (valuesTests)
 import Tests.Seed (seedTests)
 import Tests.Dapptest (dapptestTests)
+import Tests.Cheat (cheatTests)
 
 main :: IO ()
 main = withCurrentDirectory "./tests/solidity" . defaultMain $
@@ -30,4 +31,5 @@ main = withCurrentDirectory "./tests/solidity" . defaultMain $
            , researchTests
            , dapptestTests
            , encodingJSONTests
+           , cheatTests
            ]

--- a/src/test/Tests/Cheat.hs
+++ b/src/test/Tests/Cheat.hs
@@ -1,0 +1,12 @@
+module Tests.Cheat (cheatTests) where
+
+import Test.Tasty (TestTree, testGroup)
+
+import Common (testContract', solcV, solved)
+
+cheatTests :: TestTree
+cheatTests =
+  testGroup "Cheatcodes Tests"
+    [ testContract' "cheat/ffi.sol" (Just "TestFFI") (Just (> solcV (0,6,0))) (Just "cheat/ffi.yaml") False
+        [ ("echidna_ffi passed", solved "echidna_ffi") ]
+    ]

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -73,6 +73,8 @@ maxBlockDelay: 60480
 filterFunctions: []
 # by default, blacklist methods in filterFunctions
 filterBlacklist: true
+# enable or disable ffi HEVM cheatcode
+allowFFI: false
 #directory to save the corpus; by default is disabled
 corpusDir: null
 # constants for corpus mutations (for experimentation only)

--- a/tests/solidity/cheat/ffi.sol
+++ b/tests/solidity/cheat/ffi.sol
@@ -1,0 +1,28 @@
+pragma experimental ABIEncoderV2;
+
+interface Hevm {
+  function ffi(string[] calldata) external returns (bytes memory);
+}
+
+contract TestFFI {
+  address constant HEVM_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+
+  bytes32 hehe;
+
+  function foo(int x) external {
+    string[] memory inputs = new string[](3);
+    inputs[0] = "echo";
+    inputs[1] = "-n";
+    // ABI encoded "gm", as a string
+    inputs[2] = "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002676d000000000000000000000000000000000000000000000000000000000000";
+
+    bytes memory res = Hevm(HEVM_ADDRESS).ffi(inputs);
+
+    (string memory output) = abi.decode(res, (string));
+    hehe = keccak256(bytes(output));
+  }
+
+  function echidna_ffi() public returns (bool){
+    return hehe != keccak256("gm");
+  }
+}

--- a/tests/solidity/cheat/ffi.yaml
+++ b/tests/solidity/cheat/ffi.yaml
@@ -1,0 +1,3 @@
+allowFFI: true
+testLimit: 1
+seqLen: 1


### PR DESCRIPTION
This PR allows to use the FFI cheatcode from HEVM in Echidna if the `allowFFI: true` is used in the configuration yaml. This is disabled by default.