### PR TITLE
Enable the setUp() function for every type of test

### DIFF
--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -224,7 +224,7 @@ loadSpecified name cs = do
 
       -- Run
       let transaction = execTx $ uncurry basicTx setUpFunction d ca (fromInteger unlimitedGasPerBlock) (0, 0)
-      vm2 <- if isDapptestMode tm && setUpFunction `elem` abi then execStateT transaction vm1 else return vm1
+      vm2 <- if setUpFunction `elem` abi then execStateT transaction vm1 else return vm1
 
       case vm2 ^. result of
         Just (VMFailure _) -> throwM SetUpCallFailed


### PR DESCRIPTION
This small PR is testing to enable the `setUp()` for every type of test (not only dapptools). It will be always executed, if available if it will still be part of the ABI so it can be re-executed at any time (therefore, it must be idempotent).