### PR TITLE
Add Cirrus CI Mac M1 build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,17 @@
+macos_instance:
+  image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
+
+task:
+  name: Build (macOS M1)
+
+  install_dependencies_script: brew install automake libtool haskell-stack
+  install_secp256k1_script: .github/scripts/install-libsecp256k1.sh
+  install_libff_script: .github/scripts/install-libff.sh
+  install_ghc_script: stack --resolver=ghc-8.10.5 setup
+
+  build_dependencies_script: stack build --compiler=ghc-8.10.5 --ghc-options="-Werror" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib --only-dependencies
+  build_echidna_script: stack install --compiler=ghc-8.10.5 --ghc-options="-Werror" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib
+
+  build_release_script: .github/scripts/build-macos-release.sh
+  build_output_artifacts:
+    path: echidna-test.tar.gz

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,13 +23,13 @@ task:
   install_ghc_script: stack --resolver=ghc-8.10.7 setup
 
   build_dependencies_script: >
-    stack build --compiler=ghc-8.10.7 --ghc-options="-Werror"
-      --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include
-      --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib
+    stack build --compiler=ghc-8.10.7 --ghc-options="-Werror" \
+      --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include \
+      --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib \
       --only-dependencies
   build_echidna_script: >
-    stack install --compiler=ghc-8.10.7 --ghc-options="-Werror"
-      --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include
+    stack install --compiler=ghc-8.10.7 --ghc-options="-Werror" \
+      --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include \
       --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib
 
   build_release_script: .github/scripts/build-macos-release.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,19 @@ macos_instance:
 
 task:
   name: Build (macOS M1)
+  timeout_in: 120m
+
+  local_cache:
+    folder: $HOME/.local
+    fingerprint_script: echo $CIRRUS_OS && shasum .github/scripts/*
+
+  stack_cache:
+    folder: $HOME/.stack
+    fingerprint_script: echo $CIRRUS_OS
+
+  cabal_cache:
+    folder: $HOME/.cabal
+    fingerprint_script: echo $CIRRUS_OS
 
   install_dependencies_script: brew install automake libtool haskell-stack
   install_secp256k1_script: .github/scripts/install-libsecp256k1.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ macos_instance:
 
 task:
   name: Build (macOS M1)
-  timeout_in: 120m
+  timeout_in: 60m
 
   local_cache:
     folder: $HOME/.local
@@ -22,8 +22,15 @@ task:
   install_libff_script: .github/scripts/install-libff.sh
   install_ghc_script: stack --resolver=ghc-8.10.7 setup
 
-  build_dependencies_script: stack build -j 4 --compiler=ghc-8.10.7 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib --only-dependencies
-  build_echidna_script: stack install -j 4 --compiler=ghc-8.10.7 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib
+  build_dependencies_script: >
+    stack build --compiler=ghc-8.10.7 --ghc-options="-Werror"
+      --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include
+      --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib
+      --only-dependencies
+  build_echidna_script: >
+    stack install --compiler=ghc-8.10.7 --ghc-options="-Werror"
+      --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include
+      --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib
 
   build_release_script: .github/scripts/build-macos-release.sh
   build_output_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,8 +22,8 @@ task:
   install_libff_script: .github/scripts/install-libff.sh
   install_ghc_script: stack --resolver=ghc-8.10.5 setup
 
-  build_dependencies_script: stack build --compiler=ghc-8.10.5 --ghc-options="-Werror" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib --only-dependencies
-  build_echidna_script: stack install --compiler=ghc-8.10.5 --ghc-options="-Werror" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib
+  build_dependencies_script: stack build -j 4 --compiler=ghc-8.10.5 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib --only-dependencies
+  build_echidna_script: stack install -j 4 --compiler=ghc-8.10.5 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib
 
   build_release_script: .github/scripts/build-macos-release.sh
   build_output_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,13 +17,13 @@ task:
     folder: $HOME/.cabal
     fingerprint_script: echo $CIRRUS_OS
 
-  install_dependencies_script: brew install automake libtool haskell-stack
+  install_dependencies_script: brew install automake libtool haskell-stack gmp
   install_secp256k1_script: .github/scripts/install-libsecp256k1.sh
   install_libff_script: .github/scripts/install-libff.sh
   install_ghc_script: stack --resolver=ghc-8.10.7 setup
 
-  build_dependencies_script: stack build -j 4 --compiler=ghc-8.10.7 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib --only-dependencies
-  build_echidna_script: stack install -j 4 --compiler=ghc-8.10.7 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib
+  build_dependencies_script: stack build -j 4 --compiler=ghc-8.10.7 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib --only-dependencies
+  build_echidna_script: stack install -j 4 --compiler=ghc-8.10.7 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-include-dirs=/opt/homebrew/include --extra-lib-dirs=$HOME/.local/lib --extra-lib-dirs=/opt/homebrew/lib
 
   build_release_script: .github/scripts/build-macos-release.sh
   build_output_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,10 +13,6 @@ task:
     folder: $HOME/.stack
     fingerprint_script: echo $CIRRUS_OS
 
-  cabal_cache:
-    folder: $HOME/.cabal
-    fingerprint_script: echo $CIRRUS_OS
-
   install_dependencies_script: brew install automake libtool haskell-stack gmp
   install_secp256k1_script: .github/scripts/install-libsecp256k1.sh
   install_libff_script: .github/scripts/install-libff.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,10 +20,10 @@ task:
   install_dependencies_script: brew install automake libtool haskell-stack
   install_secp256k1_script: .github/scripts/install-libsecp256k1.sh
   install_libff_script: .github/scripts/install-libff.sh
-  install_ghc_script: stack --resolver=ghc-8.10.5 setup
+  install_ghc_script: stack --resolver=ghc-8.10.7 setup
 
-  build_dependencies_script: stack build -j 4 --compiler=ghc-8.10.5 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib --only-dependencies
-  build_echidna_script: stack install -j 4 --compiler=ghc-8.10.5 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib
+  build_dependencies_script: stack build -j 4 --compiler=ghc-8.10.7 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib --only-dependencies
+  build_echidna_script: stack install -j 4 --compiler=ghc-8.10.7 --ghc-options="-Werror -j" --extra-include-dirs=$HOME/.local/include --extra-lib-dirs=$HOME/.local/lib
 
   build_release_script: .github/scripts/build-macos-release.sh
   build_output_artifacts:


### PR DESCRIPTION
This adds automated builds using Cirrus CI, which offers M1 runners. The build process performed is similar to the current GH Actions Mac CI, which uses Stack. The main process changes include:

* `brew install`: add `libtool haskell-stack` which are not available by default.
* `--extra-include-dirs=/opt/homebrew/include --extra-lib-dirs=/opt/homebrew/lib`: Fixes failure to link with gmp.
* `--resolver=ghc-8.10.7`, `--compiler=ghc-8.10.7`: GHC 8.10.4 is not available on M1. 8.10.5 hanged during build 😞  8.10.7 works fine 🎉 

Enabling the CI requires installing a GitHub Application to the org/repository.