### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sol linguist-language=Solidity
+*.sh            eol=lf


### PR DESCRIPTION
fixes #689
----------------------------------
Normally git converts LF to CRLF while cloning on windows automatically so the OS can detect line endings. However, this shouldn't happen to UNIX-specific files such as bash scripts. This PR simply adds a line to `.gitattributes`  to prevent converting from LF to CRLF for bash files