### PR TITLE
Improved dynamic array shrinking 

### DIFF
--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -262,7 +262,10 @@ shrinkAbiValue (AbiBytes n b)        = AbiBytes n <$> addNulls b
 shrinkAbiValue (AbiBytesDynamic b)   = fmap AbiBytesDynamic $ addNulls =<< shrinkBS b
 shrinkAbiValue (AbiString b)         = fmap AbiString       $ addNulls =<< shrinkBS b
 shrinkAbiValue (AbiArray n t l)      = AbiArray n t <$> traverse shrinkAbiValue l
-shrinkAbiValue (AbiArrayDynamic t l) = fmap (AbiArrayDynamic t) $ traverse shrinkAbiValue =<< shrinkV l
+shrinkAbiValue (AbiArrayDynamic t l) = getRandomR (0, 9 :: Int) >>= -- 10% of chance of shrinking all elements
+                                          \case
+                                            0 -> AbiArrayDynamic t <$> traverse shrinkAbiValue l
+                                            _ -> AbiArrayDynamic t <$> shrinkV l
 shrinkAbiValue (AbiTuple v)          = AbiTuple <$> traverse shrinkAbiValue' v
   where shrinkAbiValue' x = liftM3 bool (pure x) (shrinkAbiValue x) getRandom
 


### PR DESCRIPTION
It seems that dynamic array shrinking was too aggressive, requiring to reduce the size of them at the same type as reducing the size of each element. This PR allows Echidna to fix #774 reducing the size of the dynamic array 90% of the time, and all their elements the remaining 10%.