### PR TITLE
Bound max values for certain config options

### DIFF
--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -30,6 +30,7 @@ import Echidna.Exec               (execTx, initialVM)
 import Echidna.Events             (EventMap)
 import Echidna.Test               (createTests, isAssertionMode, isPropertyMode, isDapptestMode)
 import Echidna.RPC                (loadEthenoBatch)
+import Echidna.Types.Config       (twoPower64)
 import Echidna.Types.Solidity     hiding (deployBytecodes, deployContracts)
 import Echidna.Types.Signature    (ContractName, FunctionHash, SolSignature, SignatureMap, getBytecodeMetadata)
 import Echidna.Types.Tx           (TxConf, basicTx, createTxWithValue, unlimitedGasPerBlock, initialTimestamp, initialBlockNumber)
@@ -191,7 +192,7 @@ loadSpecified name cs = do
 
   -- Set up initial VM, either with chosen contract or Etheno initialization file
   -- need to use snd to add to ABI dict
-  blank' <- maybe (pure (initialVM & block . gaslimit .~ fromInteger unlimitedGasPerBlock & block . maxCodeSize .~ w256 (fromInteger mcs)))
+  blank' <- maybe (pure (initialVM & block . gaslimit .~ fromInteger unlimitedGasPerBlock & block . maxCodeSize .~ w256 (fromInteger $ min mcs $ fromIntegral twoPower64)))
                   loadEthenoBatch
                   fp
   let blank = populateAddresses (NE.toList ads |> d) bala blank'

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -20,7 +20,7 @@ import Echidna.UI
 import Echidna.UI.Report
 
 twoPower64 :: Int
-twoPower64 = 2 ^ 64
+twoPower64 = 2 ^ (64 :: Int)
 
 -- | Our big glorious global config type, just a product of each local config.,
 data EConfig = EConfig { 

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -19,6 +19,9 @@ import Echidna.Types.Test  (TestConf)
 import Echidna.UI
 import Echidna.UI.Report
 
+twoPower64 :: Int
+twoPower64 = 2 ^ 64
+
 -- | Our big glorious global config type, just a product of each local config.,
 data EConfig = EConfig { 
   _cConf :: CampaignConf,


### PR DESCRIPTION
If the user specifies extremely large values for certain config options (e.g. max gas usage), echidna will silently change it to a very large but valid value (2**64). Should fixes #765 