### PR TITLE
Correctly decode non-utf8 strings from slither printer

### DIFF
--- a/src/test/Tests/Values.hs
+++ b/src/test/Tests/Values.hs
@@ -26,6 +26,8 @@ valuesTests = testGroup "Value extraction tests"
         ("testMinInt64 passed",                  solved      "testMinInt32"),
         ("testMinInt128 passed",                 solved      "testMinInt128")
       ]
+    , testContract' "values/utf8.sol"   Nothing Nothing (Just "values/extreme.yaml") False
+      [ ("testNonUtf8 passed",                   solved      "testNonUTF8")]
     , testContract' "values/create.sol" (Just "C") Nothing Nothing True
       [ ("echidna_state failed",                   solved      "echidna_state") ]
     , testContract "values/time.sol"         (Just "values/time.yaml")

--- a/tests/solidity/values/extreme.yaml
+++ b/tests/solidity/values/extreme.yaml
@@ -1,2 +1,4 @@
+testLimit: 5000
+shrinkLimit: 100
 testMode: assertion
 seqLen: 1

--- a/tests/solidity/values/utf8.sol
+++ b/tests/solidity/values/utf8.sol
@@ -1,0 +1,8 @@
+contract Test {
+    bytes16 key = "\xf8";
+    function testNonUTF8(string memory input) public {
+       bytes memory x = bytes(input);
+       if (x.length > 0)
+         assert(key[0] != x[0]);
+    }
+}


### PR DESCRIPTION
Tests are missing, but this should work.