### PR TITLE
Add nix flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,16 +3,15 @@
     url = "https://github.com/nixos/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz";
     sha256 = "sha256:0zg7ak2mcmwzi2kg29g4v9fvbvs0viykjsg2pwaphm1fi13s7s0i";
   }) {},
-  profiling ? false,
-  tests ? true
-}:
-let
-  newerPkgs = import (builtins.fetchTarball {
+  newerPkgs ? import (builtins.fetchTarball {
     name = "nixpkgs-22.05-darwin-2022-06-27";
     url = "https://github.com/nixos/nixpkgs/archive/ce6aa13369b667ac2542593170993504932eb836.tar.gz";
     sha256 = "sha256:0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
-  }) {};
-
+  }) {},
+  profiling ? false,
+  tests ? false
+}:
+let
   # this is not perfect for development as it hardcodes solc to 0.5.7, test suite runs fine though
   # would be great to integrate solc-select to be more flexible, improve this in future
   solc = pkgs.stdenv.mkDerivation {
@@ -74,6 +73,7 @@ let
         license = pkgs.lib.licenses.agpl3;
         doHaddock = false;
         doCheck = tests;
+        mainProgram = "echidna-test";
       };
 
   dapptools = pkgs.fetchFromGitHub {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "newerNixpkgs": {
+      "locked": {
+        "lastModified": 1659009481,
+        "narHash": "sha256-BRM5R7AMKa58NAJnZsmWsVhDxuGllnhTvpVEZ+sP49I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2d9b7cb5f0a41da95fccc120acf730fd20d8598d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1659009481,
+        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "newerNixpkgs": "newerNixpkgs",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,17 @@
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
       newerPkgs = newerNixpkgs.legacyPackages.x86_64-linux;
     };
+    defaultPackage.aarch64-linux = import ./. {
+      pkgs = nixpkgs.legacyPackages.aarch64-linux;
+      newerPkgs = newerNixpkgs.legacyPackages.aarch64-linux;
+    };
     defaultPackage.x86_64-darwin = import ./. {
       pkgs = nixpkgs.legacyPackages.x86_64-darwin;
       newerPkgs = newerNixpkgs.legacyPackages.x86_64-darwin;
+    };
+    defaultPackage.aarch64-darwin = import ./. {
+      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+      newerPkgs = newerNixpkgs.legacyPackages.aarch64-darwin;
     };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs;
+    newerNixpkgs.url = github:NixOS/nixpkgs;
+  };
+
+  outputs = { self, nixpkgs, newerNixpkgs }: {
+    defaultPackage.x86_64-linux = import ./. {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      newerPkgs = newerNixpkgs.legacyPackages.x86_64-linux;
+    };
+    defaultPackage.x86_64-darwin = import ./. {
+      pkgs = nixpkgs.legacyPackages.x86_64-darwin;
+      newerPkgs = newerNixpkgs.legacyPackages.x86_64-darwin;
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,9 @@
 {
+  nixConfig = {
+    extra-substituters = "https://trailofbits.cachix.org";
+    extra-trusted-public-keys = "trailofbits.cachix.org-1:jRuxrlFghP6HstIaZg7DhvTgHyK/lcYa7U8y3CgKjzU=";
+  };
+
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs;
     newerNixpkgs.url = github:NixOS/nixpkgs;


### PR DESCRIPTION
This enables to run echidna just with `nix run github:crytic/echidna`. This PR branch can be tested with `nix run github:crytic/echidna/flake`. For now, I disabled running tests by default as they are quite heavy.