### PR TITLE
Cleanup imports and extensions

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -12,14 +12,14 @@ jobs:
   hlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Get Packages
-        uses: mstksg/get-package@v1
-        with:
-          apt-get: hlint
-
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - name: HLint
         run: |
-          hlint lib src
+          nix-shell -p hlint --command 'hlint lib src'

--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 module Echidna where
 
 import Control.Lens (view, (^.), to)
@@ -7,9 +5,10 @@ import Data.Has (Has(..))
 import Control.Monad.Catch (MonadCatch(..), MonadThrow(..))
 import Control.Monad.Reader (MonadReader, MonadIO, liftIO)
 import Control.Monad.Random (MonadRandom)
-import Data.Map.Strict (keys)
 import Data.HashMap.Strict (toList)
+import Data.Map.Strict (keys)
 import Data.List (nub, find)
+import Data.List.NonEmpty qualified as NE
 
 import EVM (env, contracts, VM)
 import EVM.ABI (AbiValue(AbiAddress))
@@ -28,8 +27,6 @@ import Echidna.Solidity
 import Echidna.Processor
 import Echidna.Output.Corpus
 import Echidna.RPC (loadEtheno, extractFromEtheno)
-
-import qualified Data.List.NonEmpty as NE
 
 -- | This function is used to prepare, process, compile and initialize smart contracts for testing.
 -- It takes:

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -1,9 +1,4 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Echidna.ABI where
@@ -11,35 +6,34 @@ module Echidna.ABI where
 import Control.Lens
 import Control.Monad (join, liftM2, liftM3, foldM, replicateM)
 import Control.Monad.Random.Strict (MonadRandom, getRandom, getRandoms, getRandomR, uniformMay)
+import Control.Monad.Random.Strict qualified as R
 import Data.Binary.Put (runPut, putWord32be)
 import Data.Bool (bool)
 import Data.ByteString.Lazy as BSLazy (toStrict)
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.DoubleWord (Int256, Word256)
 import Data.Foldable (toList)
 import Data.Hashable (Hashable(..))
 import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as M
 import Data.HashSet (HashSet, fromList, union)
+import Data.HashSet qualified as H
 import Data.List (intercalate)
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, catMaybes)
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
+import Data.Text.Encoding qualified as TE
 import Data.Vector (Vector)
+import Data.Vector qualified as V
 import Data.Vector.Instances ()
 import Data.Word8 (Word8)
-import Data.DoubleWord (Int256, Word256)
 import Numeric (showHex)
 
 import EVM.ABI hiding (genAbiValue)
 import EVM.Types (Addr, abiKeccak)
-
-import qualified Control.Monad.Random.Strict as R
-import qualified Data.ByteString as BS
-import qualified Data.HashMap.Strict as M
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
-import qualified Data.Vector as V
-import qualified Data.HashSet as H
 
 import Echidna.Mutator.Array (mutateLL, replaceAt)
 import Echidna.Types.Random

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -1,12 +1,5 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Echidna.Campaign where
@@ -22,20 +15,20 @@ import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Random.Strict (liftCatch)
 import Data.Binary.Get (runGetOrFail)
 import Data.Bool (bool)
+import Data.Has (Has(..))
+import Data.HashMap.Strict qualified as H
+import Data.HashSet qualified as S
 import Data.Map (Map, unionWith, (\\), elems, keys, lookup, insert, mapWithKey)
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Ord (comparing)
-import Data.Has (Has(..))
+import Data.Set qualified as DS
 import Data.Text (Text)
+import System.Random (mkStdGen)
+
 import EVM
 import EVM.Dapp (DappInfo)
 import EVM.ABI (getAbi, AbiType(AbiAddressType), AbiValue(AbiAddress))
 import EVM.Types (Addr, Buffer(..))
-import System.Random (mkStdGen)
-
-import qualified Data.HashMap.Strict as H
-import qualified Data.HashSet as S
-import qualified Data.Set as DS
 
 import Echidna.ABI
 import Echidna.Exec
@@ -97,8 +90,8 @@ updateTest w vm (Just (vm', xs)) test = do
     Open i | i >= tl -> case test ^. testType of
                           OptimizationTest _ _ -> pure $ test { _testState = Large (-1) }
                           _                    -> pure $ test { _testState = Passed }
-    Open i           -> do r <- evalStateT (checkETest test) vm' 
-                           pure $ updateOpenTest test xs i r 
+    Open i           -> do r <- evalStateT (checkETest test) vm'
+                           pure $ updateOpenTest test xs i r
     _                -> updateTest w vm Nothing test
 
 updateTest _ vm Nothing test = do
@@ -111,7 +104,7 @@ updateTest _ vm Nothing test = do
     Large i | i >= sl -> pure $ test { _testState =  Solved, _testReproducer = x }
     Large i           -> if length x > 1 || any canShrinkTx x
                              then do (txs, val, evs, r) <- evalStateT (shrinkSeq (checkETest test) (v, es, res) x) vm
-                                     pure $ test { _testState = Large (i + 1), _testReproducer = txs, _testEvents = evs, _testResult = r, _testValue = val} 
+                                     pure $ test { _testState = Large (i + 1), _testReproducer = txs, _testEvents = evs, _testResult = r, _testValue = val}
                              else pure $ test { _testState = Solved, _testReproducer = x}
     _                   -> pure test
 

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -1,38 +1,33 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Echidna.Config where
 
 import Control.Lens
 import Control.Monad.Catch (MonadThrow)
+import Control.Monad.Fail qualified as M (MonadFail(..))
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader (Reader, ReaderT(..), runReader)
 import Control.Monad.State (StateT(..), runStateT)
 import Control.Monad.Trans (lift)
-import Data.Bool (bool)
 import Data.Aeson
+import Data.Bool (bool)
+import Data.ByteString qualified as BS
+import Data.List.NonEmpty qualified as NE
 import Data.Has (Has(..))
 import Data.HashMap.Strict (keys)
 import Data.HashSet (fromList, insert, difference)
 import Data.Maybe (fromMaybe)
 import Data.Text (isPrefixOf)
+import Data.Yaml qualified as Y
+
 import EVM (result)
 import EVM.Types (w256)
 
-import qualified Control.Monad.Fail as M (MonadFail(..))
-import qualified Data.ByteString as BS
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Yaml as Y
-
 import Echidna.Test
-import Echidna.Types.Campaign 
+import Echidna.Types.Campaign
 import Echidna.Mutator.Corpus (defaultMutationConsts)
 import Echidna.Types.Config (EConfigWithUsage(..), EConfig(..))
 import Echidna.Types.Solidity
-import Echidna.Types.Tx  (TxConf(TxConf), maxGasPerBlock, defaultTimeDelay, defaultBlockDelay)
-import Echidna.Types.Test  (TestConf(..))
+import Echidna.Types.Tx (TxConf(TxConf), maxGasPerBlock, defaultTimeDelay, defaultBlockDelay)
+import Echidna.Types.Test (TestConf(..))
 import Echidna.UI
 import Echidna.UI.Report
 

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Echidna.Exec where
@@ -11,22 +7,21 @@ import Control.Lens
 import Control.Monad.Catch (Exception, MonadThrow(..))
 import Control.Monad.State.Strict (MonadState, execState, execState)
 import Data.Has (Has(..))
+import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
+import Data.Set qualified as S
+
 import EVM
 import EVM.Exec (exec, vmForEthrunCreation)
 import EVM.Types (Buffer(..), Word)
 import EVM.Symbolic (litWord)
 
-import qualified Data.Map as M
-import qualified Data.Set as S
-
+import Echidna.Events (emptyEvents)
 import Echidna.Transaction
 import Echidna.Types.Buffer (viewBuffer)
 import Echidna.Types.Coverage (CoverageMap)
-import Echidna.Types.Tx (TxCall(..), Tx, TxResult(..), call, dst, initialTimestamp, initialBlockNumber)
-
 import Echidna.Types.Signature (BytecodeMemo, lookupBytecodeMetadata)
-import Echidna.Events (emptyEvents)
+import Echidna.Types.Tx (TxCall(..), Tx, TxResult(..), call, dst, initialTimestamp, initialBlockNumber)
 
 -- | Broad categories of execution failures: reversions, illegal operations, and ???.
 data ErrorClass = RevertE | IllegalE | UnknownE
@@ -136,7 +131,7 @@ handleErrorsAndConstruction onErr vmResult' vmBeforeTx tx' = case (vmResult', tx
     -- contract address, calldata, result and traces.
     hasLens . result ?= vmResult'
     hasLens . state . calldata .= calldataBeforeVMReset
-    hasLens . state . callvalue .= callvalueBeforeVMReset 
+    hasLens . state . callvalue .= callvalueBeforeVMReset
     hasLens . traces .= tracesBeforeVMReset
     hasLens . state . codeContract .= codeContractBeforeVMReset
   (VMFailure x, _) -> onErr x

--- a/lib/Echidna/Fetch.hs
+++ b/lib/Echidna/Fetch.hs
@@ -1,27 +1,24 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 module Echidna.Fetch where
 
 import Control.Lens
-import Control.Monad.Reader       (MonadReader)
+import Control.Monad.Catch (MonadThrow(..), throwM)
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.Reader (MonadReader)
 import Control.Monad.State.Strict (execStateT)
-import Control.Monad.Catch        (MonadThrow(..), throwM)
-import Control.Monad.IO.Class     (MonadIO(..))
-import Data.Either                (fromRight)
-import Data.Has                   (Has(..))
+import Data.ByteString (ByteString, pack, append)
+import Data.ByteString.Base16 qualified as BS16 (decode)
+import Data.Either (fromRight)
+import Data.Has (Has(..))
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
 
 import EVM
 import EVM.Solidity
-import EVM.Types         (Addr)
+import EVM.Types (Addr)
 
-import Echidna.Types.Solidity     (SolConf(..), SolException(..))
-import Echidna.Types.Tx           (createTx, unlimitedGasPerBlock)
-import Echidna.Exec               (execTx)
-
-import Data.ByteString (ByteString, pack, append)
-import qualified Data.ByteString.Base16 as BS16 (decode)
-import Data.Text (Text)
-import Data.Text.Encoding (encodeUtf8)
+import Echidna.Types.Solidity (SolConf(..), SolException(..))
+import Echidna.Types.Tx (createTx, unlimitedGasPerBlock)
+import Echidna.Exec (execTx)
 
 -- | Deploy a list of solidity contracts in certain addresses
 deployBytecodes' :: (MonadIO m, MonadThrow m, MonadReader x m, Has SolConf x)

--- a/lib/Echidna/Mutator/Array.hs
+++ b/lib/Echidna/Mutator/Array.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 module Echidna.Mutator.Array where
 
 import Control.Monad.Random.Strict (fromList, MonadRandom, getRandomR)
-
-import qualified Data.ListLike as LL
+import Data.ListLike qualified as LL
 
 -- | A list of mutators to randomly select to perform a mutation of list-like values
 listMutators :: (LL.ListLike f i, MonadRandom m) => m (f -> m f)

--- a/lib/Echidna/Mutator/Corpus.hs
+++ b/lib/Echidna/Mutator/Corpus.hs
@@ -1,18 +1,15 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 module Echidna.Mutator.Corpus where
 
-import Control.Monad.Random.Strict (MonadRandom, getRandomR, weighted)
 import Control.Monad.State.Strict (MonadState(..))
+import Control.Monad.Random.Strict (MonadRandom, getRandomR, weighted)
 import Data.Has (Has(..))
+import Data.Set qualified as DS
 
-import qualified Data.Set as DS
-
-import Echidna.Types.Tx (Tx)
-import Echidna.Types.Corpus
-import Echidna.Transaction (mutateTx, shrinkTx)
 import Echidna.ABI (GenDict)
 import Echidna.Mutator.Array
+import Echidna.Transaction (mutateTx, shrinkTx)
+import Echidna.Types.Tx (Tx)
+import Echidna.Types.Corpus
 
 type MutationConsts a = (a, a, a, a)
 defaultMutationConsts :: Num a => MutationConsts a

--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -4,11 +4,10 @@ import Prelude hiding (Word)
 
 import Control.Monad (unless)
 import Data.Aeson (ToJSON(..), decodeStrict, encodeFile)
+import Data.ByteString qualified as BS
 import Data.Hashable (hash)
 import Data.Maybe (catMaybes)
 import System.Directory (createDirectoryIfMissing, makeRelativeToCurrentDirectory, doesFileExist)
-
-import qualified Data.ByteString as BS
 
 import Echidna.Types.Tx
 import Echidna.Output.Utils
@@ -23,7 +22,7 @@ saveTxs Nothing  _   = pure ()
 loadTxs :: Maybe FilePath -> IO [[Tx]]
 loadTxs (Just d) = do
   let d' = d ++ "/coverage"
-  createDirectoryIfMissing True d' 
+  createDirectoryIfMissing True d'
   fs <- listDirectory d'
   css <- mapM readCall <$> mapM makeRelativeToCurrentDirectory fs
   txs <- catMaybes <$> withCurrentDirectory d' css

--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -4,21 +4,23 @@
 module Echidna.Output.JSON where
 
 import Control.Lens ((^.))
-import Echidna.ABI (ppAbiValue, GenDict(..))
-import Echidna.Types.Coverage (CoverageInfo)
-import qualified Echidna.Types.Campaign as C
-import qualified Echidna.Types.Test as T
-import Echidna.Types.Test (EchidnaTest, testState, testReproducer)
-import Echidna.Types.Tx (Tx(..), TxCall(..))
 import Data.Aeson hiding (Error)
-import qualified Data.ByteString.Base16 as BS16
+import Data.ByteString.Base16 qualified as BS16
 import Data.ByteString.Lazy (ByteString)
+import Data.Foldable qualified as DF
+import Data.Map
 import Data.Text
 import Data.Text.Encoding (decodeUtf8)
-import Data.Map
-import EVM.Types (keccak)
-import qualified Data.Foldable as DF
 import Numeric (showHex)
+
+import EVM.Types (keccak)
+
+import Echidna.ABI (ppAbiValue, GenDict(..))
+import Echidna.Types.Coverage (CoverageInfo)
+import Echidna.Types.Campaign qualified as C
+import Echidna.Types.Test qualified as T
+import Echidna.Types.Test (EchidnaTest, testState, testReproducer)
+import Echidna.Types.Tx (Tx(..), TxCall(..))
 
 data Campaign = Campaign
   { _success :: Bool
@@ -104,13 +106,13 @@ encodeCampaign C.Campaign{..} = encode
 mapTest :: EchidnaTest -> Test
 mapTest echidnaTest =
   let tst = echidnaTest ^. testState
-      txs = echidnaTest ^. testReproducer 
+      txs = echidnaTest ^. testReproducer
       (status, transactions, err) = mapTestState tst txs in
   Test { contract = "" -- TODO add when mapping is available https://github.com/crytic/echidna/issues/415
        , name = "name" --TODO add a proper name here
        , status = status
        , _error = err
-       , testType = Property 
+       , testType = Property
        , transactions = transactions
        }
   where

--- a/lib/Echidna/Output/Source.hs
+++ b/lib/Echidna/Output/Source.hs
@@ -1,28 +1,23 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Echidna.Output.Source where
+
+import Prelude hiding (writeFile)
 
 import Control.Lens
 import Data.Foldable
-import Data.Maybe (fromMaybe, mapMaybe, catMaybes)
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
+import Data.List (nub, sort)
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Data.Text (Text, pack)
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
 import Data.Text.IO (writeFile)
-import Data.List (nub, sort)
+import Data.Vector qualified as V
+import HTMLEntities.Text qualified as HTML
 import Text.Printf (printf)
-import qualified HTMLEntities.Text as HTML
 
-import EVM.Solidity (SourceCache, SrcMap, SolcContract, sourceLines, sourceFiles, runtimeCode, runtimeSrcmap, creationSrcmap)
 import EVM.Debug (srcMapCodePos)
-import Prelude hiding (writeFile)
-
-import qualified Data.Vector as V
-
-import qualified Data.Map as M
-import qualified Data.Set as S
-import qualified Data.Text as T
+import EVM.Solidity (SourceCache, SrcMap, SolcContract, sourceLines, sourceFiles, runtimeCode, runtimeSrcmap, creationSrcmap)
 
 import Echidna.Types.Coverage (CoverageMap, CoverageInfo)
 import Echidna.Types.Tx (TxResult(..))

--- a/lib/Echidna/Pretty.hs
+++ b/lib/Echidna/Pretty.hs
@@ -1,16 +1,13 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Echidna.Pretty where
 
+import Data.ByteString.Base16 qualified as BS16
+import Data.ByteString.Char8 qualified as BSC8
 import Data.List (intercalate)
 import Data.Text (unpack)
 
 import Echidna.ABI (ppAbiValue)
 import Echidna.Types.Signature (SolCall)
 import Echidna.Types.Tx (TxCall(..))
-
-import qualified Data.ByteString.Base16 as BS16
-import qualified Data.ByteString.Char8 as BSC8
 
 -- | Pretty-print some 'AbiCall'.
 ppSolCall :: SolCall -> String

--- a/lib/Echidna/Processor.hs
+++ b/lib/Echidna/Processor.hs
@@ -1,37 +1,32 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Echidna.Processor where
 
 import Control.Monad.IO.Class (MonadIO(..))
-import Control.Exception      (Exception)
-import Control.Monad.Catch    (MonadThrow(..))
-import Data.Aeson             ((.:), (.:?), (.!=), decode, parseJSON, withEmbeddedJSON, withObject)
-import Data.Aeson.Types       (FromJSON, Parser, Value(String))
-import Data.List              (nub, isPrefixOf)
-import Data.Maybe             (catMaybes, fromMaybe)
-import Data.Text              (pack, isSuffixOf)
-import Data.SemVer            (Version, fromText)
-import Data.Either            (fromRight)
-import Text.Read              (readMaybe)
-import System.Directory       (findExecutable)
-import System.Process         (StdStream(..), readCreateProcessWithExitCode, proc, std_err)
-import System.Exit            (ExitCode(..))
+import Control.Exception (Exception)
+import Control.Monad.Catch (MonadThrow(..))
+import Data.Aeson ((.:), (.:?), (.!=), decode, parseJSON, withEmbeddedJSON, withObject)
+import Data.Aeson.Types (FromJSON, Parser, Value(String))
+import Data.ByteString.Base16 qualified as BS16 (decode)
+import Data.ByteString.Lazy.Char8 qualified as BSL
+import Data.ByteString.UTF8 qualified as BSU
+import Data.Either (fromRight)
+import Data.HashMap.Strict qualified as M
+import Data.List (nub, isPrefixOf)
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.SemVer (Version, fromText)
+import Data.Text (pack, isSuffixOf)
+import System.Directory (findExecutable)
+import System.Process (StdStream(..), readCreateProcessWithExitCode, proc, std_err)
+import System.Exit (ExitCode(..))
+import Text.Read (readMaybe)
 
-import qualified Data.ByteString.Base16 as BS16 (decode)
-import qualified Data.ByteString.Lazy.Char8 as BSL
-import qualified Data.ByteString.UTF8 as BSU
-import qualified Data.List.NonEmpty as NE
-import qualified Data.HashMap.Strict as M
-
-import Echidna.Types.Signature (ContractName, FunctionName, FunctionHash)
 import EVM.ABI (AbiValue(..))
 import EVM.Types (Addr(..))
+
 import Echidna.ABI (hashSig, makeNumAbiValues, makeArrayAbiValues)
-
-
+import Echidna.Types.Signature (ContractName, FunctionName, FunctionHash)
 
 -- | Things that can go wrong trying to run a processor. Read the 'Show'
 -- instance for more detailed explanations.

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Echidna.RPC where
 
 import Prelude hiding (Word)
@@ -10,32 +6,30 @@ import Control.Exception (Exception)
 import Control.Lens
 import Control.Monad (foldM, void)
 import Control.Monad.Catch (MonadThrow, throwM)
+import Control.Monad.Fail qualified as M (MonadFail(..))
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader.Class (MonadReader(..))
 import Control.Monad.State.Strict (MonadState, runStateT, get, put)
 import Data.Aeson (FromJSON(..), (.:), withObject, eitherDecodeFileStrict)
+import Data.ByteString.Base16 qualified as BS16 (decode)
 import Data.ByteString.Char8 (ByteString)
+import Data.ByteString.Char8 qualified as BS
+import Data.ByteString.Lazy qualified as LBS
 import Data.Has (Has(..))
+import Data.Text qualified as T (drop)
 import Data.Text.Encoding (encodeUtf8)
+import Data.Vector qualified as V (fromList, toList)
+import Text.Read (readMaybe)
 
 import EVM
 import EVM.ABI (AbiType(..), AbiValue(..), decodeAbiValue, selector)
 import EVM.Exec (exec)
 import EVM.Types (Addr, Buffer(..), W256, w256)
-import Text.Read (readMaybe)
-
-import qualified Control.Monad.Fail as M (MonadFail(..))
-import qualified Data.ByteString.Base16 as BS16 (decode)
-import qualified Data.Text as T (drop)
-import qualified Data.Vector as V (fromList, toList)
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Lazy as LBS
 
 import Echidna.Exec
 import Echidna.Transaction
 import Echidna.Types.Signature (SolSignature)
 import Echidna.ABI (encodeSig)
-
 import Echidna.Types.Tx (TxCall(..), Tx(..), TxConf, makeSingleTx, createTxWithValue, unlimitedGasPerBlock)
 
 -- | During initialization we can either call a function or create an account or contract

--- a/lib/Echidna/Shrink.hs
+++ b/lib/Echidna/Shrink.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 module Echidna.Shrink where
 
 import Control.Lens
@@ -11,6 +9,7 @@ import Control.Monad.State.Strict (MonadState(get, put))
 import Data.Foldable (traverse_)
 import Data.Has (Has(..))
 import Data.Maybe (fromMaybe)
+
 import EVM (VM)
 
 import Echidna.Exec
@@ -32,7 +31,7 @@ shrinkSeq f (v,es,r) xs = do
   xs' <- strategy
   (value, events, result) <- check xs'
   -- if the test passed it means we didn't shrink successfully
-  pure $ case (value,v) of 
+  pure $ case (value,v) of
     (BoolValue False, _)               ->  (xs', value, events, result)
     (IntValue x, IntValue y) | x >= y  ->  (xs', value, events, result)
     _                                  ->  (xs, v, es, r)

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 module Echidna.Test where
 
 import Prelude hiding (Word)
@@ -8,17 +6,17 @@ import Control.Lens
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Reader.Class (MonadReader)
 import Control.Monad.State.Strict (MonadState(get, put), gets)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
 import Data.Has (Has(..))
 import Data.Text (Text)
+import Data.Text qualified as T
+
 import EVM (Error(..), VMResult(..), VM, calldata, callvalue, codeContract, result, tx, state, substate, selfdestructs)
 import EVM.ABI (AbiValue(..), AbiType(..), encodeAbiValue, decodeAbiValue, )
+import EVM.Dapp (DappInfo)
 import EVM.Types (Addr)
 import EVM.Symbolic (forceLit)
-
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
-
-import qualified Data.Text as T
 
 import Echidna.ABI
 import Echidna.Events (Events, extractEvents)
@@ -27,8 +25,6 @@ import Echidna.Types.Buffer (viewBuffer)
 import Echidna.Types.Test
 import Echidna.Types.Signature (SolSignature)
 import Echidna.Types.Tx (Tx, TxConf, basicTx, TxResult(..), getResult, propGas)
-
-import EVM.Dapp (DappInfo)
 
 --- | Possible responses to a call to an Echidna test: @true@, @false@, @REVERT@, and ???.
 data CallRes = ResFalse | ResTrue | ResRevert | ResOther
@@ -50,8 +46,8 @@ getResultFromVM vm =
     Nothing -> error "getResultFromVM failed"
 
 createTest :: TestType -> EchidnaTest
-createTest m =  EchidnaTest (Open (-1)) m v [] Stop []   
-                where v = case m of 
+createTest m =  EchidnaTest (Open (-1)) m v [] Stop []
+                where v = case m of
                            PropertyTest _ _     -> BoolValue True
                            OptimizationTest _ _ -> IntValue minBound
                            _                    -> NoValue
@@ -100,15 +96,15 @@ createTests m td ts r ss = case m of
          sdat = createTest (CallTest "No contract can be self-destructed" checkAnySelfDestructed)
 
 updateOpenTest :: EchidnaTest -> [Tx] -> Int -> (TestValue, Events, TxResult) -> EchidnaTest
-updateOpenTest test txs _ (BoolValue False,es,r) = test { _testState = Large (-1), _testReproducer = txs, _testEvents = es, _testResult = r } 
-updateOpenTest test _   i (BoolValue True,_,_)   = test { _testState = Open (i + 1) } 
+updateOpenTest test txs _ (BoolValue False,es,r) = test { _testState = Large (-1), _testReproducer = txs, _testEvents = es, _testResult = r }
+updateOpenTest test _   i (BoolValue True,_,_)   = test { _testState = Open (i + 1) }
 
 
-updateOpenTest test txs i (IntValue v',es,r) = if v' > v then test { _testState = Open (i + 1), _testReproducer = txs, _testValue = IntValue v', _testEvents = es, _testResult = r } 
+updateOpenTest test txs i (IntValue v',es,r) = if v' > v then test { _testState = Open (i + 1), _testReproducer = txs, _testValue = IntValue v', _testEvents = es, _testResult = r }
                                                          else test { _testState = Open (i + 1) }
                                                 where v = case test ^. testValue of
                                                            IntValue x -> x
-                                                           _          -> error "Invalid type of value for optimization" 
+                                                           _          -> error "Invalid type of value for optimization"
 
 
 updateOpenTest _ _ _ _                       = error "Invalid type of test"
@@ -182,7 +178,7 @@ checkStatefullAssertion (sig, addr) = do
       -- Whether the last transaction called the function `sig`.
   let isCorrectFn = case viewBuffer $ vm ^. state . calldata . _1 of
         Just cd -> BS.isPrefixOf (BS.take 4 (abiCalldata (encodeSig sig) mempty)) cd
-        Nothing -> False 
+        Nothing -> False
       -- Whether the last transaction executed a function on the contract `addr`.
       isCorrectAddr = addr == vm ^. state . codeContract
       isCorrectTarget = isCorrectFn && isCorrectAddr
@@ -198,7 +194,7 @@ checkStatefullAssertion (sig, addr) = do
   pure (BoolValue (not isFailure), events, getResultFromVM vm)
 
 assumeMagicReturnCode :: BS.ByteString
-assumeMagicReturnCode = "FOUNDRY::ASSUME\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0" 
+assumeMagicReturnCode = "FOUNDRY::ASSUME\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
 
 checkDapptestAssertion :: (MonadReader x m, Has TestConf x, Has TxConf x, Has DappInfo x, MonadState y m, Has VM y, MonadThrow m)
            => (SolSignature, Addr) -> m (TestValue, Events, TxResult)
@@ -210,14 +206,14 @@ checkDapptestAssertion (sig, addr) = do
       -- Whether the last transaction called the function `sig`.
   let isCorrectFn = case viewBuffer $ vm ^. state . calldata . _1 of
         Just cd -> BS.isPrefixOf (BS.take 4 (abiCalldata (encodeSig sig) mempty)) cd
-        Nothing -> False 
+        Nothing -> False
       isAssertionFailure = case vm ^. result of
-        Just (VMFailure (Revert bs)) -> not $ BS.isSuffixOf assumeMagicReturnCode bs 
+        Just (VMFailure (Revert bs)) -> not $ BS.isSuffixOf assumeMagicReturnCode bs
         Just (VMFailure _)           -> True
         _                            -> False
       isCorrectAddr = addr == vm ^. state . codeContract
-      isCorrectTarget = isCorrectFn && isCorrectAddr 
-      events = extractEvents dappInfo vm 
+      isCorrectTarget = isCorrectFn && isCorrectAddr
+      events = extractEvents dappInfo vm
       isFailure = not hasValue && (isCorrectTarget && isAssertionFailure)
   pure (BoolValue (not isFailure), events, getResultFromVM vm)
 
@@ -230,7 +226,7 @@ checkCall f = do
   pure (f dappInfo vm, extractEvents dappInfo vm, getResultFromVM vm)
 
 checkAssertionTest :: DappInfo -> VM -> TestValue
-checkAssertionTest dappInfo vm = 
+checkAssertionTest dappInfo vm =
   let events = extractEvents dappInfo vm
   in BoolValue $ null events || not (checkAssertionEvent events)
 
@@ -251,6 +247,6 @@ checkPanicEvent :: T.Text -> Events -> Bool
 checkPanicEvent n = any (T.isPrefixOf ("Panic(" <> n <> ")"))
 
 checkOverflowTest :: DappInfo -> VM -> TestValue
-checkOverflowTest dappInfo vm = 
+checkOverflowTest dappInfo vm =
   let es = extractEvents dappInfo vm
   in BoolValue $ null es || not (checkPanicEvent "17" es)

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Echidna.Transaction where
@@ -15,18 +9,17 @@ import Control.Monad (join, liftM2)
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader)
 import Control.Monad.State.Strict (MonadState, State, runState, get, put)
+import Data.ByteString qualified as BS
+import Data.List.NonEmpty qualified as NE
 import Data.Has (Has(..))
+import Data.HashMap.Strict qualified as M
 import Data.Map (Map, toList)
 import Data.Maybe (catMaybes)
+import Data.Vector qualified as V
 import EVM hiding (value)
 import EVM.ABI (abiValueType)
-import EVM.Symbolic ( litWord, litAddr)
-import EVM.Types (Addr, Buffer(..),Word(..),w256, w256lit, SymWord)
-
-import qualified Data.ByteString as BS
-import qualified Data.HashMap.Strict as M
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Vector as V
+import EVM.Symbolic (litWord, litAddr)
+import EVM.Types (Addr, Buffer(..), Word(..), w256, w256lit, SymWord)
 
 import Echidna.ABI
 import Echidna.Types.Random

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TupleSections #-}
 
 module Echidna.Types.Campaign where
 

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -66,9 +66,8 @@ makeLenses ''Campaign
 
 instance ToJSON Campaign where
   toJSON (Campaign ts co gi _ _ _ _ _) = object $ ("tests", toJSON $ map format ts)
-    : ((if co == mempty then [] else [
-    ("coverage",) . toJSON . mapKeys (("0x" <>) . (`showHex` "") . keccak) $ toList <$> co]) ++
-       [(("maxgas",) . toJSON . toList) gi | gi /= mempty]) where
+    : [("coverage",) . toJSON . mapKeys (("0x" <>) . (`showHex` "") . keccak) $ toList <$> co | co /= mempty] ++
+      [(("maxgas",) . toJSON . toList) gi | gi /= mempty] where
         format _ = "" :: String -- TODO: complete this format string
 
 instance Has GenDict Campaign where

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -1,14 +1,11 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Echidna.Types.Config where
 
 import Control.Lens
+import Data.Has (Has(..))
 import Data.HashSet (HashSet)
 import Data.Text (Text)
-import Data.Has (Has(..))
 
 import EVM.Dapp (DappInfo)
 
@@ -20,7 +17,7 @@ import Echidna.UI
 import Echidna.UI.Report
 
 -- | Our big glorious global config type, just a product of each local config.,
-data EConfig = EConfig { 
+data EConfig = EConfig {
   _cConf :: CampaignConf,
   _nConf :: Names,
   _sConf :: SolConf,
@@ -31,7 +28,7 @@ data EConfig = EConfig {
 
 makeLenses ''EConfig
 
-data EConfigWithUsage = EConfigWithUsage { 
+data EConfigWithUsage = EConfigWithUsage {
   _econfig   :: EConfig,
   _badkeys   :: HashSet Text,
   _unsetkeys :: HashSet Text

--- a/lib/Echidna/Types/Coverage.hs
+++ b/lib/Echidna/Types/Coverage.hs
@@ -1,21 +1,21 @@
 module Echidna.Types.Coverage where
 
 import Control.Lens
-import Data.Set (Set, size, map)
-import Data.ByteString (ByteString) 
+import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
+import Data.Set (Set, size, map)
 
 import Echidna.Types.Tx (TxResult)
 
 -- Program Counter directly obtained from the EVM
 type PC = Int
--- Index per operation in the source code, obtained from the source mapping 
+-- Index per operation in the source code, obtained from the source mapping
 type OpIx = Int
 -- Stack size from the EVM
 type FrameCount = Int
 -- Basic coverage information
 type CoverageInfo = (PC, OpIx, FrameCount, TxResult)
--- Map with the coverage information needed for fuzzing and source code printing 
+-- Map with the coverage information needed for fuzzing and source code printing
 type CoverageMap = Map ByteString (Set CoverageInfo)
 
 -- | Given good point coverage, count unique points.
@@ -26,5 +26,3 @@ coveragePoints = sum . fmap size
 -- This is useful to report a coverage measure to the user
 scoveragePoints :: CoverageMap -> Int
 scoveragePoints = sum . fmap (size . Data.Set.map (view _1))
-
-

--- a/lib/Echidna/Types/Signature.hs
+++ b/lib/Echidna/Types/Signature.hs
@@ -1,17 +1,17 @@
 module Echidna.Types.Signature where
 
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.Foldable (find)
 import Data.HashMap.Strict (HashMap)
 import Data.List.NonEmpty (NonEmpty)
+import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import EVM.ABI (AbiType, AbiValue)
-import EVM.Types (Addr)
 import GHC.Word (Word32)
 
-import qualified Data.Map as M
-import qualified Data.ByteString as BS
+import EVM.ABI (AbiType, AbiValue)
+import EVM.Types (Addr)
 
 -- | Name of the contract
 type ContractName = Text

--- a/lib/Echidna/Types/Solidity.hs
+++ b/lib/Echidna/Types/Solidity.hs
@@ -1,23 +1,17 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Echidna.Types.Solidity where
 
-import Control.Lens
 import Control.Exception (Exception)
-import Data.Text         (Text)
-import Data.SemVer       (Version, version, toString)
+import Control.Lens
+import Data.List.NonEmpty qualified as NE
+import Data.SemVer (Version, version, toString)
+import Data.Text (Text)
 
 import EVM.Solidity
-import EVM.Types         (Addr)
+import EVM.Types (Addr)
 
-import Echidna.Types.Signature    (ContractName)
-
-import qualified Data.List.NonEmpty  as NE
+import Echidna.Types.Signature (ContractName)
 
 minSupportedSolcVersion :: Version
 minSupportedSolcVersion = version 0 4 25 [] []
@@ -38,7 +32,7 @@ data SolException = BadAddr Addr
                   | OnlyTests
                   | ConstructorArgs String
                   | DeploymentFailed Addr
-                  | SetUpCallFailed 
+                  | SetUpCallFailed
                   | NoCryticCompile
                   | InvalidMethodFilters Filter
                   | OutdatedSolcVersion Version
@@ -80,7 +74,7 @@ data SolConf = SolConf { _contractAddr    :: Addr             -- ^ Contract addr
                        , _quiet           :: Bool             -- ^ Suppress @solc@ output, errors, and warnings
                        , _initialize      :: Maybe FilePath   -- ^ Initialize world with Etheno txns
                        , _deployContracts :: [(Addr, String)] -- ^ List of contracts to deploy in specific addresses
-                       , _deployBytecodes :: [(Addr, Text)]   -- ^ List of contracts to deploy in specific addresses 
+                       , _deployBytecodes :: [(Addr, Text)]   -- ^ List of contracts to deploy in specific addresses
                        , _multiAbi        :: Bool             -- ^ Whether or not to use the multi-abi mode
                        , _testMode        :: String           -- ^ Testing mode
                        , _testDestruction :: Bool             -- ^ Whether or not to add a property to detect contract destruction
@@ -95,4 +89,4 @@ defaultContractAddr :: Addr
 defaultContractAddr = 0x00a329c0648769a73afac7f9381e08fb43dbea72
 
 defaultDeployerAddr :: Addr
-defaultDeployerAddr = 0x30000 
+defaultDeployerAddr = 0x30000

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -7,6 +7,7 @@ import Data.Aeson (ToJSON(..), object)
 import Data.DoubleWord (Int256)
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
+
 import EVM (VM)
 import EVM.Types (Addr)
 import EVM.Dapp (DappInfo)
@@ -51,7 +52,7 @@ instance Show TestValue where
 data TestType = PropertyTest Text Addr
               | OptimizationTest Text Addr
               | AssertionTest Bool SolSignature Addr
-              | CallTest Text (DappInfo -> VM -> TestValue) 
+              | CallTest Text (DappInfo -> VM -> TestValue)
               | Exploration
 
 instance Eq TestType where
@@ -65,20 +66,20 @@ instance Eq TestType where
 
 instance Eq TestState where
   (Open i)  == (Open j)    = i == j
-  (Large i) == (Large j)   = i == j 
+  (Large i) == (Large j)   = i == j
   Passed    == Passed      = True
   Solved    == Solved      = True
   _         == _           = False
 
 -- | An Echidna test is represented with the following data record
-data EchidnaTest = EchidnaTest { 
+data EchidnaTest = EchidnaTest {
                                  _testState      :: TestState
                                , _testType       :: TestType
                                , _testValue      :: TestValue
                                , _testReproducer :: [Tx]
                                , _testResult     :: TxResult
-                               , _testEvents     :: Events 
-                               } deriving Eq  
+                               , _testEvents     :: Events
+                               } deriving Eq
 
 makeLenses ''EchidnaTest
 
@@ -87,17 +88,17 @@ isOpen t = case t ^. testState of
             Open _ -> True
             _      -> False
 
-didFailed :: EchidnaTest -> Bool 
+didFailed :: EchidnaTest -> Bool
 didFailed t = case t ^. testState of
               Large _ -> True
               Solved  -> True
               _       -> False
- 
-isPassed :: EchidnaTest -> Bool 
+
+isPassed :: EchidnaTest -> Bool
 isPassed t = case t ^. testState of
               Passed -> True
               _      -> False
- 
+
 
 instance ToJSON TestState where
   toJSON s = object $ ("passed", toJSON passed) : maybeToList desc where

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -8,9 +8,10 @@ import Control.Lens.TH (makePrisms, makeLenses)
 import Data.Aeson.TH (deriveJSON, defaultOptions)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
+
 import EVM (VMResult(..), Error(..))
-import EVM.Types (Addr, W256, Word, w256)
 import EVM.ABI (encodeAbiValue, AbiValue(..))
+import EVM.Types (Addr, W256, Word, w256)
 
 import Echidna.Types.Buffer (viewBuffer)
 import Echidna.Orphans.JSON ()
@@ -96,7 +97,7 @@ createTxWithValue bc s d g = Tx (SolCreate bc) s d g 0
 data TxResult = ReturnTrue
               | ReturnFalse
               | Stop
-              | ErrorBalanceTooLow 
+              | ErrorBalanceTooLow
               | ErrorUnrecognizedOpcode
               | ErrorSelfDestruction
               | ErrorStackUnderrun

--- a/lib/Echidna/Types/World.hs
+++ b/lib/Echidna/Types/World.hs
@@ -4,12 +4,14 @@ module Echidna.Types.World where
 
 import Control.Lens.TH (makeLenses)
 import Data.List.NonEmpty (NonEmpty)
+
 import EVM.Types (Addr)
+
 import Echidna.Types.Signature (FunctionHash, SignatureMap)
 import Echidna.Events (EventMap)
 
--- | The world is composed by: 
---    * A list of "human" addresses 
+-- | The world is composed by:
+--    * A list of "human" addresses
 --    * A high-priority map of signatures from every contract
 --    * A low-priority map of signatures from every contract
 --    * A list of function hashes from payable functions

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Echidna.UI where
 
@@ -16,11 +11,10 @@ import Control.Monad.Catch (MonadCatch(..))
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader (MonadReader, runReader)
 import Control.Monad.Random.Strict (MonadRandom)
-import qualified Data.ByteString.Lazy as BS
+import Data.ByteString.Lazy qualified as BS
 import Data.Has (Has(..))
-import Data.Maybe (fromMaybe)
 import Data.IORef
-import EVM (VM)
+import Data.Maybe (fromMaybe)
 import Graphics.Vty (Config, Event(..), Key(..), Modifier(..), defaultConfig, inputMap, mkVty)
 import System.Posix.Terminal (queryTerminal)
 import System.Posix.Types (Fd(..))
@@ -28,9 +22,12 @@ import UnliftIO (MonadUnliftIO)
 import UnliftIO.Concurrent (forkIO, forkFinally)
 import UnliftIO.Timeout (timeout)
 
-import Echidna.Campaign (campaign)
+import EVM (VM)
+import EVM.Dapp (DappInfo)
+
 import Echidna.ABI
-import qualified Echidna.Output.JSON
+import Echidna.Campaign (campaign)
+import Echidna.Output.JSON qualified
 import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Campaign
 import Echidna.Types.Test (TestConf(..), EchidnaTest)
@@ -38,8 +35,6 @@ import Echidna.Types.Tx (Tx, TxConf)
 import Echidna.Types.World (World)
 import Echidna.UI.Report
 import Echidna.UI.Widgets
-
-import EVM.Dapp (DappInfo)
 
 data UIConf = UIConf { _maxTime       :: Maybe Int
                      , _operationMode :: OperationMode

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Echidna.UI.Report where
 
 import Control.Lens
@@ -10,16 +7,16 @@ import Data.List (intercalate, nub, sortOn)
 import Data.Map (toList)
 import Data.Maybe (catMaybes)
 import Data.Text (Text, unpack)
+import Data.Text qualified as T
+
 import EVM.Types (Addr)
 
-import qualified Data.Text as T
-
 import Echidna.ABI (defSeed, encodeSig)
-import Echidna.Types.Coverage (CoverageMap, scoveragePoints)
 import Echidna.Events (Events)
 import Echidna.Pretty (ppTxCall)
 import Echidna.Types.Campaign
 import Echidna.Types.Corpus (Corpus, corpusSize)
+import Echidna.Types.Coverage (CoverageMap, scoveragePoints)
 import Echidna.Types.Test (testEvents, testState, TestState(..), testType, TestType(..), testReproducer, testValue)
 import Echidna.Types.Tx (Tx(Tx), TxCall(..), TxConf, txGas, src)
 
@@ -106,7 +103,7 @@ ppTests Campaign { _tests = ts } = unlines . catMaybes <$> mapM pp ts where
          CallTest n _          ->  Just . ((T.unpack n ++ ": ") ++) <$> ppTS (t ^. testState) (t ^. testEvents) (t ^. testReproducer)
          AssertionTest _ s _   ->  Just . ((T.unpack (encodeSig s) ++ ": ") ++) <$> ppTS (t ^. testState) (t ^. testEvents) (t ^. testReproducer)
          OptimizationTest n _  ->  Just . ((T.unpack n ++ ": max value: " ++ show (t ^. testValue)) ++) <$> ppTS (t ^. testState) (t ^. testEvents) (t ^. testReproducer)
-         Exploration           ->  return Nothing 
+         Exploration           ->  return Nothing
 
 ppCampaign :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Campaign -> m String
 ppCampaign c = do

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -1,23 +1,18 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Echidna.UI.Widgets where
 
 import Brick
+import Brick.AttrMap qualified as A
 import Brick.Widgets.Border
 import Brick.Widgets.Center
 import Control.Lens
 import Control.Monad.Reader (MonadReader)
 import Data.Has (Has(..))
 import Data.List (nub, intersperse, sortBy)
+import Data.Text qualified as T
 import Data.Version (showVersion)
+import Graphics.Vty qualified as V
+import Paths_echidna qualified (version)
 import Text.Printf (printf)
-
-import qualified Brick.AttrMap as A
-import qualified Data.Text as T
-import qualified Graphics.Vty as V
-import qualified Paths_echidna (version)
 
 import Echidna.ABI
 import Echidna.Campaign (isDone)
@@ -78,7 +73,7 @@ summaryWidget c =
 
 failedFirst :: EchidnaTest -> EchidnaTest -> Ordering
 failedFirst t1 _ | didFailed t1 = LT
-                 | otherwise   = GT 
+                 | otherwise   = GT
 
 testsWidget :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x)
             => [EchidnaTest] -> m (Widget())
@@ -90,10 +85,10 @@ testWidget etest =
  case etest ^. testType of
       Exploration           -> widget tsWidget "exploration" ""
       PropertyTest n _      -> widget tsWidget n ""
-      OptimizationTest n _  -> widget optWidget n "optimizing " 
+      OptimizationTest n _  -> widget optWidget n "optimizing "
       AssertionTest _ s _   -> widget tsWidget (encodeSig s) "assertion in "
       CallTest n _          -> widget tsWidget n ""
- 
+
   where
   widget f n infront = do
     (status, details) <- f (etest ^. testState) etest

--- a/package.yaml
+++ b/package.yaml
@@ -59,6 +59,17 @@ dependencies:
 
 default-extensions:
   - OverloadedStrings
+  # GHC2021 default extensions from 9.2
+  - FlexibleContexts
+  - FlexibleInstances
+  - ImportQualifiedPost
+  - LambdaCase
+  - MultiParamTypeClasses
+  - NamedFieldPuns
+  - RankNTypes
+  - ScopedTypeVariables
+  - StandaloneDeriving
+  - TupleSections
 
 library:
   source-dirs: lib/

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,16 +6,21 @@ import Control.Lens hiding (argument)
 import Control.Monad (unless)
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.Random (getRandom)
+import Data.List.NonEmpty qualified as NE
+import Data.Map (fromList)
 import Data.Maybe (fromMaybe)
+import Data.Set qualified as DS
 import Data.Text (Text, unpack)
 import Data.Time.Clock.System (getSystemTime, systemSeconds)
 import Data.Version (showVersion)
-import Data.Map (fromList)
 import EVM.Types (Addr)
 import Options.Applicative
 import Paths_echidna (version)
 import System.Exit (exitWith, exitSuccess, ExitCode(..))
 import System.IO (hPutStrLn, stderr)
+
+import EVM.Dapp (dappInfo)
+import EVM.Solidity (contractName)
 
 import Echidna
 import Echidna.Config
@@ -28,12 +33,6 @@ import Echidna.Campaign (isSuccess)
 import Echidna.UI
 import Echidna.Output.Source
 import Echidna.Output.Corpus
-
-import EVM.Dapp (dappInfo)
-import EVM.Solidity (contractName)
-
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Set as DS
 
 data Options = Options
   { cliFilePath         :: NE.NonEmpty FilePath

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 import Test.Tasty (defaultMain, testGroup)
 import System.Directory (withCurrentDirectory)
 import Tests.ABIv2 (abiv2Tests)

--- a/src/test/Tests/Compile.hs
+++ b/src/test/Tests/Compile.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE Rank2Types #-}
-
 module Tests.Compile (compilationTests) where
 
 import Test.Tasty (TestTree, testGroup)


### PR DESCRIPTION
This uses the new `ImportQualifiedPost` extensions that allows more natural placement of `qualified` keyword. I cleaned up the imports alphabetically, dividing them into common, hevm, and echidna as we tend to style this and made this consistent throughout the codebase.

We also use a lot of extensions that will become standard starting from GHC 9.2 - https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2021. I removed those from the sources and placed them as default extensions. When we update to 9.2 we can simply remove them from `package.yaml`.

EDIT: I had to update hlint action as it was too old and didn't recognize `ImportQualifiedPost`