### PR TITLE
Update to GHC 9.0.2

### DIFF
--- a/.github/scripts/build-macos-release.sh
+++ b/.github/scripts/build-macos-release.sh
@@ -12,7 +12,7 @@ fix_path()
     BINARY="$1"
     MATCH="$2"
     NEW="$3"
-    OLD=$(otool -L "$BINARY" | grep "$MATCH" | awk '{print $1}')
+    OLD=$(otool -L "$BINARY" | grep "${MATCH}\." | awk '{print $1}')
     install_name_tool -change "$OLD" "$NEW" "$BINARY"
     cp -n "$OLD" "$(dirname "$BINARY")/$(basename "$NEW")" || true
 }

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,7 @@
 { pkgs ? import (builtins.fetchTarball {
-    name = "nixpkgs-unstable-2022-02-10";
-    url = "https://github.com/nixos/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz";
-    sha256 = "sha256:0zg7ak2mcmwzi2kg29g4v9fvbvs0viykjsg2pwaphm1fi13s7s0i";
-  }) {},
-  newerPkgs ? import (builtins.fetchTarball {
-    name = "nixpkgs-22.05-darwin-2022-06-27";
-    url = "https://github.com/nixos/nixpkgs/archive/ce6aa13369b667ac2542593170993504932eb836.tar.gz";
-    sha256 = "sha256:0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
+    name = "nixpkgs-unstable-2022-11-15";
+    url = "https://github.com/nixos/nixpkgs/archive/97b8d9459f7922ce0e666113a1e8e6071424ae16.tar.gz";
+    sha256 = "sha256:0nhmvgy2w4d9dxx4jvsy5hhzk29h8bb5z0850bdh82a3k157dnxc";
   }) {},
   profiling ? false,
   tests ? false
@@ -36,7 +31,7 @@ let
 
   v = "2.0.3";
 
-  testInputs = [ newerPkgs.slither-analyzer solc ];
+  testInputs = [ pkgs.slither-analyzer solc ];
 
   f = { mkDerivation, aeson, ansi-terminal, base, base16-bytestring, binary
       , brick, bytestring, containers, data-dword, data-has, deepseq
@@ -64,7 +59,7 @@ let
         testHaskellDepends = [ tasty tasty-hunit tasty-quickcheck ];
         testToolDepends = testInputs;
         configureFlags = if profiling then [ "--enable-profiling" "--enable-library-profiling" ] else [];
-        libraryToolDepends = [ hpack newerPkgs.slither-analyzer solc ];
+        libraryToolDepends = [ hpack pkgs.slither-analyzer solc ];
         preConfigure = ''
           hpack
           # re-enable dynamic build for Linux
@@ -76,20 +71,7 @@ let
         mainProgram = "echidna-test";
       };
 
-  dapptools = pkgs.fetchFromGitHub {
-    owner = "dapphub";
-    repo = "dapptools";
-    rev = "hevm/0.49.0";
-    sha256 = "sha256-giBcHTlFV1zJVgdbzWmezPdtPRdJQbocBEmuenBFVqk";
-  };
-
-  hevm = pkgs.haskell.lib.dontCheck (
-    pkgs.haskell.lib.doJailbreak (
-      pkgs.haskellPackages.callCabal2nix "hevm" "${dapptools}/src/hevm"
-        { secp256k1 = pkgs.secp256k1; }
-  ));
-
-  echidna = pkgs.haskellPackages.callPackage f { hevm = hevm; };
+  echidna = pkgs.haskellPackages.callPackage f { };
   echidnaShell = pkgs.haskellPackages.shellFor {
     packages = p: [ echidna ];
     shellHook = "hpack";

--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,12 @@
 {
   "nodes": {
-    "newerNixpkgs": {
-      "locked": {
-        "lastModified": 1659009481,
-        "narHash": "sha256-BRM5R7AMKa58NAJnZsmWsVhDxuGllnhTvpVEZ+sP49I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "2d9b7cb5f0a41da95fccc120acf730fd20d8598d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659009481,
-        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "lastModified": 1668462796,
+        "narHash": "sha256-MdQVi7GvWqTY5vldTC+HDNm6sEKl89MBbesudjwEkgo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "rev": "b3a285628a6928f62cdf4d09f4e656f7ecbbcafb",
         "type": "github"
       },
       "original": {
@@ -32,7 +17,6 @@
     },
     "root": {
       "inputs": {
-        "newerNixpkgs": "newerNixpkgs",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,25 +6,20 @@
 
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs;
-    newerNixpkgs.url = github:NixOS/nixpkgs;
   };
 
-  outputs = { self, nixpkgs, newerNixpkgs }: {
+  outputs = { self, nixpkgs }: {
     defaultPackage.x86_64-linux = import ./. {
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      newerPkgs = newerNixpkgs.legacyPackages.x86_64-linux;
     };
     defaultPackage.aarch64-linux = import ./. {
       pkgs = nixpkgs.legacyPackages.aarch64-linux;
-      newerPkgs = newerNixpkgs.legacyPackages.aarch64-linux;
     };
     defaultPackage.x86_64-darwin = import ./. {
       pkgs = nixpkgs.legacyPackages.x86_64-darwin;
-      newerPkgs = newerNixpkgs.legacyPackages.x86_64-darwin;
     };
     defaultPackage.aarch64-darwin = import ./. {
       pkgs = nixpkgs.legacyPackages.aarch64-darwin;
-      newerPkgs = newerNixpkgs.legacyPackages.aarch64-darwin;
     };
   };
 }

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -8,11 +8,11 @@ import Control.Monad.Reader (Reader, ReaderT(..), runReader)
 import Control.Monad.State (StateT(..), runStateT)
 import Control.Monad.Trans (lift)
 import Data.Aeson
+import Data.Aeson.KeyMap (keys)
 import Data.Bool (bool)
 import Data.ByteString qualified as BS
 import Data.List.NonEmpty qualified as NE
 import Data.Has (Has(..))
-import Data.HashMap.Strict (keys)
 import Data.HashSet (fromList, insert, difference)
 import Data.Maybe (fromMaybe)
 import Data.Text (isPrefixOf)

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -3,9 +3,9 @@
 module Echidna.Types.Config where
 
 import Control.Lens
+import Data.Aeson.Key (Key)
 import Data.Has (Has(..))
 import Data.HashSet (HashSet)
-import Data.Text (Text)
 
 import EVM.Dapp (DappInfo)
 
@@ -30,8 +30,8 @@ makeLenses ''EConfig
 
 data EConfigWithUsage = EConfigWithUsage {
   _econfig   :: EConfig,
-  _badkeys   :: HashSet Text,
-  _unsetkeys :: HashSet Text
+  _badkeys   :: HashSet Key,
+  _unsetkeys :: HashSet Key
 }
 
 makeLenses ''EConfigWithUsage

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,11 +6,12 @@ import Control.Lens hiding (argument)
 import Control.Monad (unless)
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.Random (getRandom)
+import Data.Aeson.Key qualified as Aeson.Key
 import Data.List.NonEmpty qualified as NE
 import Data.Map (fromList)
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as DS
-import Data.Text (Text, unpack)
+import Data.Text (Text)
 import Data.Time.Clock.System (getSystemTime, systemSeconds)
 import Data.Version (showVersion)
 import EVM.Types (Addr)
@@ -116,7 +117,8 @@ main = do
   g <- getRandom
   EConfigWithUsage loadedCfg ks _ <- maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig cliConfigFilepath
   let cfg = overrideConfig loadedCfg opts
-  unless (cfg ^. sConf . quiet) $ mapM_ (hPutStrLn stderr . ("Warning: unused option: " ++) . unpack) ks
+  unless (cfg ^. sConf . quiet) $
+    mapM_ (hPutStrLn stderr . ("Warning: unused option: " ++) . Aeson.Key.toString) ks
   let cd = cfg ^. cConf . corpusDir
 
   (sc, cs, cpg) <- flip runReaderT cfg $ do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,24 +1,18 @@
-resolver: lts-17.14
+resolver: lts-19.33
 
 packages:
 - '.'
 
 extra-deps:
-- git: https://github.com/dapphub/dapptools.git
-  commit: fb9476ded759da44c449eb391cc67bfb0df61112
+- git: https://github.com/crytic/dapptools.git
+  commit: f1ccf43e466b4fdfee4b18d137bd393632d5afda
   subdirs:
   - src/hevm
 
-- base16-bytestring-1.0.1.0@sha256:33b9d57afa334d06485033e930c6b13fc760baf88fd8f715ae2f9a4b46e19a54,2641
 - restless-git-0.7@sha256:346a5775a586f07ecb291036a8d3016c3484ccdc188b574bcdec0a82c12db293,968
 - s-cargot-0.1.4.0@sha256:61ea1833fbb4c80d93577144870e449d2007d311c34d74252850bb48aa8c31fb,3525
-- sbv-8.15@sha256:bc0ea4e3564626030ac2cb21905b97cd9bd25fddcd6d6010834e8cc2ebf79067,29016
 - semver-range-0.2.8@sha256:44918080c220cf67b6e7c8ad16f01f3cfe1ac69d4f72e528e84d566348bb23c3,1941
-- tree-view-0.5.1@sha256:a32b16fdbe24ad21cb6679c2a925bcc7715ae5c5db0ae6b633e35e28e2fefd98,1184
-- witherable-0.4.1@sha256:5b4840efe20d16cab6b13fa2f39ed383703cccbc246f5b710591069fcc6884c0,2249
 - HSH-2.1.3@sha256:71ded11b224f5066373ce985ec63b10c87129850b33916736dd64fa2bea9ea0a,1705
-- indexed-traversable-instances-0.1@sha256:3aaf97040001bbe583e29c2b9c7d41660df265e6565a0d2ac09a3ed5b8bc21be,2874
-- libBF-0.6.3@sha256:ad38e44a038b8da62c82a58b8a762331097569c27a5978258caed8b28cda73e2,1770
 
 extra-include-dirs:
 - /usr/local/opt/readline/include


### PR DESCRIPTION
This builds upon the work I did in https://github.com/NixOS/nixpkgs/pull/190144. Both nix and stack are updated. We are using now pre-built hevm from nixpkgs. For stack I had to fork dapptools and add the patch that I created for nixpkgs https://github.com/crytic/dapptools/tree/hevm/0.49.0-updated-deps. This is a temporary solution until hevm 0.50.0 is released. The upside is that we are now up to date and migration to 0.50.0 will be easier.