### PR TITLE
Fix a small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Then, you can run the `echidna` image locally. For example, to install solc
 0.5.7 and check `tests/solidity/basic/flags.sol`, you can run:
 
 ```sh
-$ docker run -it -v `pwd`:/src echidna bash -c "solc-select install 0.5.7 && solc-select use 0.5.7 && echidna-test /src/tests/solidity/basic/flags.sol"
+$ docker run -it -v `pwd`:/src echidna bash -c "solc-select install 0.5.7 && solc-select use 0.5.7 && echidna-test src/tests/solidity/basic/flags.sol"
 ```
 
 ### Building using Stack


### PR DESCRIPTION
Fixed very small typo in post-installation test run instructions. A stray `/` before `src/tests/solidity/basic/flags.sol` was causing a file not found error.