### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ EVM emulation and testing is hard. Echidna has a number of limitations in the la
 | Lack of support for function pointers in Solidity | [#798](https://github.com/crytic/echidna/issues/798) | *on hold* |
 ## Installation
 
+### Precompiled binaries
+
+Before starting, make sure Slither is [installed](https://github.com/crytic/slither) (`pip3 install slither-analyzer --user`).
+If you want to quickly test Echidna in Linux or MacOS, we provide statically linked Linux binaries built on Ubuntu and mostly static MacOS binaries on our [releases page](https://github.com/crytic/echidna/releases). You can also grab the same type of binaries from our [CI pipeline](https://github.com/crytic/echidna/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush), just click the commit to find binaries for Linux or MacOS.
+
 ### Homebrew (macOS / Linux)
 
 If you have Homebrew installed on your Mac or Linux machine, you can install Echidna and all of its dependencies (Slither, crytic-compile) by running `brew install echidna`.
@@ -180,11 +185,6 @@ If you have Homebrew installed on your Mac or Linux machine, you can install Ech
 You can also compile and install the latest `master` branch code by running `brew install --HEAD echidna`
 
 You can get further information in the [`echidna` Homebrew Formula](https://formulae.brew.sh/formula/echidna) page. The formula itself is maintained as part of the [homebrew-core repository](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/echidna.rb)
-
-### Precompiled binaries
-
-Before starting, make sure Slither is [installed](https://github.com/crytic/slither) (`pip3 install slither-analyzer --user`).
-If you want to quickly test Echidna in Linux or MacOS, we provide statically linked Linux binaries built on Ubuntu and mostly static MacOS binaries on our [releases page](https://github.com/crytic/echidna/releases). You can also grab the same type of binaries from our [CI pipeline](https://github.com/crytic/echidna/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush), just click the commit to find binaries for Linux or MacOS.
 
 ### Docker container
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ EVM emulation and testing is hard. Echidna has a number of limitations in the la
 | Lack of support for function pointers in Solidity | [#798](https://github.com/crytic/echidna/issues/798) | *on hold* |
 ## Installation
 
+### Building using Homebrew (MacOS)
+
+You can install Echidna with `brew install echidna`.
+
 ### Precompiled binaries
 
 Before starting, make sure Slither is [installed](https://github.com/crytic/slither) (`pip3 install slither-analyzer --user`).

--- a/README.md
+++ b/README.md
@@ -173,9 +173,13 @@ EVM emulation and testing is hard. Echidna has a number of limitations in the la
 | Lack of support for function pointers in Solidity | [#798](https://github.com/crytic/echidna/issues/798) | *on hold* |
 ## Installation
 
-### Building using Homebrew (MacOS)
+### Homebrew (macOS / Linux)
 
-You can install Echidna with `brew install echidna`.
+If you have Homebrew installed on your Mac or Linux machine, you can install Echidna and all of its dependencies (Slither, crytic-compile) by running `brew install echidna`.
+
+You can also compile and install the latest `master` branch code by running `brew install --HEAD echidna`
+
+You can get further information in the [`echidna` Homebrew Formula](https://formulae.brew.sh/formula/echidna) page. The formula itself is maintained as part of the [homebrew-core repository](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/echidna.rb)
 
 ### Precompiled binaries
 


### PR DESCRIPTION
During the "Learn how to fuzz like a pro" workshop (16.11.2022) Anish mentioned that it is possible to install echidna with Homebrew. It seems that this information is missing in the main Echidna readme. I've spent some time fighting with the docker container setup and later found out that you can simply `brew install echidna`. I think that adding this information would be helpful for beginner users like me. 

Such instruction is already present in the [building secure smart contracts repo](https://github.com/crytic/building-secure-contracts/tree/master/program-analysis/echidna#installation).