### PR TITLE
ci: use ubuntu-20.04 for builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             apt-get: autoconf automake libtool
           - os: macos-latest
             brew: automake


### PR DESCRIPTION
Stack GHC fails to link statically on Ubuntu 22.04