### PR TITLE
Forcelit when showing address in events

### DIFF
--- a/lib/Echidna/Events.hs
+++ b/lib/Echidna/Events.hs
@@ -20,6 +20,8 @@ import EVM.Format (showValues, showError, contractNamePart)
 import EVM.Types (Expr(ConcreteBuf), W256, maybeLitWord)
 import EVM.Solidity (contractName)
 
+import Echidna.Types.Buffer (forceLit)
+
 type EventMap = M.Map W256 Event
 type Events = [Text]
 
@@ -53,7 +55,7 @@ extractEvents decodeErrors dappInfo' vm =
                                 showValues [t | (_, t, NotIndexed) <- types] bytes <>
                                 pack " from: " <>
                                 maybe mempty (\ x -> x <> pack "@") maybeContractName <>
-                                pack (show addr)]
+                                pack (show $ forceLit addr)]
                              Nothing -> [pack $ show word]
           ErrorTrace e ->
             case e of

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -18,12 +18,12 @@ import Data.Set (Set)
 import Data.Vector qualified as V
 import EVM hiding (value)
 import EVM.ABI (abiValueType)
-import EVM.Types (Expr(ConcreteBuf, Lit), EType(EWord), Addr, W256)
+import EVM.Types (Expr(ConcreteBuf, Lit), Addr, W256)
 
 import Echidna.ABI
 import Echidna.Types.Random
 import Echidna.Orphans.JSON ()
-import Echidna.Types.Buffer (viewBuffer)
+import Echidna.Types.Buffer (viewBuffer, forceLit)
 import Echidna.Types.Signature (SignatureMap, SolCall, ContractA, FunctionHash, BytecodeMemo, lookupBytecodeMetadata)
 import Echidna.Types.Tx
 import Echidna.Types.World (World(..))
@@ -148,8 +148,3 @@ setupTx (Tx c s r g gp v (t, b)) = liftSH . sequence_ $
     incrementBalance = (env . contracts . ix r . balance) += v
     encode (n, vs) = abiCalldata
       (encodeSig (n, abiValueType <$> vs)) $ V.fromList vs
-
-forceLit :: Expr 'EWord -> W256
-forceLit x = case x of
-  Lit x' -> x'
-  _ -> error "expected Lit"

--- a/lib/Echidna/Types/Buffer.hs
+++ b/lib/Echidna/Types/Buffer.hs
@@ -3,8 +3,13 @@
 module Echidna.Types.Buffer where
 
 import Data.ByteString (ByteString)
-import EVM.Types (Expr(ConcreteBuf), EType(Buf))
+import EVM.Types (Expr(ConcreteBuf, Lit), EType(Buf), EType(EWord), W256)
 
 viewBuffer :: Expr 'Buf -> Maybe ByteString
 viewBuffer (ConcreteBuf b) = Just b
 viewBuffer _ = Nothing
+
+forceLit :: Expr 'EWord -> W256
+forceLit x = case x of
+  Lit x' -> x'
+  _ -> error "expected Lit"


### PR DESCRIPTION
This will avoid showing "Lit X" when printing an address X.