### PR TITLE
Refactor and simplify code to not use Data.Has

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -6,17 +6,16 @@
 module Echidna.Campaign where
 
 import Control.Lens
-import Control.Monad (liftM3, replicateM, when, (<=<), ap, unless)
+import Control.Monad (replicateM, when, (<=<), ap, unless)
 import Control.Monad.Catch (MonadCatch(..), MonadThrow(..))
 import Control.Monad.Random.Strict (MonadRandom, RandT, evalRandT, getRandomR, uniform, uniformMay)
 import Control.Monad.Reader.Class (MonadReader)
-import Control.Monad.Reader (runReaderT)
-import Control.Monad.State.Strict (MonadState(..), StateT(..), evalStateT, execStateT)
+import Control.Monad.Reader (runReaderT, asks)
+import Control.Monad.State.Strict (MonadState(..), StateT(..), evalStateT, execStateT, gets)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Random.Strict (liftCatch)
 import Data.Binary.Get (runGetOrFail)
 import Data.Bool (bool)
-import Data.Has (Has(..))
 import Data.HashMap.Strict qualified as H
 import Data.HashSet qualified as S
 import Data.Map (Map, unionWith, (\\), elems, keys, lookup, insert, mapWithKey)
@@ -26,8 +25,7 @@ import Data.Set qualified as DS
 import Data.Text (Text)
 import System.Random (mkStdGen)
 
-import EVM
-import EVM.Dapp (DappInfo)
+import EVM (Contract, VM, VMResult(..), bytecode, contracts, env)
 import EVM.ABI (getAbi, AbiType(AbiAddressType), AbiValue(AbiAddress))
 import EVM.Types (Addr, Expr(ConcreteBuf))
 
@@ -37,13 +35,14 @@ import Echidna.Test
 import Echidna.Transaction
 import Echidna.Shrink (shrinkSeq)
 import Echidna.Types.Campaign
+import Echidna.Types.Config
 import Echidna.Types.Corpus (InitialCorpus)
 import Echidna.Types.Coverage (coveragePoints)
 import Echidna.Types.Test
 import Echidna.Types.Buffer (viewBuffer)
 import Echidna.Types.Signature (makeBytecodeMemo)
-import Echidna.Types.Tx (TxCall(..), Tx(..), TxConf, getResult, src, call, _SolCall)
-import Echidna.Types.Solidity (SolConf(..), sender)
+import Echidna.Types.Tx (TxCall(..), Tx(..), getResult, src, call, _SolCall)
+import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.World (World)
 import Echidna.Mutator.Corpus
 
@@ -54,19 +53,18 @@ instance MonadCatch m => MonadCatch (RandT g m) where
 
 -- | Given a 'Campaign', checks if we can attempt any solves or shrinks without exceeding
 -- the limits defined in our 'CampaignConf'.
-isDone :: (MonadReader x m, Has CampaignConf x) => Campaign -> m Bool
+isDone :: MonadReader EConfig m => Campaign -> m Bool
 isDone c | null (view tests c) = do
-  tl <- view (hasLens . testLimit)
-  q <- view (hasLens . seqLen)
-  return $ view ncallseqs c * q >= tl
+  conf <- asks (._cConf)
+  pure $ c._ncallseqs * conf._seqLen >= conf._testLimit
 isDone (view tests -> ts) = do
-  (tl, sl, sof) <- view (hasLens . to (liftM3 (,,) _testLimit _shrinkLimit _stopOnFail))
-  let res (Open  i)   = if i >= tl then Just True else Nothing
+  conf <- asks (._cConf)
+  let res (Open  i)   = if i >= conf._testLimit then Just True else Nothing
       res Passed      = Just True
-      res (Large i)   = if i >= sl then Just False else Nothing
+      res (Large i)   = if i >= conf._shrinkLimit then Just False else Nothing
       res Solved      = Just False
       res (Failed _)  = Just False
-  pure $ res . view testState <$> ts & if sof then elem $ Just False else all isJust
+  pure $ res . (._testState) <$> ts & if conf._stopOnFail then elem $ Just False else all isJust
 
 -- | Given a 'Campaign', check if the test results should be reported as a
 -- success or a failure.
@@ -80,13 +78,12 @@ isSuccess = allOf (tests . traverse . testState) (\case { Passed -> True; Open _
 -- (2): The test is 'Open', and evaluating it breaks our runtime
 -- (3): The test is unshrunk, and we can shrink it
 -- Then update accordingly, keeping track of how many times we've tried to solve or shrink.
-updateTest :: ( MonadCatch m, MonadRandom m, MonadReader x m
-              , Has SolConf x, Has TestConf x, Has TxConf x, Has CampaignConf x, Has DappInfo x)
+updateTest :: (MonadCatch m, MonadRandom m, MonadReader Env m)
            => World -> VM -> Maybe (VM, [Tx]) -> EchidnaTest -> m EchidnaTest
 
 
 updateTest w vm (Just (vm', xs)) test = do
-  tl <- view (hasLens . testLimit)
+  tl <- asks (.cfg._cConf._testLimit)
   case test ^. testState of
     Open i | i >= tl -> case test ^. testType of
                           OptimizationTest _ _ -> pure $ test { _testState = Large (-1) }
@@ -96,7 +93,7 @@ updateTest w vm (Just (vm', xs)) test = do
     _                -> updateTest w vm Nothing test
 
 updateTest _ vm Nothing test = do
-  sl <- view (hasLens . shrinkLimit)
+  sl <- asks (.cfg._cConf._shrinkLimit)
   let es = test ^. testEvents
       res = test ^. testResult
       x = test ^. testReproducer
@@ -112,27 +109,25 @@ updateTest _ vm Nothing test = do
 
 
 -- | Given a rule for updating a particular test's state, apply it to each test in a 'Campaign'.
-runUpdate :: (MonadReader x m, Has TxConf x, MonadState y m, Has Campaign y)
+runUpdate :: (MonadReader Env m, MonadState Campaign m)
           => (EchidnaTest -> m EchidnaTest) -> m ()
-runUpdate f = let l = hasLens . tests in use l >>= mapM f >>= (l .=)
+runUpdate f = let l = tests in use l >>= mapM f >>= (l .=)
 
 -- | Given an initial 'VM' state and a way to run transactions, evaluate a list of transactions, constantly
 -- checking if we've solved any tests or can shrink known solves.
-evalSeq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
-           , Has SolConf x, Has TestConf x, Has TxConf x, Has CampaignConf x, Has DappInfo x
-           , Has Campaign y, Has VM y)
+evalSeq :: (MonadCatch m, MonadRandom m, MonadReader Env m, MonadState (VM, Campaign) m)
         => World -> VM -> (Tx -> m a) -> [Tx] -> m [(Tx, a)]
 evalSeq w v e = go [] where
   go r xs = do
-    v' <- use hasLens
-    runUpdate (updateTest w v $ Just (v', reverse r))
+    (v', camp) <- get
+    camp' <- execStateT (runUpdate (updateTest w v $ Just (v', reverse r))) camp
+    put (v', camp')
     case xs of []     -> pure []
                (y:ys) -> e y >>= \a -> ((y, a) :) <$> go (y:r) ys
 
 -- | Given a call sequence that produces Tx with gas >= g for f, try to randomly generate
 -- a smaller one that achieves at least that gas usage
-shrinkGasSeq :: ( MonadRandom m, MonadReader x m, MonadThrow m
-                , Has SolConf x, Has TestConf x, Has TxConf x, MonadState y m, Has VM y)
+shrinkGasSeq :: (MonadRandom m, MonadReader Env m, MonadThrow m, MonadState VM m)
           => Text -> Int -> [Tx] -> m [Tx]
 shrinkGasSeq f g xs = sequence [shorten, shrunk] >>= uniform >>= ap (fmap . flip bool xs) check where
   callsF f' t = t ^? call . _SolCall . _1 == Just f'
@@ -141,7 +136,7 @@ shrinkGasSeq f g xs = sequence [shorten, shrunk] >>= uniform >>= ap (fmap . flip
     pure $ (snd . head) res >= g
   check _ = pure False
   shrinkSender x = do
-    l <- view (hasLens . sender)
+    l <- asks (.cfg._sConf._sender)
     case ifind (const (== x ^. src)) l of
       Nothing     -> pure x
       Just (i, _) -> flip (set src) x . fromMaybe (x ^. src) <$> uniformMay (l ^.. folded . indices (< i))
@@ -165,12 +160,12 @@ updateGasInfo ((t, _):ts) tseq gi = updateGasInfo ts (t:tseq) gi
 
 -- | Execute a transaction, capturing the PC and codehash of each instruction executed, saving the
 -- transaction if it finds new coverage.
-execTxOptC :: (MonadState x m, Has Campaign x, Has VM x, MonadThrow m) => Tx -> m (VMResult, Int)
+execTxOptC :: (MonadState (VM, Campaign) m, MonadThrow m) => Tx -> m (VMResult, Int)
 execTxOptC t = do
-  let cov = hasLens . coverage
+  (_, camp) <- get
+  let cov = _2 . coverage
   og   <- cov <<.= mempty
-  memo <- use $ hasLens . bcMemo
-  res  <- execTxWith vmExcept (execTxWithCov memo cov) t
+  res  <- execTxWith _1 vmExcept (execTxWithCov camp._bcMemo) t
   let vmr = getResult $ fst res
   -- Update the coverage map with the proper binary according to the vm result
   cov %= mapWithKey (\_ s -> DS.map (set _4 vmr) s)
@@ -178,23 +173,22 @@ execTxOptC t = do
   cov %= unionWith DS.union og
   grew <- (== LT) . comparing coveragePoints og <$> use cov
   when grew $ do
-    hasLens . genDict %= gaddCalls ([t ^. call] ^.. traverse . _SolCall)
-    hasLens . newCoverage .= True
+    _2 . genDict %= gaddCalls ([t ^. call] ^.. traverse . _SolCall)
+    _2 . newCoverage .= True
   return res
 
 -- | Given a list of transactions in the corpus, save them discarding reverted transactions
-addToCorpus :: (MonadState s m, Has Campaign s) => Int -> [(Tx, (VMResult, Int))] -> m ()
-addToCorpus n res = unless (null rtxs) $ hasLens . corpus %= DS.insert (toInteger n, rtxs)
+addToCorpus :: MonadState Campaign m => Int -> [(Tx, (VMResult, Int))] -> m ()
+addToCorpus n res = unless (null rtxs) $ corpus %= DS.insert (n, rtxs)
   where rtxs = fst <$> res
 
 -- | Generate a new sequences of transactions, either using the corpus or with randomly created transactions
-randseq :: ( MonadRandom m, MonadReader x m, MonadState y m
-           , Has TxConf x, Has TestConf x, Has CampaignConf x, Has GenDict y, Has Campaign y)
+randseq :: (MonadRandom m, MonadReader Env m, MonadState Campaign m)
         => InitialCorpus -> Int -> Map Addr Contract -> World -> m [Tx]
 randseq (n,txs) ql o w = do
-  ca <- use hasLens
-  cs <- view $ hasLens . mutConsts
-  txConf :: TxConf <- view hasLens
+  ca <- get
+  cs <- asks (.cfg._cConf._mutConsts)
+  txConf <- asks (.cfg._xConf)
   let ctxs = ca ^. corpus
       -- TODO: include reproducer when optimizing
       --rs   = filter (not . null) $ map (view testReproducer) $ ca ^. tests
@@ -202,7 +196,7 @@ randseq (n,txs) ql o w = do
   if n > p then -- Replay the transactions in the corpus, if we are executing the first iterations
     return $ txs !! p
   else do
-    memo <- use $ hasLens . bcMemo
+    memo <- gets (._bcMemo)
     -- Randomly generate new random transactions
     gtxs <- replicateM ql $ runReaderT (genTxM memo o) (w, txConf)
     -- Generate a random mutator
@@ -216,18 +210,21 @@ randseq (n,txs) ql o w = do
 
 -- | Given an initial 'VM' and 'World' state and a number of calls to generate, generate that many calls,
 -- constantly checking if we've solved any tests or can shrink known solves. Update coverage as a result
-callseq :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadState y m
-           , Has SolConf x, Has TestConf x, Has TxConf x, Has CampaignConf x, Has DappInfo x, Has Campaign y, Has GenDict y)
+callseq :: (MonadCatch m, MonadRandom m, MonadReader Env m, MonadState Campaign m)
         => InitialCorpus -> VM -> World -> Int -> m ()
 callseq ic v w ql = do
+  conf <- asks (.cfg._cConf)
   -- First, we figure out whether we need to execute with or without coverage optimization and gas info,
   -- and pick our execution function appropriately
-  coverageEnabled <- isJust <$> view (hasLens . knownCoverage)
-  let ef = if coverageEnabled then execTxOptC else execTx
+  let coverageEnabled = isJust conf._knownCoverage
+  let ef = if coverageEnabled then execTxOptC else (\t -> do (xd, ca) <- get
+                                                             (r, vm') <- runStateT (execTx t) xd
+                                                             put (vm', ca)
+                                                             pure r)
       old = v ^. env . EVM.contracts
-  gasEnabled <- view $ hasLens . estimateGas
+  let gasEnabled = conf._estimateGas
   -- Then, we get the current campaign state
-  ca <- use hasLens
+  ca <- get
   -- Then, we generate the actual transaction in the sequence
   is <- randseq ic ql old w
   -- We then run each call sequentially. This gives us the result of each call, plus a new state
@@ -238,22 +235,22 @@ callseq ic v w ql = do
       -- and construct a set to union to the constants table
       diffs = H.fromList [(AbiAddressType, S.fromList $ AbiAddress <$> diff)]
   -- Save the global campaign state (also vm state, but that gets reset before it's used)
-  hasLens .= snd s -- Update the gas estimation
-  when gasEnabled $ hasLens . gasInfo %= updateGasInfo res []
+  put (snd s) -- Update the gas estimation
+  when gasEnabled $ gasInfo %= updateGasInfo res []
   -- If there is new coverage, add the transaction list to the corpus
   when (s ^. _2 . newCoverage) $ addToCorpus (s ^. _2 . ncallseqs + 1) res
   -- Reset the new coverage flag
-  hasLens . newCoverage .= False
+  newCoverage .= False
   -- Keep track of the number of calls to `callseq`
-  hasLens . ncallseqs += 1
+  ncallseqs += 1
   -- Now we try to parse the return values as solidity constants, and add then to the 'GenDict'
-  types <- use $ hasLens . rTypes
+  types <- gets (._genDict._rTypes)
   let results = parse (map (\(t, (vr, _)) -> (t, vr)) res) types
       -- union the return results with the new addresses
       additions = H.unionWith S.union diffs results
   -- append to the constants dictionary
-  modifying (hasLens . genDict . constants) . H.unionWith S.union $ additions
-  modifying (hasLens . genDict . dictValues) . DS.union $ mkDictValues $ S.toList $ S.unions $ H.elems additions
+  modifying (genDict . constants) . H.unionWith S.union $ additions
+  modifying (genDict . dictValues) . DS.union $ mkDictValues $ S.toList $ S.unions $ H.elems additions
   where
     -- Given a list of transactions and a return typing rule, this checks whether we know the return
     -- type for each function called, and if we do, tries to parse the return value as a value of that
@@ -265,42 +262,33 @@ callseq ic v w ql = do
 
 -- | Run a fuzzing campaign given an initial universe state, some tests, and an optional dictionary
 -- to generate calls with. Return the 'Campaign' state once we can't solve or shrink anything.
-campaign :: ( MonadCatch m, MonadRandom m, MonadReader x m
-            , Has SolConf x, Has TestConf x, Has TxConf x, Has CampaignConf x, Has DappInfo x)
-         => StateT Campaign m a -- ^ Callback to run after each state update (for instrumentation)
-         -> VM                  -- ^ Initial VM state
-         -> World               -- ^ Initial world state
-         -> [EchidnaTest]       -- ^ Tests to evaluate
-         -> Maybe GenDict       -- ^ Optional generation dictionary
-         -> [[Tx]]              -- ^ Initial corpus of transactions
-         -> m Campaign
+campaign
+  :: (MonadCatch m, MonadRandom m, MonadReader Env m)
+  => StateT Campaign m a -- ^ Callback to run after each state update (for instrumentation)
+  -> VM                  -- ^ Initial VM state
+  -> World               -- ^ Initial world state
+  -> [EchidnaTest]       -- ^ Tests to evaluate
+  -> Maybe GenDict       -- ^ Optional generation dictionary
+  -> [[Tx]]              -- ^ Initial corpus of transactions
+  -> m Campaign
 campaign u vm w ts d txs = do
-  c <- fromMaybe mempty <$> view (hasLens . knownCoverage)
-  g <- view (hasLens . seed)
-  let effectiveSeed = fromMaybe (d' ^. defSeed) g
+  conf <- asks (.cfg._cConf)
+  let c = fromMaybe mempty (conf._knownCoverage)
+  let effectiveSeed = fromMaybe (d' ^. defSeed) conf._seed
       effectiveGenDict = d' { _defSeed = effectiveSeed }
       d' = fromMaybe defaultDict d
   execStateT
     (evalRandT runCampaign (mkStdGen effectiveSeed))
-    (Campaign
-      ts
-      c
-      mempty
-      effectiveGenDict
-      False
-      DS.empty
-      0
-      memo
-    )
+    (Campaign ts c mempty effectiveGenDict False DS.empty 0 memo)
   where
     -- "mapMaybe ..." is to get a list of all contracts
     ic          = (length txs, txs)
     memo        = makeBytecodeMemo . mapMaybe (viewBuffer . (^. bytecode)) . elems $ (vm ^. env . EVM.contracts)
     step        = runUpdate (updateTest w vm Nothing) >> lift u >> runCampaign
-    runCampaign = use (hasLens . tests . to (fmap (view testState))) >>= update
+    runCampaign = use (tests . to (fmap (view testState))) >>= update
     update c    = do
-      CampaignConf tl sof _ q sl _ _ _ _ _ <- view hasLens
-      Campaign { _ncallseqs } <- view hasLens <$> get
+      CampaignConf tl sof _ q sl _ _ _ _ _ <- asks (.cfg._cConf)
+      Campaign { _ncallseqs } <- get
       if | sof && any (\case Solved -> True; Failed _ -> True; _ -> False) c -> lift u
          | any (\case Open  n   -> n < tl; _ -> False) c                       -> callseq ic vm w q >> step
          | any (\case Large n   -> n < sl; _ -> False) c                       -> step

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -18,12 +18,12 @@ import EVM.Types (Expr(ConcreteBuf, Lit))
 
 import Echidna.Events (emptyEvents)
 import Echidna.Transaction
+import Echidna.Types (ExecException(..), fromEVM)
 import Echidna.Types.Buffer (viewBuffer)
 import Echidna.Types.Campaign
 import Echidna.Types.Coverage (CoverageMap)
 import Echidna.Types.Signature (BytecodeMemo, lookupBytecodeMetadata)
 import Echidna.Types.Tx (TxCall(..), Tx, TxResult(..), call, dst, initialTimestamp, initialBlockNumber)
-import Echidna.Types (ExecException(..))
 
 -- | Broad categories of execution failures: reversions, illegal operations, and ???.
 data ErrorClass = RevertE | IllegalE | UnknownE

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -5,9 +5,8 @@
 module Echidna.Exec where
 
 import Control.Lens
-import Control.Monad.Catch (Exception, MonadThrow(..))
-import Control.Monad.State.Strict (MonadState, execState, execState)
-import Data.Has (Has(..))
+import Control.Monad.Catch (MonadThrow(..))
+import Control.Monad.State.Strict (MonadState (get, put), execState, execState)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as S
@@ -20,9 +19,11 @@ import EVM.Types (Expr(ConcreteBuf, Lit))
 import Echidna.Events (emptyEvents)
 import Echidna.Transaction
 import Echidna.Types.Buffer (viewBuffer)
+import Echidna.Types.Campaign
 import Echidna.Types.Coverage (CoverageMap)
 import Echidna.Types.Signature (BytecodeMemo, lookupBytecodeMetadata)
 import Echidna.Types.Tx (TxCall(..), Tx, TxResult(..), call, dst, initialTimestamp, initialBlockNumber)
+import Echidna.Types (ExecException(..))
 
 -- | Broad categories of execution failures: reversions, illegal operations, and ???.
 data ErrorClass = RevertE | IllegalE | UnknownE
@@ -54,109 +55,99 @@ pattern Reversion <- VMFailure (classifyError -> RevertE)
 pattern Illegal :: VMResult
 pattern Illegal <- VMFailure (classifyError -> IllegalE)
 
--- | We throw this when our execution fails due to something other than reversion.
-data ExecException = IllegalExec Error | UnknownFailure Error
-
-instance Show ExecException where
-  show (IllegalExec e) = "VM attempted an illegal operation: " ++ show e
-  show (UnknownFailure e) = "VM failed for unhandled reason, " ++ show e
-    ++ ". This shouldn't happen. Please file a ticket with this error message and steps to reproduce!"
-
-instance Exception ExecException
-
 -- | Given an execution error, throw the appropriate exception.
 vmExcept :: MonadThrow m => Error -> m ()
 vmExcept e = throwM $ case VMFailure e of {Illegal -> IllegalExec e; _ -> UnknownFailure e}
 
 -- | Given an error handler `onErr`, an execution strategy `executeTx`, and a transaction `tx`,
 -- execute that transaction using the given execution strategy, calling `onErr` on errors.
-execTxWith :: (MonadState x m, Has VM x) => (Error -> m ()) -> m VMResult -> Tx -> m (VMResult, Int)
-execTxWith onErr executeTx tx' = do
-  isSelfDestruct <- hasSelfdestructed (tx' ^. dst)
-  if isSelfDestruct then pure (VMFailure (Revert (ConcreteBuf "")), 0)
+execTxWith :: MonadState s m => Lens' s VM -> (Error -> m ()) -> m VMResult -> Tx -> m (VMResult, Int)
+execTxWith l onErr executeTx tx' = do
+  vm <- use l
+  if hasSelfdestructed vm (tx'^. dst) then
+    pure (VMFailure (Revert (ConcreteBuf "")), 0)
   else do
-    hasLens . traces .= emptyEvents
-    vmBeforeTx <- use hasLens
-    setupTx tx'
-    gasLeftBeforeTx <- use $ hasLens . state . gas
+    l . traces .= emptyEvents
+    vmBeforeTx <- use l
+    l %= execState (setupTx tx')
+    gasLeftBeforeTx <- use $ l . state . gas
     vmResult' <- executeTx
-    gasLeftAfterTx <- use $ hasLens . state . gas
-    checkAndHandleQuery vmBeforeTx vmResult' onErr executeTx tx' gasLeftBeforeTx gasLeftAfterTx
+    gasLeftAfterTx <- use $ l . state . gas
+    checkAndHandleQuery l vmBeforeTx vmResult' onErr executeTx tx' gasLeftBeforeTx gasLeftAfterTx
 
-checkAndHandleQuery :: (MonadState x m, Has VM x) => VM -> VMResult -> (Error -> m ()) -> m VMResult -> Tx -> Word64 -> Word64 -> m (VMResult, Int)
-checkAndHandleQuery vmBeforeTx vmResult' onErr executeTx tx' gasLeftBeforeTx gasLeftAfterTx =
+checkAndHandleQuery :: MonadState s m => Lens' s VM -> VM -> VMResult -> (Error -> m ()) -> m VMResult -> Tx -> Word64 -> Word64 -> m (VMResult, Int)
+checkAndHandleQuery l vmBeforeTx vmResult' onErr executeTx tx' gasLeftBeforeTx gasLeftAfterTx =
         -- Continue transaction whose execution queried a contract or slot
     let continueAfterQuery = do
           -- Run remaining effects
           vmResult'' <- executeTx
           -- Correct gas usage
-          gasLeftAfterTx' <- use $ hasLens . state . gas
-          checkAndHandleQuery vmBeforeTx vmResult'' onErr executeTx tx' gasLeftBeforeTx gasLeftAfterTx'
+          gasLeftAfterTx' <- use $ l . state . gas
+          checkAndHandleQuery l vmBeforeTx vmResult'' onErr executeTx tx' gasLeftBeforeTx gasLeftAfterTx'
 
     in case getQuery vmResult' of
       -- A previously unknown contract is required
       Just (PleaseFetchContract _ continuation) -> do
         -- Use the empty contract
-        hasLens %= execState (continuation emptyAccount)
+        l %= execState (continuation emptyAccount)
         continueAfterQuery
 
       -- A previously unknown slot is required
       Just (PleaseFetchSlot _ _ continuation) -> do
         -- Use the zero slot
-        hasLens %= execState (continuation 0)
+        l %= execState (continuation 0)
         continueAfterQuery
 
       -- No queries to answer
       _ -> do
-        handleErrorsAndConstruction onErr vmResult' vmBeforeTx tx'
+        handleErrorsAndConstruction l onErr vmResult' vmBeforeTx tx'
         return (vmResult', fromIntegral $ gasLeftBeforeTx - gasLeftAfterTx)
 
 -- | Handles reverts, failures and contract creations that might be the result
 -- (`vmResult`) of executing transaction `tx`.
-handleErrorsAndConstruction :: (MonadState s m, Has VM s)
-                            => (Error -> m ())
+handleErrorsAndConstruction :: MonadState s m
+                            => Lens' s VM
+                            -> (Error -> m ())
                             -> VMResult
                             -> VM
                             -> Tx
                             -> m ()
-handleErrorsAndConstruction onErr vmResult' vmBeforeTx tx' = case (vmResult', tx' ^. call) of
+handleErrorsAndConstruction l onErr vmResult' vmBeforeTx tx' = case (vmResult', tx' ^. call) of
   (Reversion, _) -> do
-    tracesBeforeVMReset <- use $ hasLens . traces
-    codeContractBeforeVMReset <- use $ hasLens . state . codeContract
-    calldataBeforeVMReset <- use $ hasLens . state . calldata
-    callvalueBeforeVMReset <- use $ hasLens . state . callvalue
+    tracesBeforeVMReset <- use $ l . traces
+    codeContractBeforeVMReset <- use $ l . state . codeContract
+    calldataBeforeVMReset <- use $ l . state . calldata
+    callvalueBeforeVMReset <- use $ l . state . callvalue
     -- If a transaction reverts reset VM to state before the transaction.
-    hasLens .= vmBeforeTx
+    l .= vmBeforeTx
     -- Undo reset of some of the VM state.
     -- Otherwise we'd loose all information about the reverted transaction like
     -- contract address, calldata, result and traces.
-    hasLens . result ?= vmResult'
-    hasLens . state . calldata .= calldataBeforeVMReset
-    hasLens . state . callvalue .= callvalueBeforeVMReset
-    hasLens . traces .= tracesBeforeVMReset
-    hasLens . state . codeContract .= codeContractBeforeVMReset
+    l . result ?= vmResult'
+    l . state . calldata .= calldataBeforeVMReset
+    l . state . callvalue .= callvalueBeforeVMReset
+    l . traces .= tracesBeforeVMReset
+    l . state . codeContract .= codeContractBeforeVMReset
   (VMFailure x, _) -> onErr x
   (VMSuccess (ConcreteBuf bytecode'), SolCreate _) ->
     -- Handle contract creation.
-    hasLens %= execState (do
+    l %= execState (do
       env . contracts . at (tx' ^. dst) . _Just . contractcode .= InitCode mempty mempty
       replaceCodeOfSelf (RuntimeCode (ConcreteRuntimeCode bytecode'))
       loadContract (tx' ^. dst))
   _ -> pure ()
 
 -- | Execute a transaction "as normal".
-execTx :: (MonadState x m, Has VM x, MonadThrow m) => Tx -> m (VMResult, Int)
-execTx = execTxWith vmExcept $ liftSH exec
+execTx :: (MonadState VM m, MonadThrow m) => Tx -> m (VMResult, Int)
+execTx = execTxWith id vmExcept $ fromEVM exec
 
 -- | Execute a transaction, logging coverage at every step.
-execTxWithCov :: (MonadState x m, Has VM x) => BytecodeMemo -> Lens' x CoverageMap -> m VMResult
-execTxWithCov memo l = do
-  vm :: VM          <- use hasLens
-  cm :: CoverageMap <- use l
-  let (r, vm', cm') = loop vm cm
-  hasLens .= vm'
-  l       .= cm'
-  return r
+execTxWithCov :: MonadState (VM, Campaign) m => BytecodeMemo -> m VMResult
+execTxWithCov memo = do
+  (vm, camp) <- get
+  let (r, vm', cm') = loop vm camp._coverage
+  put (vm', camp { _coverage = cm' })
+  pure r
   where
     -- | Repeatedly exec a step and add coverage until we have an end result
     loop :: VM -> CoverageMap -> (VMResult, VM, CoverageMap)

--- a/lib/Echidna/Mutator/Corpus.hs
+++ b/lib/Echidna/Mutator/Corpus.hs
@@ -5,10 +5,10 @@ import Data.Set qualified as DS
 
 import Echidna.Mutator.Array
 import Echidna.Transaction (mutateTx, shrinkTx)
+import Echidna.Types (MutationConsts)
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.Corpus
 
-type MutationConsts a = (a, a, a, a)
 defaultMutationConsts :: Num a => MutationConsts a
 defaultMutationConsts = (1, 1, 1, 1)
 
@@ -40,7 +40,7 @@ mutator Deletion = deleteRandList
 selectAndMutate :: MonadRandom m
                 => ([Tx] -> m [Tx]) -> Corpus -> m [Tx]
 selectAndMutate f ctxs = do
-  rtxs <- weighted $ map (\(i, txs) -> (txs, fromInteger i)) $ DS.toDescList ctxs
+  rtxs <- weighted $ map (\(i, txs) -> (txs, fromIntegral i)) $ DS.toDescList ctxs
   k <- getRandomR (0, length rtxs - 1)
   f $ take k rtxs
 
@@ -51,7 +51,7 @@ selectAndCombine f ql ctxs gtxs = do
   rtxs2 <- selectFromCorpus
   txs <- f rtxs1 rtxs2
   return . take ql $ txs ++ gtxs
-    where selectFromCorpus = weighted $ map (\(i, txs) -> (txs, fromInteger i)) $ DS.toDescList ctxs
+    where selectFromCorpus = weighted $ map (\(i, txs) -> (txs, fromIntegral i)) $ DS.toDescList ctxs
 
 getCorpusMutation :: MonadRandom m
                   => CorpusMutation -> (Int -> Corpus -> [Tx] -> m [Tx])

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -31,6 +31,7 @@ import Echidna.Exec
 import Echidna.Transaction
 import Echidna.Types.Signature (SolSignature)
 import Echidna.ABI (encodeSig)
+import Echidna.Types (fromEVM)
 import Echidna.Types.Tx (TxCall(..), Tx(..), makeSingleTx, createTxWithValue, unlimitedGasPerBlock)
 
 -- | During initialization we can either call a function or create an account or contract

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -154,7 +154,7 @@ execEthenoTxs et = do
        (VMSuccess (ConcreteBuf bc),
         ContractCreated _ ca _ _ _ _) -> do
           env . contracts . at ca . _Just . contractcode .= InitCode mempty mempty
-          liftSH (replaceCodeOfSelf (RuntimeCode (ConcreteRuntimeCode bc)) >> loadContract ca)
+          fromEVM (replaceCodeOfSelf (RuntimeCode (ConcreteRuntimeCode bc)) >> loadContract ca)
           return ()
        _                              -> return ()
 

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -8,7 +8,7 @@ import Control.Lens
 import Control.Monad (join, liftM2)
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader, asks)
-import Control.Monad.State.Strict (MonadState, runState, get, put, gets)
+import Control.Monad.State.Strict (MonadState, gets)
 import Data.List.NonEmpty qualified as NE
 import Data.HashMap.Strict qualified as M
 import Data.Map (Map, toList)
@@ -22,6 +22,7 @@ import EVM.Types (Expr(ConcreteBuf, Lit), Addr, W256)
 import Echidna.ABI
 import Echidna.Types.Random
 import Echidna.Orphans.JSON ()
+import Echidna.Types (fromEVM)
 import Echidna.Types.Buffer (viewBuffer, forceLit)
 import Echidna.Types.Signature (SignatureMap, SolCall, ContractA, FunctionHash, BytecodeMemo, lookupBytecodeMetadata)
 import Echidna.Types.Tx
@@ -116,15 +117,6 @@ mutateTx t@(Tx (SolCall c) _ _ _ _ _ _) = do f <- oftenUsually skip mutate
                                            where mutate  z = mutateAbiCall z >>= \c' -> pure $ t { _call = SolCall c' }
                                                  skip    _ = pure t
 mutateTx t                              = pure t
-
-
--- | Transform an EVM action from HEVM to our MonadState VM
-fromEVM :: MonadState VM m => EVM a -> m a
-fromEVM evmAction = do
-  vm <- get
-  let (r, vm') = runState evmAction vm
-  put vm'
-  pure r
 
 -- | Given a 'Transaction', set up some 'VM' so it can be executed. Effectively, this just brings
 -- 'Transaction's \"on-chain\".

--- a/lib/Echidna/Types.hs
+++ b/lib/Echidna/Types.hs
@@ -1,1 +1,17 @@
 module Echidna.Types where
+
+import EVM (Error)
+import Control.Exception (Exception)
+
+-- | We throw this when our execution fails due to something other than reversion.
+data ExecException = IllegalExec Error | UnknownFailure Error
+
+instance Show ExecException where
+  show (IllegalExec e) = "VM attempted an illegal operation: " ++ show e
+  show (UnknownFailure e) = "VM failed for unhandled reason, " ++ show e
+    ++ ". This shouldn't happen. Please file a ticket with this error message and steps to reproduce!"
+
+instance Exception ExecException
+
+
+type MutationConsts a = (a, a, a, a)

--- a/lib/Echidna/Types.hs
+++ b/lib/Echidna/Types.hs
@@ -1,7 +1,8 @@
 module Echidna.Types where
 
-import EVM (Error)
+import EVM (Error, EVM, VM)
 import Control.Exception (Exception)
+import Control.Monad.State.Strict (MonadState, runState, get, put)
 
 -- | We throw this when our execution fails due to something other than reversion.
 data ExecException = IllegalExec Error | UnknownFailure Error
@@ -15,3 +16,11 @@ instance Exception ExecException
 
 
 type MutationConsts a = (a, a, a, a)
+
+-- | Transform an EVM action from HEVM to our MonadState VM
+fromEVM :: MonadState VM m => EVM a -> m a
+fromEVM evmAction = do
+  vm <- get
+  let (r, vm') = runState evmAction vm
+  put vm'
+  pure r

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -5,19 +5,18 @@ module Echidna.Types.Campaign where
 import Control.Lens
 import Data.Aeson (ToJSON(..), object)
 import Data.Foldable (toList)
-import Data.Has (Has(..))
 import Data.Map (Map, mapKeys)
 import Data.Text (Text)
 import EVM.Types (keccak')
 import Numeric (showHex)
 
 import Echidna.ABI (GenDict, defaultDict)
+import Echidna.Types
+import Echidna.Types.Corpus
 import Echidna.Types.Coverage (CoverageMap)
 import Echidna.Types.Test (EchidnaTest)
 import Echidna.Types.Signature (BytecodeMemo)
 import Echidna.Types.Tx (Tx)
-import Echidna.Types.Corpus
-import Echidna.Mutator.Corpus
 
 -- | Configuration for running an Echidna 'Campaign'.
 data CampaignConf = CampaignConf { _testLimit     :: Int
@@ -69,9 +68,6 @@ instance ToJSON Campaign where
     : [("coverage",) . toJSON . mapKeys (("0x" <>) . (`showHex` "") . keccak') $ toList <$> co | co /= mempty] ++
       [(("maxgas",) . toJSON . toList) gi | gi /= mempty] where
         format _ = "" :: String -- TODO: complete this format string
-
-instance Has GenDict Campaign where
-  hasLens = genDict
 
 defaultCampaign :: Campaign
 defaultCampaign = Campaign mempty mempty mempty defaultDict False mempty 0 mempty

--- a/lib/Echidna/Types/Corpus.hs
+++ b/lib/Echidna/Types/Corpus.hs
@@ -4,7 +4,7 @@ import Data.Set (Set, size)
 import Echidna.Types.Tx (Tx)
 
 type InitialCorpus = (Int, [[Tx]])
-type Corpus = Set (Integer, [Tx])
+type Corpus = Set (Int, [Tx])
 
 corpusSize :: Corpus -> Int
 corpusSize = size

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -12,8 +12,8 @@ import EVM (VM)
 import EVM.Types (Addr)
 import EVM.Dapp (DappInfo)
 
-import Echidna.Exec (ExecException)
 import Echidna.Events (Events)
+import Echidna.Types
 import Echidna.Types.Tx (Tx, TxResult)
 import Echidna.Types.Signature (SolSignature)
 

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -1,18 +1,14 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Echidna.UI where
 
 import Brick
 import Brick.BChan
 import Control.Concurrent (killThread, threadDelay)
-import Control.Lens
 import Control.Monad (forever, void, when)
 import Control.Monad.Catch (MonadCatch(..))
 import Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.Reader (MonadReader, runReader)
+import Control.Monad.Reader (MonadReader, runReader, asks)
 import Control.Monad.Random.Strict (MonadRandom)
 import Data.ByteString.Lazy qualified as BS
-import Data.Has (Has(..))
 import Data.IORef
 import Data.Maybe (fromMaybe)
 import Graphics.Vty (Config, Event(..), Key(..), Modifier(..), defaultConfig, inputMap, mkVty)
@@ -23,40 +19,23 @@ import UnliftIO.Concurrent (forkIO, forkFinally)
 import UnliftIO.Timeout (timeout)
 
 import EVM (VM)
-import EVM.Dapp (DappInfo)
 
 import Echidna.ABI
 import Echidna.Campaign (campaign)
 import Echidna.Output.JSON qualified
-import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Campaign
-import Echidna.Types.Test (TestConf(..), EchidnaTest)
-import Echidna.Types.Tx (Tx, TxConf)
+import Echidna.Types.Test (EchidnaTest)
+import Echidna.Types.Tx (Tx)
 import Echidna.Types.World (World)
 import Echidna.UI.Report
 import Echidna.UI.Widgets
-
-data UIConf = UIConf { _maxTime       :: Maybe Int
-                     , _operationMode :: OperationMode
-                     }
-data OperationMode = Interactive | NonInteractive OutputFormat deriving Show
-data OutputFormat = Text | JSON | None deriving Show
-
-instance Read OutputFormat where
-  readsPrec _ = \case 't':'e':'x':'t':r -> [(Text, r)]
-                      'j':'s':'o':'n':r -> [(JSON, r)]
-                      'n':'o':'n':'e':r -> [(None, r)]
-                      _ -> []
-
-makeLenses ''UIConf
+import Echidna.Types.Config
 
 data CampaignEvent = CampaignUpdated Campaign | CampaignTimedout Campaign
 
 -- | Set up and run an Echidna 'Campaign' and display interactive UI or
 -- print non-interactive output in desired format at the end
-ui :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadUnliftIO m
-      , Has SolConf x, Has TestConf x, Has TxConf x, Has CampaignConf x
-      , Has Names x, Has UIConf x, Has DappInfo x)
+ui :: (MonadCatch m, MonadRandom m, MonadReader Env m, MonadUnliftIO m)
    => VM             -- ^ Initial VM state
    -> World          -- ^ Initial world state
    -> [EchidnaTest]  -- ^ Tests to evaluate
@@ -64,14 +43,15 @@ ui :: ( MonadCatch m, MonadRandom m, MonadReader x m, MonadUnliftIO m
    -> [[Tx]]
    -> m Campaign
 ui vm world ts d txs = do
-  campaignConf <- view hasLens
+  conf <- asks (.cfg)
+  let uiConf = conf._uConf
   ref <- liftIO $ newIORef defaultCampaign
-  let updateRef = use hasLens >>= liftIO . atomicWriteIORef ref
+  let updateRef = get >>= liftIO . atomicWriteIORef ref
       secToUsec = (* 1000000)
-      timeoutUsec = secToUsec $ fromMaybe (-1) (campaignConf ^. maxTime)
+      timeoutUsec = secToUsec $ fromMaybe (-1) uiConf.maxTime
       runCampaign = timeout timeoutUsec (campaign updateRef vm world ts d txs)
   terminalPresent <- isTerminal
-  let effectiveMode = case campaignConf ^. operationMode of
+  let effectiveMode = case uiConf.operationMode of
         Interactive | not terminalPresent -> NonInteractive Text
         other -> other
   case effectiveMode of
@@ -91,7 +71,7 @@ ui vm world ts d txs = do
       app <- customMain initialVty vty (Just bc) <$> monitor
       liftIO $ void $ app (defaultCampaign, Uninitialized)
       final <- liftIO $ readIORef ref
-      liftIO . putStrLn =<< ppCampaign final
+      liftIO . putStrLn $ runReader (ppCampaign final) conf
       pure final
 
     NonInteractive outputFormat -> do
@@ -106,7 +86,7 @@ ui vm world ts d txs = do
         JSON ->
           liftIO . BS.putStr $ Echidna.Output.JSON.encodeCampaign final
         Text -> do
-          liftIO . putStrLn =<< ppCampaign final
+          liftIO . putStrLn $ runReader (ppCampaign final) conf
           when timedout $ liftIO $ putStrLn "TIMEOUT!"
         None ->
           pure ()
@@ -119,10 +99,9 @@ vtyConfig = defaultConfig { inputMap = (Nothing, "\ESC[6;2~", EvKey KPageDown [M
                           }
 
 -- | Check if we should stop drawing (or updating) the dashboard, then do the right thing.
-monitor :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x)
-        => m (App (Campaign, UIState) CampaignEvent ())
+monitor :: MonadReader Env m => m (App (Campaign, UIState) CampaignEvent ())
 monitor = do
-  let cs :: (CampaignConf, Names, TxConf) -> (Campaign, UIState) -> Widget ()
+  let cs :: EConfig -> (Campaign, UIState) -> Widget ()
       cs s c = runReader (campaignStatus c) s
 
       se (AppEvent (CampaignUpdated c')) = put (c', Running)
@@ -130,8 +109,8 @@ monitor = do
       se (VtyEvent (EvKey KEsc _))                         = halt
       se (VtyEvent (EvKey (KChar 'c') l)) | MCtrl `elem` l = halt
       se _                                                 = pure ()
-  s <- (,,) <$> view hasLens <*> view hasLens <*> view hasLens
-  pure $ App (pure . cs s) neverShowCursor se (pure ()) (const attrs)
+  conf <- asks (.cfg)
+  pure $ App (pure . cs conf) neverShowCursor se (pure ()) (const attrs)
 
 -- | Heuristic check that we're in a sensible terminal (not a pipe)
 isTerminal :: MonadIO m => m Bool

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -1,15 +1,12 @@
 module Echidna.UI.Report where
 
 import Control.Lens
-import Control.Monad.Reader (MonadReader)
-import Data.Has (Has(..))
+import Control.Monad.Reader (MonadReader, asks)
 import Data.List (intercalate, nub, sortOn)
 import Data.Map (toList)
 import Data.Maybe (catMaybes)
 import Data.Text (Text, unpack)
 import Data.Text qualified as T
-
-import EVM.Types (Addr)
 
 import Echidna.ABI (defSeed, encodeSig)
 import Echidna.Events (Events)
@@ -18,27 +15,22 @@ import Echidna.Types.Campaign
 import Echidna.Types.Corpus (Corpus, corpusSize)
 import Echidna.Types.Coverage (CoverageMap, scoveragePoints)
 import Echidna.Types.Test (testEvents, testState, TestState(..), testType, TestType(..), testReproducer, testValue)
-import Echidna.Types.Tx (Tx(Tx), TxCall(..), TxConf, txGas, src)
-
--- | An address involved with a 'Transaction' is either the sender, the recipient, or neither of those things.
-data Role = Sender | Receiver | Ambiguous
-
--- | Rules for pretty-printing addresses based on their role in a transaction.
-type Names = Role -> Addr -> String
+import Echidna.Types.Tx (Tx(Tx), TxCall(..), _txGas, src)
+import Echidna.Types.Config
 
 -- | Given a number of boxes checked and a number of total boxes, pretty-print progress in box-checking.
 progress :: Int -> Int -> String
 progress n m = "(" ++ show n ++ "/" ++ show m ++ ")"
 
 -- | Given rules for pretty-printing associated address, and whether to print them, pretty-print a 'Transaction'.
-ppTx :: (MonadReader x m, Has Names x, Has TxConf x) => Bool -> Tx -> m String
+ppTx :: (MonadReader EConfig m) => Bool -> Tx -> m String
 ppTx _ (Tx NoCall _ _ _ _ _ (t, b)) =
   return $ "*wait*" ++ (if t == 0    then "" else " Time delay: "  ++ show (toInteger t) ++ " seconds")
                     ++ (if b == 0    then "" else " Block delay: " ++ show (toInteger b))
 
 ppTx pn (Tx c s r g gp v (t, b)) = let sOf = ppTxCall in do
-  names <- view hasLens
-  tGas  <- view $ hasLens . txGas
+  names <- asks (._nConf)
+  tGas  <- asks (._xConf._txGas)
   return $ sOf c ++ (if not pn    then "" else names Sender s ++ names Receiver r)
                  ++ (if g == tGas then "" else " Gas: "         ++ show g)
                  ++ (if gp == 0   then "" else " Gas price: "   ++ show gp)
@@ -58,18 +50,18 @@ ppCorpus c | c == mempty = Nothing
            | otherwise   = Just $ "Corpus size: " ++ show (corpusSize c)
 
 -- | Pretty-print the gas usage for a function.
-ppGasOne :: (MonadReader x m, Has Names x, Has TxConf x) => (Text, (Int, [Tx])) -> m String
+ppGasOne :: MonadReader EConfig m => (Text, (Int, [Tx])) -> m String
 ppGasOne ("", _)      = pure ""
 ppGasOne (f, (g, xs)) = let pxs = mapM (ppTx $ length (nub $ view src <$> xs) /= 1) xs in
  (("\n" ++ unpack f ++ " used a maximum of " ++ show g ++ " gas\n  Call sequence:\n") ++) . unlines . fmap ("    " ++) <$> pxs
 
 -- | Pretty-print the gas usage information a 'Campaign' has obtained.
-ppGasInfo :: (MonadReader x m, Has Names x, Has TxConf x) => Campaign -> m String
+ppGasInfo :: MonadReader EConfig m => Campaign -> m String
 ppGasInfo Campaign { _gasInfo = gi } | gi == mempty = pure ""
 ppGasInfo Campaign { _gasInfo = gi } = (fmap $ intercalate "") (mapM ppGasOne $ sortOn (\(_, (n, _)) -> n) $ toList gi)
 
 -- | Pretty-print the status of a solved test.
-ppFail :: (MonadReader x m, Has Names x, Has TxConf x) => Maybe (Int, Int) -> Events -> [Tx] -> m String
+ppFail :: MonadReader EConfig m => Maybe (Int, Int) -> Events -> [Tx] -> m String
 ppFail _ _ []  = pure "failed with no transactions made ⁉️  "
 ppFail b es xs = let status = case b of
                                 Nothing    -> ""
@@ -83,31 +75,31 @@ ppEvents es = if null es then "" else "Event sequence: " ++ T.unpack (T.intercal
 
 -- | Pretty-print the status of a test.
 
-ppTS :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => TestState -> Events -> [Tx] -> m String
+ppTS :: MonadReader EConfig m => TestState -> Events -> [Tx] -> m String
 ppTS (Failed e) _ _  = pure $ "could not evaluate ☣\n  " ++ show e
 ppTS Solved     es l = ppFail Nothing es l
 ppTS Passed     _ _  = pure " passed! 🎉"
 ppTS (Open i)   es [] = do
-  t <- view (hasLens .  testLimit)
+  t <- asks (._cConf._testLimit)
   if i >= t then ppTS Passed es [] else pure $ " fuzzing " ++ progress i t
 ppTS (Open _)   es r = ppFail Nothing es r
 ppTS (Large n) es l  = do
-  m <- view (hasLens . shrinkLimit)
+  m <- asks (._cConf._shrinkLimit)
   ppFail (if n < m then Just (n, m) else Nothing) es l
 
 
-ppOPT :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => TestState -> Events -> [Tx] -> m String
+ppOPT :: MonadReader EConfig m => TestState -> Events -> [Tx] -> m String
 ppOPT (Failed e) _ _  = pure $ "could not evaluate ☣\n  " ++ show e
 ppOPT Solved     es l = ppOptimized Nothing es l
 ppOPT Passed     _ _  = pure " passed! 🎉"
-ppOPT (Open _)   es r = ppOptimized Nothing es r 
+ppOPT (Open _)   es r = ppOptimized Nothing es r
 ppOPT (Large n) es l  = do
-  m <- view (hasLens . shrinkLimit)
+  m <- asks (._cConf._shrinkLimit)
   ppOptimized (if n < m then Just (n, m) else Nothing) es l
 
 
 -- | Pretty-print the status of a optimized test.
-ppOptimized :: (MonadReader x m, Has Names x, Has TxConf x) => Maybe (Int, Int) -> Events -> [Tx] -> m String
+ppOptimized :: MonadReader EConfig m => Maybe (Int, Int) -> Events -> [Tx] -> m String
 ppOptimized _ _ []  = pure "Call sequence:\n(no transactions)"
 ppOptimized b es xs = let status = case b of
                                 Nothing    -> ""
@@ -118,7 +110,7 @@ ppOptimized b es xs = let status = case b of
 
 
 -- | Pretty-print the status of all 'SolTest's in a 'Campaign'.
-ppTests :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Campaign -> m String
+ppTests :: MonadReader EConfig m => Campaign -> m String
 ppTests Campaign { _tests = ts } = unlines . catMaybes <$> mapM pp ts where
   pp t = case t ^. testType of
          PropertyTest n _      ->  Just . ((T.unpack n ++ ": ") ++) <$> ppTS (t ^. testState) (t ^. testEvents) (t ^. testReproducer)
@@ -127,7 +119,7 @@ ppTests Campaign { _tests = ts } = unlines . catMaybes <$> mapM pp ts where
          OptimizationTest n _  ->  Just . ((T.unpack n ++ ": max value: " ++ show (t ^. testValue) ++ "\n") ++) <$> ppOPT (t ^. testState) (t ^. testEvents) (t ^. testReproducer)
          Exploration           ->  return Nothing
 
-ppCampaign :: (MonadReader x m, Has CampaignConf x, Has Names x, Has TxConf x) => Campaign -> m String
+ppCampaign :: MonadReader EConfig m => Campaign -> m String
 ppCampaign c = do
   testsPrinted <- ppTests c
   gasInfoPrinted <- ppGasInfo c

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ language: GHC2021
 
 default-extensions:
   - LambdaCase
+  - OverloadedRecordDot
   - OverloadedStrings
 
 library:

--- a/src/test/Tests/Compile.hs
+++ b/src/test/Tests/Compile.hs
@@ -7,10 +7,10 @@ import Common (testConfig)
 import Control.Lens (Prism', preview)
 import Control.Monad (void)
 import Control.Monad.Catch (catch)
-import Control.Monad.Reader (runReaderT)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe (isJust)
 import Data.Text (Text)
+import Echidna.Types.Config
 import Echidna.Types.Solidity (SolException, _ContractNotFound, _NoBytecode, _NoFuncs, _NoTests, _OnlyTests, _TestArgsFound, _ConstructorArgs, _DeploymentFailed)
 import Echidna.Solidity (loadWithCryticCompile)
 
@@ -38,7 +38,7 @@ compilationTests = testGroup "Compilation and loading tests"
 
 loadFails :: FilePath -> Maybe Text -> String -> (SolException -> Bool) -> TestTree
 loadFails fp c e p = testCase fp . catch tryLoad $ assertBool e . p where
-  tryLoad = runReaderT (void (loadWithCryticCompile (fp :| []) c)) testConfig
+  tryLoad = void $ loadWithCryticCompile testConfig._sConf (fp :| []) c
 
 pmatch :: Prism' s a -> s -> Bool
 pmatch p = isJust . preview p

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -15,7 +15,7 @@ configTests :: TestTree
 configTests = testGroup "Configuration tests" $
   [ testCase file . void $ parseConfig file | file <- files ] ++
   [ testCase "parse \"coverage: true\"" $ do
-      config <- _econfig <$> parseConfig "coverage/test.yaml"
+      config <- econfig <$> parseConfig "coverage/test.yaml"
       assertCoverage config $ Just mempty
   , testCase "coverage enabled by default" $
       assertCoverage defaultConfig $ Just mempty


### PR DESCRIPTION
We've been using `Data.Has` extensively and it's been a significant pattern in our code. While it allows for more abstract code to be written, it's not a commonly used library and it comes at a cost of substantial mental load as it was often hard to understand what the code is doing.

This PR removes all `Data.Has` from our code and replaces it with more common patterns, in the hope to improve the project's maintenance and development.

I also enabled the `OverloadedRecordDot` extension that comes with GHC 9.2 that somewhat fixes the records so they can be accessed like in "normal" languages 😄.