### PR TITLE
Code cleanup

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -8,7 +8,7 @@ module Echidna.Campaign where
 import Control.Lens
 import Control.Monad (replicateM, when, (<=<), ap, unless)
 import Control.Monad.Catch (MonadCatch(..), MonadThrow(..))
-import Control.Monad.Random.Strict (MonadRandom, RandT, evalRandT, getRandomR, uniform, uniformMay)
+import Control.Monad.Random.Strict (MonadRandom, RandT, evalRandT, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader)
 import Control.Monad.Reader (runReaderT, asks)
 import Control.Monad.State.Strict (MonadState(..), StateT(..), evalStateT, execStateT, gets)
@@ -16,8 +16,8 @@ import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Random.Strict (liftCatch)
 import Data.Binary.Get (runGetOrFail)
 import Data.Bool (bool)
+import Data.ByteString.Lazy qualified as LBS
 import Data.HashMap.Strict qualified as H
-import Data.HashSet qualified as S
 import Data.Map (Map, unionWith, (\\), elems, keys, lookup, insert, mapWithKey)
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Ord (comparing)
@@ -25,7 +25,8 @@ import Data.Set qualified as DS
 import Data.Text (Text)
 import System.Random (mkStdGen)
 
-import EVM (Contract, VM, VMResult(..), bytecode, contracts, env)
+import EVM (Contract, VM(..), VMResult(..), bytecode)
+import qualified EVM (Env(..))
 import EVM.ABI (getAbi, AbiType(AbiAddressType), AbiValue(AbiAddress))
 import EVM.Types (Addr, Expr(ConcreteBuf))
 
@@ -33,7 +34,7 @@ import Echidna.ABI
 import Echidna.Exec
 import Echidna.Test
 import Echidna.Transaction
-import Echidna.Shrink (shrinkSeq)
+import Echidna.Shrink (shrinkSeq, shrinkSender)
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Corpus (InitialCorpus)
@@ -41,10 +42,10 @@ import Echidna.Types.Coverage (coveragePoints)
 import Echidna.Types.Test
 import Echidna.Types.Buffer (viewBuffer)
 import Echidna.Types.Signature (makeBytecodeMemo)
-import Echidna.Types.Tx (TxCall(..), Tx(..), getResult, src, call, _SolCall)
-import Echidna.Types.Solidity (SolConf(..))
+import Echidna.Types.Tx (TxCall(..), Tx(..), getResult, call)
 import Echidna.Types.World (World)
 import Echidna.Mutator.Corpus
+import qualified Data.Set as Set
 
 instance MonadThrow m => MonadThrow (RandT g m) where
   throwM = lift . throwM
@@ -64,12 +65,13 @@ isDone (view tests -> ts) = do
       res (Large i)   = if i >= conf._shrinkLimit then Just False else Nothing
       res Solved      = Just False
       res (Failed _)  = Just False
-  pure $ res . (._testState) <$> ts & if conf._stopOnFail then elem $ Just False else all isJust
+  pure $ res . (.testState) <$> ts & if conf._stopOnFail then elem $ Just False else all isJust
 
 -- | Given a 'Campaign', check if the test results should be reported as a
 -- success or a failure.
-isSuccess :: Campaign -> Bool
-isSuccess = allOf (tests . traverse . testState) (\case { Passed -> True; Open _ -> True; _ -> False; })
+isSuccessful :: Campaign -> Bool
+isSuccessful Campaign{_tests} =
+  all (\case { Passed -> True; Open _ -> True; _ -> False; }) ((.testState) <$> _tests)
 
 -- | Given an initial 'VM' state and a @('SolTest', 'TestState')@ pair, as well as possibly a sequence
 -- of transactions and the state after evaluation, see if:
@@ -84,27 +86,27 @@ updateTest :: (MonadCatch m, MonadRandom m, MonadReader Env m)
 
 updateTest w vm (Just (vm', xs)) test = do
   tl <- asks (.cfg._cConf._testLimit)
-  case test ^. testState of
-    Open i | i >= tl -> case test ^. testType of
-                          OptimizationTest _ _ -> pure $ test { _testState = Large (-1) }
-                          _                    -> pure $ test { _testState = Passed }
+  case test.testState of
+    Open i | i >= tl -> case test.testType of
+                          OptimizationTest _ _ -> pure $ test { testState = Large (-1) }
+                          _                    -> pure $ test { testState = Passed }
     Open i           -> do r <- evalStateT (checkETest test) vm'
                            pure $ updateOpenTest test xs i r
     _                -> updateTest w vm Nothing test
 
 updateTest _ vm Nothing test = do
   sl <- asks (.cfg._cConf._shrinkLimit)
-  let es = test ^. testEvents
-      res = test ^. testResult
-      x = test ^. testReproducer
-      v = test ^. testValue
-      t = test ^. testType
-  case test ^. testState of
-    Large i | i >= sl -> pure $ test { _testState =  Solved, _testReproducer = x }
+  let es = test.testEvents
+      res = test.testResult
+      x = test.testReproducer
+      v = test.testValue
+      t = test.testType
+  case test.testState of
+    Large i | i >= sl -> pure $ test { testState =  Solved, testReproducer = x }
     Large i           -> if length x > 1 || any canShrinkTx x
                              then do (txs, val, evs, r) <- evalStateT (shrinkSeq (checkETest test) (v, es, res) x) vm
-                                     pure $ test { _testState = Large (i + 1), _testReproducer = txs, _testEvents = evs, _testResult = r, _testValue = val}
-                             else pure $ test { _testState = if isOptimizationTest t then Large (i + 1) else Solved, _testReproducer = x}
+                                     pure $ test { testState = Large (i + 1), testReproducer = txs, testEvents = evs, testResult = r, testValue = val}
+                             else pure $ test { testState = if isOptimizationTest t then Large (i + 1) else Solved, testReproducer = x}
     _                   -> pure test
 
 
@@ -130,16 +132,14 @@ evalSeq w v e = go [] where
 shrinkGasSeq :: (MonadRandom m, MonadReader Env m, MonadThrow m, MonadState VM m)
           => Text -> Int -> [Tx] -> m [Tx]
 shrinkGasSeq f g xs = sequence [shorten, shrunk] >>= uniform >>= ap (fmap . flip bool xs) check where
-  callsF f' t = t ^? call . _SolCall . _1 == Just f'
-  check xs' | callsF f $ last xs' = do
+  callsF t =
+    case t.call of
+      SolCall (f', _) | f == f' -> True
+      _ -> False
+  check xs' | callsF $ last xs' = do
     res <- traverse execTx xs'
     pure $ (snd . head) res >= g
   check _ = pure False
-  shrinkSender x = do
-    l <- asks (.cfg._sConf._sender)
-    case ifind (const (== x ^. src)) l of
-      Nothing     -> pure x
-      Just (i, _) -> flip (set src) x . fromMaybe (x ^. src) <$> uniformMay (l ^.. folded . indices (< i))
   shrunk = mapM (shrinkSender <=< shrinkTx) xs
   shorten = (\i -> take i xs ++ drop (i + 1) xs) <$> getRandomR (0, length xs)
 
@@ -161,11 +161,11 @@ updateGasInfo ((t, _):ts) tseq gi = updateGasInfo ts (t:tseq) gi
 -- | Execute a transaction, capturing the PC and codehash of each instruction executed, saving the
 -- transaction if it finds new coverage.
 execTxOptC :: (MonadState (VM, Campaign) m, MonadThrow m) => Tx -> m (VMResult, Int)
-execTxOptC t = do
+execTxOptC tx = do
   (_, camp) <- get
   let cov = _2 . coverage
   og   <- cov <<.= mempty
-  res  <- execTxWith _1 vmExcept (execTxWithCov camp._bcMemo) t
+  res  <- execTxWith _1 vmExcept (execTxWithCov camp._bcMemo) tx
   let vmr = getResult $ fst res
   -- Update the coverage map with the proper binary according to the vm result
   cov %= mapWithKey (\_ s -> DS.map (set _4 vmr) s)
@@ -173,7 +173,9 @@ execTxOptC t = do
   cov %= unionWith DS.union og
   grew <- (== LT) . comparing coveragePoints og <$> use cov
   when grew $ do
-    _2 . genDict %= gaddCalls ([t ^. call] ^.. traverse . _SolCall)
+    case tx.call of
+      SolCall c -> _2 . genDict %= gaddCalls (Set.singleton c)
+      _ -> pure ()
     _2 . newCoverage .= True
   return res
 
@@ -189,10 +191,10 @@ randseq (n,txs) ql o w = do
   ca <- get
   cs <- asks (.cfg._cConf._mutConsts)
   txConf <- asks (.cfg._xConf)
-  let ctxs = ca ^. corpus
+  let ctxs = ca._corpus
       -- TODO: include reproducer when optimizing
       --rs   = filter (not . null) $ map (view testReproducer) $ ca ^. tests
-      p    = ca ^. ncallseqs
+      p    = ca._ncallseqs
   if n > p then -- Replay the transactions in the corpus, if we are executing the first iterations
     return $ txs !! p
   else do
@@ -221,24 +223,24 @@ callseq ic v w ql = do
                                                              (r, vm') <- runStateT (execTx t) xd
                                                              put (vm', ca)
                                                              pure r)
-      old = v ^. env . EVM.contracts
+      old = v._env._contracts
   let gasEnabled = conf._estimateGas
   -- Then, we get the current campaign state
   ca <- get
   -- Then, we generate the actual transaction in the sequence
   is <- randseq ic ql old w
   -- We then run each call sequentially. This gives us the result of each call, plus a new state
-  (res, s) <- runStateT (evalSeq w v ef is) (v, ca)
-  let new = s ^. _1 . env . EVM.contracts
+  (res, (vm, camp)) <- runStateT (evalSeq w v ef is) (v, ca)
+  let new = vm._env._contracts
       -- compute the addresses not present in the old VM via set difference
       diff = keys $ new \\ old
       -- and construct a set to union to the constants table
-      diffs = H.fromList [(AbiAddressType, S.fromList $ AbiAddress <$> diff)]
+      diffs = H.fromList [(AbiAddressType, Set.fromList $ AbiAddress <$> diff)]
   -- Save the global campaign state (also vm state, but that gets reset before it's used)
-  put (snd s) -- Update the gas estimation
+  put camp -- Update the gas estimation
   when gasEnabled $ gasInfo %= updateGasInfo res []
   -- If there is new coverage, add the transaction list to the corpus
-  when (s ^. _2 . newCoverage) $ addToCorpus (s ^. _2 . ncallseqs + 1) res
+  when (camp._newCoverage) $ addToCorpus (camp._ncallseqs + 1) res
   -- Reset the new coverage flag
   newCoverage .= False
   -- Keep track of the number of calls to `callseq`
@@ -247,18 +249,25 @@ callseq ic v w ql = do
   types <- gets (._genDict._rTypes)
   let results = parse (map (\(t, (vr, _)) -> (t, vr)) res) types
       -- union the return results with the new addresses
-      additions = H.unionWith S.union diffs results
+      additions = H.unionWith Set.union diffs results
   -- append to the constants dictionary
-  modifying (genDict . constants) . H.unionWith S.union $ additions
-  modifying (genDict . dictValues) . DS.union $ mkDictValues $ S.toList $ S.unions $ H.elems additions
+  modifying (genDict . constants) . H.unionWith Set.union $ additions
+  modifying (genDict . dictValues) . DS.union $ mkDictValues $ Set.unions $ H.elems additions
   where
     -- Given a list of transactions and a return typing rule, this checks whether we know the return
     -- type for each function called, and if we do, tries to parse the return value as a value of that
     -- type. It returns a 'GenDict' style HashMap.
-    parse l rt = H.fromList . flip mapMaybe l $ \(x, r) -> case (rt =<< x ^? call . _SolCall . _1, r) of
-      (Just ty, VMSuccess (ConcreteBuf b)) ->
-        (ty,) . S.fromList . pure <$> runGetOrFail (getAbi ty) (b ^. lazy) ^? _Right . _3
-      _ -> Nothing
+    parse l rt = H.fromList . flip mapMaybe l $ \(tx, result) -> do
+      fname <- case tx.call of
+        SolCall (fname, _) -> Just fname
+        _ -> Nothing
+      type' <- rt fname
+      case result of
+        VMSuccess (ConcreteBuf buf) ->
+          case runGetOrFail (getAbi type') (LBS.fromStrict buf) of
+            Right (_, _, abiValue) -> Just (type', Set.singleton abiValue)
+            _ -> Nothing
+        _ -> Nothing
 
 -- | Run a fuzzing campaign given an initial universe state, some tests, and an optional dictionary
 -- to generate calls with. Return the 'Campaign' state once we can't solve or shrink anything.
@@ -274,7 +283,7 @@ campaign
 campaign u vm w ts d txs = do
   conf <- asks (.cfg._cConf)
   let c = fromMaybe mempty (conf._knownCoverage)
-  let effectiveSeed = fromMaybe (d' ^. defSeed) conf._seed
+  let effectiveSeed = fromMaybe d'._defSeed conf._seed
       effectiveGenDict = d' { _defSeed = effectiveSeed }
       d' = fromMaybe defaultDict d
   execStateT
@@ -283,14 +292,19 @@ campaign u vm w ts d txs = do
   where
     -- "mapMaybe ..." is to get a list of all contracts
     ic          = (length txs, txs)
-    memo        = makeBytecodeMemo . mapMaybe (viewBuffer . (^. bytecode)) . elems $ (vm ^. env . EVM.contracts)
+    memo        = makeBytecodeMemo . mapMaybe (viewBuffer . (^. bytecode)) . elems $ vm._env._contracts
     step        = runUpdate (updateTest w vm Nothing) >> lift u >> runCampaign
-    runCampaign = use (tests . to (fmap (view testState))) >>= update
+    runCampaign = gets (fmap (.testState) . (._tests)) >>= update
     update c    = do
-      CampaignConf tl sof _ q sl _ _ _ _ _ <- asks (.cfg._cConf)
-      Campaign { _ncallseqs } <- get
-      if | sof && any (\case Solved -> True; Failed _ -> True; _ -> False) c -> lift u
-         | any (\case Open  n   -> n < tl; _ -> False) c                       -> callseq ic vm w q >> step
-         | any (\case Large n   -> n < sl; _ -> False) c                       -> step
-         | null c && (q * _ncallseqs) < tl                                     -> callseq ic vm w q >> step
-         | otherwise                                                           -> lift u
+      CampaignConf{_testLimit, _stopOnFail, _seqLen, _shrinkLimit} <- asks (.cfg._cConf)
+      Campaign{_ncallseqs} <- get
+      if | _stopOnFail && any (\case Solved -> True; Failed _ -> True; _ -> False) c ->
+           lift u
+         | any (\case Open  n   -> n < _testLimit; _ -> False) c ->
+           callseq ic vm w _seqLen >> step
+         | any (\case Large n   -> n < _shrinkLimit; _ -> False) c ->
+           step
+         | null c && (_seqLen * _ncallseqs) < _testLimit ->
+           callseq ic vm w _seqLen >> step
+         | otherwise ->
+           lift u

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -1,9 +1,7 @@
 module Echidna.Config where
 
 import Control.Lens
-import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Fail qualified as M (MonadFail(..))
-import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader (Reader, ReaderT(..), runReader)
 import Control.Monad.State (StateT(..), runStateT, modify')
 import Control.Monad.Trans (lift)
@@ -126,8 +124,8 @@ defaultConfig :: EConfig
 defaultConfig = either (error "Config parser got messed up :(") id $ Y.decodeEither' ""
 
 -- | Try to parse an Echidna config file, throw an error if we can't.
-parseConfig :: (MonadThrow m, MonadIO m) => FilePath -> m EConfigWithUsage
-parseConfig f = liftIO (BS.readFile f) >>= Y.decodeThrow
+parseConfig :: FilePath -> IO EConfigWithUsage
+parseConfig f = BS.readFile f >>= Y.decodeThrow
 
 -- | Run some action with the default configuration, useful in the REPL.
 withDefaultConfig :: ReaderT EConfig m a -> m a

--- a/lib/Echidna/Events.hs
+++ b/lib/Echidna/Events.hs
@@ -35,14 +35,14 @@ maybeContractNameFromCodeHash codeHash = fmap contractToName maybeContract
 
 extractEvents :: Bool -> DappInfo -> VM -> Events
 extractEvents decodeErrors dappInfo' vm =
-  let eventMap = dappInfo' ^. dappEventMap
+  let eventMap = dappInfo'._dappEventMap
       forest = traceForest vm
       showTrace trace =
         let ?context = DappContext { _contextInfo = dappInfo', _contextEnv = vm ^?! EVM.env . EVM.contracts } in
-        let codehash' = fromJust $ maybeLitWord (trace ^. traceContract . codehash)
+        let codehash' = fromJust $ maybeLitWord trace._traceContract._codehash
             maybeContractName = maybeContractNameFromCodeHash codehash'
         in
-        case trace ^. traceData of
+        case trace._traceData of
           EventTrace addr bytes topics ->
             case maybeLitWord =<< listToMaybe topics of
               Nothing   -> []
@@ -68,7 +68,7 @@ extractEvents decodeErrors dappInfo' vm =
 
 decodeRevert :: Bool -> VM -> Events
 decodeRevert decodeErrors vm =
-  case vm ^. result of
+  case vm._result of
     Just (VMFailure (Revert (ConcreteBuf bs))) -> decodeRevertMsg decodeErrors bs
     _                            -> []
 

--- a/lib/Echidna/Fetch.hs
+++ b/lib/Echidna/Fetch.hs
@@ -27,13 +27,13 @@ deployBytecodes' _ []            _ vm = return vm
 deployBytecodes' di ((a, bc):cs) d vm = deployBytecodes' di cs d =<< loadRest
   where zeros = pack $ replicate 320 0 -- This will initialize with zero a large number of possible constructor parameters
         loadRest = do vm' <- execStateT (execTx $ createTx (bc `append` zeros) d a (fromInteger unlimitedGasPerBlock) (0, 0)) vm
-                      case vm' ^. result of
+                      case vm'._result of
                        (Just (VMSuccess _)) -> return vm'
                        _                    -> throwM $ DeploymentFailed a (Data.Text.unlines $ extractEvents True di vm')
 
 deployContracts :: (MonadIO m, MonadThrow m)
                        => DappInfo -> [(Addr, SolcContract)] -> Addr -> VM -> m VM
-deployContracts di cs = deployBytecodes' di $ map (\(a, c) -> (a, c ^. creationCode)) cs
+deployContracts di cs = deployBytecodes' di $ map (\(a, c) -> (a, c._creationCode)) cs
 
 deployBytecodes :: (MonadIO m, MonadThrow m)
                        => DappInfo -> [(Addr, Text)] -> Addr -> VM -> m VM

--- a/lib/Echidna/Fetch.hs
+++ b/lib/Echidna/Fetch.hs
@@ -1,7 +1,6 @@
 module Echidna.Fetch where
 
 import Control.Monad.Catch (MonadThrow(..), throwM)
-import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.State.Strict (execStateT)
 import Data.ByteString (ByteString, pack, append)
 import Data.ByteString.Base16 qualified as BS16 (decode)
@@ -19,21 +18,22 @@ import Echidna.Types.Tx (createTx, unlimitedGasPerBlock)
 import Echidna.Exec (execTx)
 import Echidna.Events (extractEvents)
 
--- | Deploy a list of solidity contracts in certain addresses
-deployBytecodes' :: (MonadIO m, MonadThrow m)
-                       => DappInfo -> [(Addr, ByteString)] -> Addr -> VM -> m VM
-deployBytecodes' _ []            _ vm = return vm
-deployBytecodes' di ((a, bc):cs) d vm = deployBytecodes' di cs d =<< loadRest
-  where zeros = pack $ replicate 320 0 -- This will initialize with zero a large number of possible constructor parameters
-        loadRest = do vm' <- execStateT (execTx $ createTx (bc `append` zeros) d a (fromInteger unlimitedGasPerBlock) (0, 0)) vm
-                      case vm'._result of
-                       (Just (VMSuccess _)) -> return vm'
-                       _                    -> throwM $ DeploymentFailed a (Data.Text.unlines $ extractEvents True di vm')
-
-deployContracts :: (MonadIO m, MonadThrow m)
-                       => DappInfo -> [(Addr, SolcContract)] -> Addr -> VM -> m VM
+deployContracts :: DappInfo -> [(Addr, SolcContract)] -> Addr -> VM -> IO VM
 deployContracts di cs = deployBytecodes' di $ map (\(a, c) -> (a, c._creationCode)) cs
 
-deployBytecodes :: (MonadIO m, MonadThrow m)
-                       => DappInfo -> [(Addr, Text)] -> Addr -> VM -> m VM
-deployBytecodes di cs = deployBytecodes' di $ map (\(a, bc) -> (a, fromRight (error ("invalid b16 decoding of: " ++ show bc)) $ BS16.decode $ encodeUtf8 bc)) cs
+deployBytecodes :: DappInfo -> [(Addr, Text)] -> Addr -> VM -> IO VM
+deployBytecodes di cs =
+  deployBytecodes' di $ map (\(a, bc) -> (a, fromRight (error ("invalid b16 decoding of: " ++ show bc)) $ BS16.decode $ encodeUtf8 bc)) cs
+
+-- | Deploy a list of solidity contracts in certain addresses
+deployBytecodes' :: DappInfo -> [(Addr, ByteString)] -> Addr -> VM -> IO VM
+deployBytecodes' _ []            _ vm = return vm
+deployBytecodes' di ((a, bc):cs) d vm =
+  deployBytecodes' di cs d =<< loadRest
+  where
+    zeros = pack $ replicate 320 0 -- This will initialize with zero a large number of possible constructor parameters
+    loadRest = do
+      vm' <- execStateT (execTx $ createTx (bc `append` zeros) d a (fromInteger unlimitedGasPerBlock) (0, 0)) vm
+      case vm'._result of
+        (Just (VMSuccess _)) -> return vm'
+        _ -> throwM $ DeploymentFailed a (Data.Text.unlines $ extractEvents True di vm')

--- a/lib/Echidna/Fetch.hs
+++ b/lib/Echidna/Fetch.hs
@@ -1,6 +1,5 @@
 module Echidna.Fetch where
 
-import Control.Lens
 import Control.Monad.Catch (MonadThrow(..), throwM)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.State.Strict (execStateT)

--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -12,21 +12,18 @@ import System.Directory (createDirectoryIfMissing, makeRelativeToCurrentDirector
 import Echidna.Types.Tx
 import Echidna.Output.Utils
 
-saveTxs :: Maybe FilePath -> [[Tx]] -> IO ()
-saveTxs (Just d) txs = mapM_ saveTx txs where
+saveTxs :: FilePath -> [[Tx]] -> IO ()
+saveTxs d = mapM_ saveTx where
   saveTx v = do let fn = d ++ (show . hash . show) v ++ ".txt"
                 b <- doesFileExist fn
                 unless b $ encodeFile fn (toJSON v)
-saveTxs Nothing  _   = pure ()
 
-loadTxs :: Maybe FilePath -> IO [[Tx]]
-loadTxs (Just d) = do
-  createDirectoryIfMissing True d
-  fs <- listDirectory d
+loadTxs :: FilePath -> IO [[Tx]]
+loadTxs dir = do
+  createDirectoryIfMissing True dir
+  fs <- listDirectory dir
   css <- mapM readCall <$> mapM makeRelativeToCurrentDirectory fs
-  txs <- catMaybes <$> withCurrentDirectory d css
-  putStrLn ("Loaded total of " ++ show (length txs) ++ " transactions from " ++ d)
+  txs <- catMaybes <$> withCurrentDirectory dir css
+  putStrLn ("Loaded total of " ++ show (length txs) ++ " transactions from " ++ dir)
   return txs
   where readCall f = decodeStrict <$> BS.readFile f
-
-loadTxs Nothing  = pure []

--- a/lib/Echidna/Output/Source.hs
+++ b/lib/Echidna/Output/Source.hs
@@ -27,8 +27,8 @@ import System.FilePath ((</>))
 type FilePathText = Text
 
 saveCoverage :: Bool -> Int -> FilePath -> SourceCache -> [SolcContract] -> CoverageMap -> IO ()
-saveCoverage isHtml seed d sc cs s = let filepath = if isHtml then ".html" else ".txt"
-                                         fn = d </> "covered." </> show seed </> filepath
+saveCoverage isHtml seed d sc cs s = let extension = if isHtml then ".html" else ".txt"
+                                         fn = d </> "covered." <> show seed <> extension
                                          cc = ppCoveredCode isHtml sc cs s
                                        in writeFile fn cc
 

--- a/lib/Echidna/Output/Source.hs
+++ b/lib/Echidna/Output/Source.hs
@@ -17,29 +17,28 @@ import HTMLEntities.Text qualified as HTML
 import Text.Printf (printf)
 
 import EVM.Debug (srcMapCodePos)
-import EVM.Solidity (SourceCache, SrcMap, SolcContract, sourceLines, sourceFiles, runtimeCode, runtimeSrcmap, creationSrcmap)
+import EVM.Solidity (SourceCache(..), SrcMap, SolcContract(..))
 
 import Echidna.Types.Coverage (CoverageMap, CoverageInfo)
 import Echidna.Types.Tx (TxResult(..))
 import Echidna.Types.Signature (getBytecodeMetadata)
+import System.FilePath ((</>))
 
 type FilePathText = Text
 
-saveCoverage :: Bool -> Int -> Maybe FilePath -> SourceCache -> [SolcContract] -> CoverageMap -> IO ()
-saveCoverage isHtml seed (Just d) sc cs s = let filepath = if isHtml then ".html" else ".txt"
-                                                fn = d ++ "/covered." ++ show seed ++ filepath
-                                                cc = ppCoveredCode isHtml sc cs s
+saveCoverage :: Bool -> Int -> FilePath -> SourceCache -> [SolcContract] -> CoverageMap -> IO ()
+saveCoverage isHtml seed d sc cs s = let filepath = if isHtml then ".html" else ".txt"
+                                         fn = d </> "covered." </> show seed </> filepath
+                                         cc = ppCoveredCode isHtml sc cs s
                                        in writeFile fn cc
-saveCoverage _ _ Nothing  _  _  _ = pure ()
-
 
 -- | Pretty-print the covered code
 ppCoveredCode :: Bool -> SourceCache -> [SolcContract] -> CoverageMap -> Text
 ppCoveredCode isHtml sc cs s | s == mempty = "Coverage map is empty"
                              | otherwise   =
   let allFiles = zipWith (\(srcPath, _rawSource) srcLines -> (srcPath, V.map decodeUtf8 srcLines))
-                   (sc ^. sourceFiles)
-                   (sc ^. sourceLines)
+                   sc._sourceFiles
+                   sc._sourceLines
       -- ^ Collect all the possible lines from all the files
       covLines = srcMapCov sc s cs
       -- ^ List of covered lines during the fuzzing campaing
@@ -119,7 +118,7 @@ srcMapCov sc s contracts =
     mapContract c =
       mapMaybe (srcMapForOpLocation c) .                  -- Get the mapped line and tx result
       S.toList . fromMaybe S.empty $                      -- Convert from Set to list
-      M.lookup (getBytecodeMetadata $ c ^. runtimeCode) s -- Get the coverage information of the current contract
+      M.lookup (getBytecodeMetadata c._runtimeCode) s -- Get the coverage information of the current contract
 
 -- | Given a source cache, a mapped line, return a tuple with the filename, number of line and tx result
 srcMapCodePosResult :: SourceCache -> (SrcMap, TxResult) -> Maybe (Text, Int, TxResult)
@@ -130,7 +129,7 @@ srcMapCodePosResult sc (n, r) = case srcMapCodePos sc n of
 -- | Given a contract, and tuple as coverage, return the corresponding mapped line (if any)
 srcMapForOpLocation :: SolcContract -> CoverageInfo -> Maybe (SrcMap, TxResult)
 srcMapForOpLocation contract (_,n,_,r) =
-  case preview (ix n) (contract ^. runtimeSrcmap <> contract ^. creationSrcmap) of
+  case preview (ix n) (contract._runtimeSrcmap <> contract._creationSrcmap) of
     Just sm -> Just (sm,r)
     _       -> Nothing
 
@@ -142,4 +141,4 @@ buildRuntimeLinesMap sc contracts =
     [(k, S.singleton v) | (k, v) <- mapMaybe (srcMapCodePos sc) srcMaps]
   where
   srcMaps = concatMap
-    (\c -> toList $ c ^. runtimeSrcmap <> c ^. creationSrcmap) contracts
+    (\c -> toList $ c._runtimeSrcmap <> c._creationSrcmap) contracts

--- a/lib/Echidna/Processor.hs
+++ b/lib/Echidna/Processor.hs
@@ -52,7 +52,7 @@ filterResults Nothing rs = hashSig <$> (concat . M.elems) rs
 
 enhanceConstants :: SlitherInfo -> [AbiValue]
 enhanceConstants si =
-  nubOrd . concatMap enh . concat . concat . M.elems $ M.elems <$> constantValues si
+  nubOrd . concatMap enh . concat . concat . M.elems $ M.elems <$> si.constantValues
   where
     enh (AbiUInt _ n) = makeNumAbiValues (fromIntegral n)
     enh (AbiInt _ n) = makeNumAbiValues (fromIntegral n)

--- a/lib/Echidna/Processor.hs
+++ b/lib/Echidna/Processor.hs
@@ -2,7 +2,6 @@
 
 module Echidna.Processor where
 
-import Control.Monad.IO.Class (MonadIO(..))
 import Control.Exception (Exception)
 import Control.Monad.Catch (MonadThrow(..))
 import Data.Aeson ((.:), (.:?), (.!=), decode, parseJSON, withEmbeddedJSON, withObject)
@@ -134,12 +133,12 @@ instance FromJSON SlitherInfo where
         where failure v t = fail $ "failed to parse " ++ t ++ ": " ++ v
 
 -- Slither processing
-runSlither :: (MonadIO m, MonadThrow m) => FilePath -> [String] -> m SlitherInfo
+runSlither :: FilePath -> [String] -> IO SlitherInfo
 runSlither fp extraArgs = if ".vy" `isSuffixOf` pack fp then return noInfo else do
-  mp <- liftIO $ findExecutable "slither"
+  mp <- findExecutable "slither"
   case mp of
     Nothing -> throwM $ ProcessorNotFound "slither" "You should install it using 'pip3 install slither-analyzer --user'"
-    Just path -> liftIO $ do
+    Just path -> do
       let args = ["--ignore-compile", "--print", "echidna", "--json", "-"] ++ extraArgs ++ [fp]
       (ec, out, err) <- readCreateProcessWithExitCode (proc path args) {std_err = Inherit} ""
       case ec of

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -9,7 +9,6 @@ import Control.Lens
 import Control.Monad (void)
 import Control.Monad.Catch (MonadThrow, throwM)
 import Control.Monad.Fail qualified as M (MonadFail(..))
-import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.State.Strict (MonadState, get, put, execStateT)
 import Data.Aeson (FromJSON(..), (.:), withObject, eitherDecodeFileStrict)
 import Data.ByteString.Base16 qualified as BS16 (decode)

--- a/lib/Echidna/RPC.hs
+++ b/lib/Echidna/RPC.hs
@@ -84,8 +84,7 @@ instance Exception EthenoException
 
 loadEtheno :: FilePath -> IO [Etheno]
 loadEtheno fp = do
-  bs <- liftIO $ eitherDecodeFileStrict fp
-
+  bs <- eitherDecodeFileStrict fp
   case bs of
        (Left e) -> throwM $ EthenoException e
        (Right (ethenoInit :: [Etheno])) -> return ethenoInit

--- a/lib/Echidna/Shrink.hs
+++ b/lib/Echidna/Shrink.hs
@@ -1,13 +1,13 @@
 module Echidna.Shrink where
 
-import Control.Lens
 import Control.Monad ((<=<))
 import Control.Monad.Catch (MonadThrow)
-import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform, uniformMay)
+import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader, asks)
 import Control.Monad.State.Strict (MonadState(get, put))
 import Data.Foldable (traverse_)
-import Data.Maybe (fromMaybe)
+import Data.Set qualified as Set
+import Data.List qualified as List
 
 import EVM (VM)
 
@@ -16,7 +16,7 @@ import Echidna.Transaction
 import Echidna.Events (Events)
 import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Test (TestValue(..))
-import Echidna.Types.Tx (Tx, TxResult, src)
+import Echidna.Types.Tx (Tx(..), TxResult)
 import Echidna.Types.Config
 
 -- | Given a call sequence that solves some Echidna test, try to randomly generate a smaller one that
@@ -39,10 +39,15 @@ shrinkSeq f (v,es,r) xs = do
       res <- traverse_ execTx xs' >> f
       put og
       pure res
-    shrinkSender x = do
-      l <- asks (.cfg._sConf._sender)
-      case ifind (const (== x ^. src)) l of
-        Nothing     -> pure x
-        Just (i, _) -> flip (set src) x . fromMaybe (x ^. src) <$> uniformMay (l ^.. folded . indices (< i))
     shrunk = mapM (shrinkSender <=< shrinkTx) xs
     shorten = (\i -> take i xs ++ drop (i + 1) xs) <$> getRandomR (0, length xs)
+
+shrinkSender :: (MonadReader Env m, MonadRandom m) => Tx -> m Tx
+shrinkSender x = do
+  senderSet <- asks (.cfg._sConf._sender)
+  let orderedSenders = List.sort $ Set.toList senderSet
+  case List.elemIndex x.src orderedSenders of
+    Just i | i > 0 -> do
+      sender <- uniform (take i orderedSenders)
+      pure x{src = sender}
+    _ -> pure x

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -43,6 +43,8 @@ import Echidna.Types.Solidity hiding (deployBytecodes, deployContracts)
 import Echidna.Types.Test (EchidnaTest(..))
 import Echidna.Types.Tx (basicTx, createTxWithValue, unlimitedGasPerBlock, initialTimestamp, initialBlockNumber)
 import Echidna.Types.World (World(..))
+import qualified Data.Set as Set
+import Data.Set (Set)
 
 -- | Given a list of source caches (SourceCaches) and an optional contract name,
 -- select one that includes that contract (if possible). Otherwise, use the first source
@@ -104,16 +106,18 @@ removeJsonFiles dir =
         let path = dir </> file
         whenM (doesFileExist path) $ removeFile path
 
-addresses :: SolConf -> NE.NonEmpty AbiValue
+addresses :: SolConf -> Set AbiValue
 addresses SolConf{_contractAddr, _deployer, _sender} = do
-  AbiAddress . fromIntegral <$> NE.nub (join _sender [_contractAddr, _deployer, 0x0])
-  where join (f NE.:| r) l = f NE.:| (r ++ l)
+  Set.map AbiAddress $ Set.union _sender (Set.fromList [_contractAddr, _deployer, 0x0])
 
-populateAddresses :: [Addr] -> Integer -> VM -> VM
-populateAddresses []     _ vm = vm
-populateAddresses (a:as) b vm = if deployed then populateAddresses as b vm else populateAddresses as b (vm & set (env . EVM.contracts . at a) (Just account))
-  where account   = initialContract (RuntimeCode (ConcreteRuntimeCode mempty)) & set nonce 0 & set balance (fromInteger b)
-        deployed = a `member` (vm ^. env . EVM.contracts)
+populateAddresses :: Set Addr -> Integer -> VM -> VM
+populateAddresses addrs b vm =
+  Set.foldl' (\vm' addr ->
+    if deployed addr then vm'
+    else vm' & set (env . EVM.contracts . at addr) (Just account)
+ ) vm addrs
+  where account = initialContract (RuntimeCode (ConcreteRuntimeCode mempty)) & set nonce 0 & set balance (fromInteger b)
+        deployed addr = addr `member` vm._env._contracts
 
 -- | Address to load the first library
 addrLibrary :: Addr
@@ -142,7 +146,7 @@ filterMethodsWithArgs ms = case NE.filter (\(_, xs) -> not $ null xs) ms of
                              fs -> NE.fromList fs
 
 abiOf :: Text -> SolcContract -> NE.NonEmpty SolSignature
-abiOf pref cc = fallback NE.:| filter (not . isPrefixOf pref . fst) (elems (cc ^. abiMap) <&> \m -> (m ^. methodName, m ^.. methodInputs . traverse . _2))
+abiOf pref cc = fallback NE.:| filter (not . isPrefixOf pref . fst) (elems (cc._abiMap) <&> \m -> (m._methodName, m ^.. methodInputs . traverse . _2))
 
 -- | Given an optional contract name and a list of 'SolcContract's, try to load the specified
 -- contract, or, if not provided, the first contract in the list, into a 'VM' usable for Echidna
@@ -162,19 +166,19 @@ loadSpecified solConf name cs = do
   let SolConf ca d ads bala balc mcs pref _ _ libs _ fp dpc dpb ma tm _ fs = solConf
 
   -- generate the complete abi mapping
-  let bc = c ^. creationCode
-      abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c ^. abiMap)
+  let bc = c._creationCode
+      abi = liftM2 (,) (view methodName) (fmap snd . view methodInputs) <$> toList (c._abiMap)
       con = view constructorInputs c
       (tests, funs) = partition (isPrefixOf pref . fst) abi
 
 
   -- Filter ABI according to the config options
-  let fabiOfc = if isDapptestMode tm then filterMethodsWithArgs (abiOf pref c) else filterMethods (c ^. contractName) fs $ abiOf pref c
+  let fabiOfc = if isDapptestMode tm then filterMethodsWithArgs (abiOf pref c) else filterMethods (c._contractName) fs $ abiOf pref c
   -- Filter again for dapptest tests or assertions checking if enabled
-  let neFuns = filterMethods (c ^. contractName) fs (fallback NE.:| funs)
+  let neFuns = filterMethods (c._contractName) fs (fallback NE.:| funs)
   -- Construct ABI mapping for World
-  let abiMapping = if ma then M.fromList $ cs <&> \cc -> (getBytecodeMetadata $ cc ^. runtimeCode,  filterMethods (cc ^. contractName) fs $ abiOf pref cc)
-                         else M.singleton (getBytecodeMetadata $ c ^. runtimeCode) fabiOfc
+  let abiMapping = if ma then M.fromList $ cs <&> \cc -> (getBytecodeMetadata cc._runtimeCode, filterMethods (cc._contractName) fs $ abiOf pref cc)
+                         else M.singleton (getBytecodeMetadata c._runtimeCode) fabiOfc
 
 
   -- Set up initial VM, either with chosen contract or Etheno initialization file
@@ -182,7 +186,7 @@ loadSpecified solConf name cs = do
   let vm = initialVM & block . gaslimit .~ fromInteger unlimitedGasPerBlock
                      & block . maxCodeSize .~ fromInteger mcs
   blank' <- liftIO $ maybe (pure vm) loadEthenoBatch fp
-  let blank = populateAddresses (NE.toList ads |> d) bala blank'
+  let blank = populateAddresses (Set.insert d ads) bala blank'
 
   unless (null con || isJust fp) (throwM $ ConstructorArgs (show con))
   -- Select libraries
@@ -194,12 +198,12 @@ loadSpecified solConf name cs = do
     $ throwM NoTests
   when (null abiMapping && isDapptestMode tm)                   -- < Dapptests checks
     $ throwM NoTests
-  when (bc == mempty) $ throwM (NoBytecode $ c ^. contractName) -- Bytecode check
+  when (bc == mempty) $ throwM (NoBytecode c._contractName) -- Bytecode check
   case find (not . null . snd) tests of
     Just (t,_) -> throwM $ TestArgsFound t                      -- Test args check
     Nothing    -> do
       -- dappinfo for debugging in case of failure
-      let di = dappInfo "/" (Map.fromList $ map (\x -> (x ^. contractName, x)) cs) mempty
+      let di = dappInfo "/" (Map.fromList $ map (\x -> (x._contractName, x)) cs) mempty
 
       -- library deployment
       vm0 <- deployContracts di (zip [addrLibrary ..] ls) d blank
@@ -220,9 +224,9 @@ loadSpecified solConf name cs = do
       let transaction = execTx $ uncurry basicTx setUpFunction d ca (fromInteger unlimitedGasPerBlock) (0, 0)
       vm4 <- if isDapptestMode tm && setUpFunction `elem` abi then execStateT transaction vm3 else return vm3
 
-      case vm4 ^. result of
+      case vm4._result of
         Just (VMFailure _) -> throwM SetUpCallFailed
-        _                  -> return (vm4, unions $ map (view eventMap) cs, neFuns, fst <$> tests, abiMapping)
+        _                  -> return (vm4, unions $ map (view EVM.Solidity.eventMap) cs, neFuns, fst <$> tests, abiMapping)
 
   where choose []    _        = throwM NoContracts
         choose (c:_) Nothing  = return c
@@ -248,12 +252,12 @@ prepareForTest :: SolConf
                -> SlitherInfo
                -> (VM, World, [EchidnaTest])
 prepareForTest SolConf{_sender, _testMode, _testDestruction} (vm, em, a, ts, m) c si = do
-  let r = vm ^. state . contract
+  let r = vm._state._contract
       a' = NE.toList a
-      ps = filterResults c $ payableFunctions si
-      as = if isAssertionMode _testMode then filterResults c $ asserts si else []
-      cs = if isDapptestMode _testMode then [] else filterResults c (constantFunctions si) \\ as
-      (hm, lm) = prepareHashMaps cs as $ filterFallbacks c (fallbackDefined si) (receiveDefined si) m
+      ps = filterResults c si.payableFunctions
+      as = if isAssertionMode _testMode then filterResults c si.asserts else []
+      cs = if isDapptestMode _testMode then [] else filterResults c si.constantFunctions \\ as
+      (hm, lm) = prepareHashMaps cs as $ filterFallbacks c si.fallbackDefined si.receiveDefined m
   (vm, World _sender hm lm ps em, createTests _testMode _testDestruction ts r a')
 
 
@@ -268,7 +272,7 @@ filterFallbacks _ _ _ sm = sm
 prepareForTest' :: SolConf -> (VM, EventMap, NE.NonEmpty SolSignature, [Text], SignatureMap)
                -> (VM, World, [EchidnaTest])
 prepareForTest' SolConf{_sender, _testMode} (v, em, a, ts, _) = do
-  let r = v ^. state . contract
+  let r = v._state._contract
       a' = NE.toList a
   (v, World _sender M.empty Nothing [] em, createTests _testMode True ts r a')
 
@@ -309,5 +313,5 @@ extremeConstants = concatMap (\i -> [mkSmallAbiInt i, mkLargeAbiInt i, mkLargeAb
 returnTypes :: [SolcContract] -> Text -> Maybe AbiType
 returnTypes cs t = do
   method <- find ((== t) . view methodName) $ concatMap (toList . view abiMap) cs
-  (_, abiType) <- listToMaybe $ method ^. methodOutput
+  (_, abiType) <- listToMaybe method._methodOutput
   pure abiType

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -5,17 +5,17 @@
 module Echidna.Transaction where
 
 import Control.Lens
-import Control.Monad (join, liftM2)
+import Control.Monad (join)
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.Reader.Class (MonadReader, asks)
 import Control.Monad.State.Strict (MonadState, gets)
-import Data.List.NonEmpty qualified as NE
 import Data.HashMap.Strict qualified as M
 import Data.Map (Map, toList)
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Vector qualified as V
-import EVM hiding (Env, value)
+import EVM
 import EVM.ABI (abiValueType)
 import EVM.Types (Expr(ConcreteBuf, Lit), Addr, W256)
 
@@ -27,7 +27,7 @@ import Echidna.Types.Buffer (viewBuffer, forceLit)
 import Echidna.Types.Signature (SignatureMap, SolCall, ContractA, FunctionHash, BytecodeMemo, lookupBytecodeMetadata)
 import Echidna.Types.Tx
 import Echidna.Types.World (World(..))
-import Echidna.Types.Campaign (Campaign, _genDict)
+import Echidna.Types.Campaign (Campaign(..))
 
 hasSelfdestructed :: VM -> Addr -> Bool
 hasSelfdestructed vm addr = addr `elem` vm._tx._substate._selfdestructs
@@ -52,9 +52,9 @@ genTxM memo m = do
   World ss hmm lmm ps _ <- asks fst
   genDict <- gets (._genDict)
   mm <- getSignatures hmm lmm
-  let ns = _dictValues genDict
-  s' <- rElem ss
-  r' <- rElem $ NE.fromList (mapMaybe (toContractA mm) (toList m))
+  let ns = genDict._dictValues
+  s' <- rElem' ss
+  r' <- rElem' $ Set.fromList (mapMaybe (toContractA mm) (toList m))
   c' <- genInteractionsM genDict (snd r')
   v' <- genValue mv ns ps c'
   t' <- (,) <$> genDelay t ns <*> genDelay b ns
@@ -96,27 +96,33 @@ removeCallTx (Tx _ _ r _ _ _ d) = Tx NoCall 0 r 0 0 0 d
 -- | Given a 'Transaction', generate a random \"smaller\" 'Transaction', preserving origin,
 -- destination, value, and call signature.
 shrinkTx :: MonadRandom m => Tx -> m Tx
-shrinkTx tx'@(Tx c _ _ _ gp v (t, b)) = let
-  c' = case c of
-         SolCall sc -> SolCall <$> shrinkAbiCall sc
-         _ -> pure c
+shrinkTx tx = let
+  shrinkCall = case tx.call of
+   SolCall sc -> SolCall <$> shrinkAbiCall sc
+   _ -> pure tx.call
   lower 0 = pure 0
   lower x = (getRandomR (0 :: Integer, fromIntegral x)
               >>= (\r -> uniform [0, r]) . fromIntegral)  -- try 0 quicker
   possibilities =
-    [ set call      <$> c'
-    , set value     <$> lower v
-    , set gasprice' <$> lower gp
-    , set delay     <$> fmap level (liftM2 (,) (lower t) (lower b))
+    [ do call' <- shrinkCall
+         pure tx { call = call' }
+    , do value' <- lower tx.value
+         pure tx { Echidna.Types.Tx.value = value' }
+    , do gasprice' <- lower tx.gasprice
+         pure tx { Echidna.Types.Tx.gasprice = gasprice' }
+    , do let (time, blocks) = tx.delay
+         delay' <- level <$> ((,) <$> lower time <*> lower blocks)
+         pure tx { delay = delay' }
     ]
-  in join $ usuallyRarely (join (uniform possibilities) <*> pure tx') (pure $ removeCallTx tx')
+  in join $ usuallyRarely (join (uniform possibilities)) (pure $ removeCallTx tx)
 
 mutateTx :: (MonadRandom m) => Tx -> m Tx
-mutateTx t@(Tx (SolCall c) _ _ _ _ _ _) = do f <- oftenUsually skip mutate
-                                             f c
-                                           where mutate  z = mutateAbiCall z >>= \c' -> pure $ t { _call = SolCall c' }
-                                                 skip    _ = pure t
-mutateTx t                              = pure t
+mutateTx t@(Tx (SolCall c) _ _ _ _ _ _) = do
+  f <- oftenUsually skip mutate
+  f c
+  where mutate z = mutateAbiCall z >>= \c' -> pure $ t { call = SolCall c' }
+        skip _ = pure t
+mutateTx t = pure t
 
 -- | Given a 'Transaction', set up some 'VM' so it can be executed. Effectively, this just brings
 -- 'Transaction's \"on-chain\".

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -96,25 +96,25 @@ removeCallTx (Tx _ _ r _ _ _ d) = Tx NoCall 0 r 0 0 0 d
 -- | Given a 'Transaction', generate a random \"smaller\" 'Transaction', preserving origin,
 -- destination, value, and call signature.
 shrinkTx :: MonadRandom m => Tx -> m Tx
-shrinkTx tx = let
-  shrinkCall = case tx.call of
+shrinkTx tx' = let
+  shrinkCall = case tx'.call of
    SolCall sc -> SolCall <$> shrinkAbiCall sc
-   _ -> pure tx.call
+   _ -> pure tx'.call
   lower 0 = pure 0
   lower x = (getRandomR (0 :: Integer, fromIntegral x)
               >>= (\r -> uniform [0, r]) . fromIntegral)  -- try 0 quicker
   possibilities =
     [ do call' <- shrinkCall
-         pure tx { call = call' }
-    , do value' <- lower tx.value
-         pure tx { Echidna.Types.Tx.value = value' }
-    , do gasprice' <- lower tx.gasprice
-         pure tx { Echidna.Types.Tx.gasprice = gasprice' }
-    , do let (time, blocks) = tx.delay
+         pure tx' { call = call' }
+    , do value' <- lower tx'.value
+         pure tx' { Echidna.Types.Tx.value = value' }
+    , do gasprice' <- lower tx'.gasprice
+         pure tx' { Echidna.Types.Tx.gasprice = gasprice' }
+    , do let (time, blocks) = tx'.delay
          delay' <- level <$> ((,) <$> lower time <*> lower blocks)
-         pure tx { delay = delay' }
+         pure tx' { delay = delay' }
     ]
-  in join $ usuallyRarely (join (uniform possibilities)) (pure $ removeCallTx tx)
+  in join $ usuallyRarely (join (uniform possibilities)) (pure $ removeCallTx tx')
 
 mutateTx :: (MonadRandom m) => Tx -> m Tx
 mutateTx t@(Tx (SolCall c) _ _ _ _ _ _) = do

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -3,12 +3,8 @@
 module Echidna.Types.Campaign where
 
 import Control.Lens
-import Data.Aeson (ToJSON(..), object)
-import Data.Foldable (toList)
-import Data.Map (Map, mapKeys)
+import Data.Map (Map)
 import Data.Text (Text)
-import EVM.Types (keccak')
-import Numeric (showHex)
 
 import Echidna.ABI (GenDict, defaultDict)
 import Echidna.Types
@@ -62,12 +58,6 @@ data Campaign = Campaign { _tests       :: [EchidnaTest]
                            -- ^ Stored results of getBytecodeMetadata on all contracts
                          }
 makeLenses ''Campaign
-
-instance ToJSON Campaign where
-  toJSON (Campaign ts co gi _ _ _ _ _) = object $ ("tests", toJSON $ map format ts)
-    : [("coverage",) . toJSON . mapKeys (("0x" <>) . (`showHex` "") . keccak') $ toList <$> co | co /= mempty] ++
-      [(("maxgas",) . toJSON . toList) gi | gi /= mempty] where
-        format _ = "" :: String -- TODO: complete this format string
 
 defaultCampaign :: Campaign
 defaultCampaign = Campaign mempty mempty mempty defaultDict False mempty 0 mempty

--- a/lib/Echidna/Types/Solidity.hs
+++ b/lib/Echidna/Types/Solidity.hs
@@ -4,8 +4,8 @@ module Echidna.Types.Solidity where
 
 import Control.Exception (Exception)
 import Control.Lens
-import Data.List.NonEmpty qualified as NE
 import Data.SemVer (Version, version, toString)
+import Data.Set (Set)
 import Data.Text (Text, unpack)
 
 import EVM.Solidity
@@ -36,7 +36,6 @@ data SolException = BadAddr Addr
                   | NoCryticCompile
                   | InvalidMethodFilters Filter
                   | OutdatedSolcVersion Version
-makePrisms ''SolException
 
 instance Show SolException where
   show = \case
@@ -63,7 +62,7 @@ instance Exception SolException
 -- | Configuration for loading Solidity for Echidna testing.
 data SolConf = SolConf { _contractAddr    :: Addr             -- ^ Contract address to use
                        , _deployer        :: Addr             -- ^ Contract deployer address to use
-                       , _sender          :: NE.NonEmpty Addr -- ^ Sender addresses to use
+                       , _sender          :: Set Addr         -- ^ Sender addresses to use
                        , _balanceAddr     :: Integer          -- ^ Initial balance of deployer and senders
                        , _balanceContract :: Integer          -- ^ Initial balance of contract to test
                        , _codeSize        :: Integer          -- ^ Max code size for deployed contratcs (default 24576, per EIP-170)

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Echidna.Types.Test where
 
-import Control.Lens
 import Data.Aeson (ToJSON(..), object)
 import Data.DoubleWord (Int256)
 import Data.Maybe (maybeToList)
@@ -73,33 +70,31 @@ instance Eq TestState where
 
 -- | An Echidna test is represented with the following data record
 data EchidnaTest = EchidnaTest {
-                                 _testState      :: TestState
-                               , _testType       :: TestType
-                               , _testValue      :: TestValue
-                               , _testReproducer :: [Tx]
-                               , _testResult     :: TxResult
-                               , _testEvents     :: Events
+                                 testState      :: TestState
+                               , testType       :: TestType
+                               , testValue      :: TestValue
+                               , testReproducer :: [Tx]
+                               , testResult     :: TxResult
+                               , testEvents     :: Events
                                } deriving Eq
-
-makeLenses ''EchidnaTest
 
 isOptimizationTest :: TestType -> Bool
 isOptimizationTest (OptimizationTest _ _) = True
 isOptimizationTest _                      = False
 
 isOpen :: EchidnaTest -> Bool
-isOpen t = case t ^. testState of
+isOpen t = case t.testState of
             Open _ -> True
             _      -> False
 
 didFailed :: EchidnaTest -> Bool
-didFailed t = case t ^. testState of
+didFailed t = case t.testState of
               Large _ -> True
               Solved  -> True
               _       -> False
 
 isPassed :: EchidnaTest -> Bool
-isPassed t = case t ^. testState of
+isPassed t = case t.testState of
               Passed -> True
               _      -> False
 

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -7,7 +7,6 @@ module Echidna.Types.Tx where
 import Prelude hiding (Word)
 
 import Control.Applicative ((<|>))
-import Control.Lens.TH (makePrisms, makeLenses)
 import Data.Aeson (FromJSON, ToJSON, parseJSON, toJSON, object, withObject, (.=), (.:))
 import Data.Aeson.TH (deriveJSON, defaultOptions)
 import Data.Aeson.Types (Parser)
@@ -30,7 +29,6 @@ data TxCall = SolCreate   ByteString
             | SolCalldata ByteString
             | NoCall
   deriving (Show, Ord, Eq)
-makePrisms ''TxCall
 $(deriveJSON defaultOptions ''TxCall)
 
 maxGasPerBlock :: Integer
@@ -53,25 +51,24 @@ initialBlockNumber = 4370000  -- Initial byzantium block
 
 -- | A transaction is either a @CREATE@ or a regular call with an origin, destination, and value.
 -- Note: I currently don't model nonces or signatures here.
-data Tx = Tx { _call  :: TxCall       -- | Call
-             , _src   :: Addr         -- | Origin
-             , _dst   :: Addr         -- | Destination
-             , _gas'  :: Word64       -- | Gas
-             , _gasprice' :: W256     -- | Gas price
-             , _value :: W256         -- | Value
-             , _delay :: (W256, W256) -- | (Time, # of blocks since last call)
+data Tx = Tx { call  :: TxCall       -- | Call
+             , src   :: Addr         -- | Origin
+             , dst   :: Addr         -- | Destination
+             , gas   :: Word64       -- | Gas
+             , gasprice :: W256     -- | Gas price
+             , value :: W256         -- | Value
+             , delay :: (W256, W256) -- | (Time, # of blocks since last call)
              } deriving (Eq, Ord, Show)
-makeLenses ''Tx
 
 instance ToJSON Tx where
   toJSON Tx{..} = object
-    [ "call" .= _call
-    , "src" .= _src
-    , "dst" .= _dst
-    , "gas" .= _gas'
-    , "gasprice" .= _gasprice'
-    , "value" .= _value
-    , "delay" .= _delay
+    [ "call" .= call
+    , "src" .= src
+    , "dst" .= dst
+    , "gas" .= gas
+    , "gasprice" .= gasprice
+    , "value" .= value
+    , "delay" .= delay
     ]
 
 instance FromJSON Tx where
@@ -164,20 +161,20 @@ data TxResult = ReturnTrue
   deriving (Eq, Ord, Show)
 $(deriveJSON defaultOptions ''TxResult)
 
-data TxConf = TxConf { _propGas       :: Word64
+data TxConf = TxConf { propGas       :: Word64
                      -- ^ Gas to use evaluating echidna properties
-                     , _txGas         :: Word64
+                     , txGas         :: Word64
                      -- ^ Gas to use in generated transactions
-                     , _maxGasprice   :: W256
+                     , maxGasprice   :: W256
                      -- ^ Maximum gasprice to be checked for a transaction
-                     , _maxTimeDelay  :: W256
+                     , maxTimeDelay  :: W256
                      -- ^ Maximum time delay between transactions (seconds)
-                     , _maxBlockDelay :: W256
+                     , maxBlockDelay :: W256
                      -- ^ Maximum block delay between transactions
-                     , _maxValue      :: W256
+                     , maxValue      :: W256
                      -- ^ Maximum value to use in transactions
                      }
-makeLenses 'TxConf
+
 -- | Transform a VMResult into a more hash friendly sum type
 getResult :: VMResult -> TxResult
 getResult (VMSuccess b) | viewBuffer b == Just (encodeAbiValue (AbiBool True))  = ReturnTrue

--- a/lib/Echidna/Types/World.hs
+++ b/lib/Echidna/Types/World.hs
@@ -1,24 +1,19 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Echidna.Types.World where
-
-import Control.Lens.TH (makeLenses)
-import Data.List.NonEmpty (NonEmpty)
 
 import EVM.Types (Addr)
 
 import Echidna.Types.Signature (FunctionHash, SignatureMap)
 import Echidna.Events (EventMap)
+import Data.Set (Set)
 
 -- | The world is composed by:
 --    * A list of "human" addresses
 --    * A high-priority map of signatures from every contract
 --    * A low-priority map of signatures from every contract
 --    * A list of function hashes from payable functions
-data World = World { _senders          :: NonEmpty Addr
-                   , _highSignatureMap :: SignatureMap
-                   , _lowSignatureMap  :: Maybe SignatureMap
-                   , _payableSigs      :: [FunctionHash]
-                   , _eventMap         :: EventMap
+data World = World { senders          :: Set Addr
+                   , highSignatureMap :: SignatureMap
+                   , lowSignatureMap  :: Maybe SignatureMap
+                   , payableSigs      :: [FunctionHash]
+                   , eventMap         :: EventMap
                    }
-makeLenses ''World

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -50,7 +50,7 @@ ui vm world ts d txs = do
       secToUsec = (* 1000000)
       timeoutUsec = secToUsec $ fromMaybe (-1) uiConf.maxTime
       runCampaign = timeout timeoutUsec (campaign updateRef vm world ts d txs)
-  terminalPresent <- isTerminal
+  terminalPresent <- liftIO isTerminal
   let effectiveMode = case uiConf.operationMode of
         Interactive | not terminalPresent -> NonInteractive Text
         other -> other
@@ -113,5 +113,5 @@ monitor = do
   pure $ App (pure . cs conf) neverShowCursor se (pure ()) (const attrs)
 
 -- | Heuristic check that we're in a sensible terminal (not a pipe)
-isTerminal :: MonadIO m => m Bool
-isTerminal = liftIO $ (&&) <$> queryTerminal (Fd 0) <*> queryTerminal (Fd 1)
+isTerminal :: IO Bool
+isTerminal = (&&) <$> queryTerminal (Fd 0) <*> queryTerminal (Fd 1)

--- a/package.yaml
+++ b/package.yaml
@@ -17,7 +17,6 @@ dependencies:
   - containers
   - data-bword
   - data-dword
-  - data-has
   - extra
   - directory
   - exceptions
@@ -52,8 +51,11 @@ language: GHC2021
 
 default-extensions:
   - LambdaCase
-  - OverloadedRecordDot
   - OverloadedStrings
+
+  - DuplicateRecordFields
+  - NoFieldSelectors
+  - OverloadedRecordDot
 
 library:
   source-dirs: lib/

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,7 +10,7 @@ import Data.Aeson.Key qualified as Aeson.Key
 import Data.List.NonEmpty qualified as NE
 import Data.Map (fromList)
 import Data.Maybe (fromMaybe)
-import Data.Set qualified as DS
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Time.Clock.System (getSystemTime, systemSeconds)
 import Data.Version (showVersion)
@@ -18,22 +18,58 @@ import EVM.Types (Addr)
 import Options.Applicative
 import Paths_echidna (version)
 import System.Exit (exitWith, exitSuccess, ExitCode(..))
+import System.FilePath ((</>))
 import System.IO (hPutStrLn, stderr)
 
 import EVM.Dapp (dappInfo)
-import EVM.Solidity (contractName)
+import EVM.Solidity (SolcContract(..))
 
 import Echidna
 import Echidna.Config
 import Echidna.Types.Config
 import Echidna.Types.Solidity
 import Echidna.Types.Campaign
-import Echidna.Types.Test (TestMode, testReproducer)
+import Echidna.Types.Test (TestMode, EchidnaTest(..))
 import Echidna.Test (validateTestMode)
-import Echidna.Campaign (isSuccess)
+import Echidna.Campaign (isSuccessful)
 import Echidna.UI
 import Echidna.Output.Source
 import Echidna.Output.Corpus
+
+main :: IO ()
+main = do
+  opts@Options{..} <- execParser optsParser
+  g <- getRandom
+  EConfigWithUsage loadedCfg ks _ <-
+    maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig cliConfigFilepath
+  let cfg = overrideConfig loadedCfg opts
+  unless cfg._sConf._quiet $
+    mapM_ (hPutStrLn stderr . ("Warning: unused option: " ++) . Aeson.Key.toString) ks
+
+  (v, sc, cs, w, ts, d, txs) <- prepareContract cfg cliFilePath cliSelectedContract g
+  let solcByName = fromList [(c._contractName, c) | c <- cs]
+  -- TODO put in real path
+  let dappInfo' = dappInfo "/" solcByName sc
+  let env = Env { cfg = cfg, dapp = dappInfo' }
+  -- start ui and run tests
+  cpg <- runReaderT (ui v w ts (Just d) txs) env
+
+  -- save corpus
+  case cfg._cConf._corpusDir of
+    Nothing -> pure ()
+    Just dir -> do
+      saveTxs (dir </> "reproducers") (filter (not . null) $ (.testReproducer) <$> cpg._tests)
+      saveTxs (dir </> "coverage") (snd <$> Set.toList cpg._corpus)
+
+      -- TODO: add another option to config for saving coverage report
+      -- get current time to save coverage
+      t <- getSystemTime
+      let s = fromIntegral $ systemSeconds t
+      -- save source coverage
+      saveCoverage False s dir sc cs (cpg._coverage)
+      saveCoverage True  s dir sc cs (cpg._coverage)
+
+  if isSuccessful cpg then exitSuccess else exitWith (ExitFailure 1)
 
 data Options = Options
   { cliFilePath         :: NE.NonEmpty FilePath
@@ -54,93 +90,63 @@ data Options = Options
   , cliSolcArgs         :: Maybe String
   }
 
-options :: Parser Options
-options = Options <$> (NE.fromList <$> some (argument str (metavar "FILES"
-                        <> help "Solidity files to analyze")))
-                  <*> optional (option str $ long "contract"
-                        <> metavar "CONTRACT"
-                        <> help "Contract to analyze")
-                  <*> optional (option str $ long "config"
-                        <> metavar "CONFIG"
-                        <> help "Config file (command-line arguments override config options)")
-                  <*> optional (option auto $ long "format"
-                        <> metavar "FORMAT"
-                        <> help "Output format. Either 'json', 'text', 'none'. All these disable interactive UI")
-                  <*> optional (option str $ long "corpus-dir"
-                        <> metavar "PATH"
-                        <> help "Directory to save and load corpus and coverage data.")
-                  <*> optional (option str $ long "test-mode"
-                        <> help "Test mode to use. Either 'property', 'assertion', 'dapptest', 'optimization', 'overflow' or 'exploration'" )
-                  <*> switch (long "multi-abi"
-                        <> help "Use multi-abi mode of testing.")
-                  <*> optional (option auto $ long "test-limit"
-                        <> metavar "INTEGER"
-                        <> help ("Number of sequences of transactions to generate during testing. Default is " ++ show defaultTestLimit))
-                  <*> optional (option auto $ long "shrink-limit"
-                        <> metavar "INTEGER"
-                        <> help ("Number of tries to attempt to shrink a failing sequence of transactions. Default is " ++ show defaultShrinkLimit))
-                  <*> optional (option auto $ long "seq-len"
-                        <> metavar "INTEGER"
-                        <> help ("Number of transactions to generate during testing. Default is " ++ show defaultSequenceLength))
-                  <*> optional (option auto $ long "contract-addr"
-                        <> metavar "ADDRESS"
-                        <> help ("Address to deploy the contract to test. Default is " ++ show defaultContractAddr))
-                  <*> optional (option auto $ long "deployer"
-                        <> metavar "ADDRESS"
-                        <> help ("Address of the deployer of the contract to test. Default is " ++ show defaultDeployerAddr))
-                  <*> many (option auto $ long "sender"
-                        <> metavar "ADDRESS"
-                        <> help "Addresses to use for the transactions sent during testing. Can be passed multiple times. Check the documentation to see the default values.")
-                  <*> optional (option auto $ long "seed"
-                        <> metavar "SEED"
-                        <> help "Run with a specific seed.")
-                  <*> optional (option str $ long "crytic-args"
-                        <> metavar "ARGS"
-                        <> help "Additional arguments to use in crytic-compile for the compilation of the contract to test.")
-                  <*> optional (option str $ long "solc-args"
-                        <> metavar "ARGS"
-                        <> help "Additional arguments to use in solc for the compilation of the contract to test.")
-
-versionOption :: Parser (a -> a)
-versionOption = infoOption
-                  ("Echidna " ++ showVersion version)
-                  (long "version" <> help "Show version")
-
 optsParser :: ParserInfo Options
 optsParser = info (helper <*> versionOption <*> options) $ fullDesc
   <> progDesc "EVM property-based testing framework"
   <> header "Echidna"
 
-main :: IO ()
-main = do
-  opts@Options{..} <- execParser optsParser
-  g <- getRandom
-  EConfigWithUsage loadedCfg ks _ <- maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig cliConfigFilepath
-  let cfg = overrideConfig loadedCfg opts
-  unless cfg._sConf._quiet $
-    mapM_ (hPutStrLn stderr . ("Warning: unused option: " ++) . Aeson.Key.toString) ks
-  let cd = cfg._cConf._corpusDir
+options :: Parser Options
+options = Options
+  <$> (NE.fromList <$> some (argument str (metavar "FILES"
+                        <> help "Solidity files to analyze")))
+  <*> optional (option str $ long "contract"
+        <> metavar "CONTRACT"
+        <> help "Contract to analyze")
+  <*> optional (option str $ long "config"
+        <> metavar "CONFIG"
+        <> help "Config file (command-line arguments override config options)")
+  <*> optional (option auto $ long "format"
+        <> metavar "FORMAT"
+        <> help "Output format. Either 'json', 'text', 'none'. All these disable interactive UI")
+  <*> optional (option str $ long "corpus-dir"
+        <> metavar "PATH"
+        <> help "Directory to save and load corpus and coverage data.")
+  <*> optional (option str $ long "test-mode"
+        <> help "Test mode to use. Either 'property', 'assertion', 'dapptest', 'optimization', 'overflow' or 'exploration'" )
+  <*> switch (long "multi-abi"
+        <> help "Use multi-abi mode of testing.")
+  <*> optional (option auto $ long "test-limit"
+        <> metavar "INTEGER"
+        <> help ("Number of sequences of transactions to generate during testing. Default is " ++ show defaultTestLimit))
+  <*> optional (option auto $ long "shrink-limit"
+        <> metavar "INTEGER"
+        <> help ("Number of tries to attempt to shrink a failing sequence of transactions. Default is " ++ show defaultShrinkLimit))
+  <*> optional (option auto $ long "seq-len"
+        <> metavar "INTEGER"
+        <> help ("Number of transactions to generate during testing. Default is " ++ show defaultSequenceLength))
+  <*> optional (option auto $ long "contract-addr"
+        <> metavar "ADDRESS"
+        <> help ("Address to deploy the contract to test. Default is " ++ show defaultContractAddr))
+  <*> optional (option auto $ long "deployer"
+        <> metavar "ADDRESS"
+        <> help ("Address of the deployer of the contract to test. Default is " ++ show defaultDeployerAddr))
+  <*> many (option auto $ long "sender"
+        <> metavar "ADDRESS"
+        <> help "Addresses to use for the transactions sent during testing. Can be passed multiple times. Check the documentation to see the default values.")
+  <*> optional (option auto $ long "seed"
+        <> metavar "SEED"
+        <> help "Run with a specific seed.")
+  <*> optional (option str $ long "crytic-args"
+        <> metavar "ARGS"
+        <> help "Additional arguments to use in crytic-compile for the compilation of the contract to test.")
+  <*> optional (option str $ long "solc-args"
+        <> metavar "ARGS"
+        <> help "Additional arguments to use in solc for the compilation of the contract to test.")
 
-  (v, sc, cs, w, ts, d, txs) <- prepareContract cfg cliFilePath cliSelectedContract g
-  let solcByName = fromList [(c ^. contractName, c) | c <- cs]
-  -- TODO put in real path
-  let dappInfo' = dappInfo "/" solcByName sc
-  let env = Env { cfg = cfg, dapp = dappInfo' }
-  -- start ui and run tests
-  cpg <- runReaderT (ui v w ts d txs) env
-
-  -- save corpus
-  saveTxs (fmap (++ "/reproducers/") cd) (filter (not . null) $ map (^. testReproducer) $ cpg ^. tests)
-  saveTxs (fmap (++ "/coverage/") cd) (snd <$> DS.toList (cpg ^. corpus))
-
-  -- get current time to save coverage
-  t <- getSystemTime
-  let s = fromIntegral $ systemSeconds t
-  -- save source coverage
-  saveCoverage False s cd sc cs (cpg ^. coverage)
-  saveCoverage True  s cd sc cs (cpg ^. coverage)
-
-  if not . isSuccess $ cpg then exitWith $ ExitFailure 1 else exitSuccess
+versionOption :: Parser (a -> a)
+versionOption = infoOption
+                  ("Echidna " ++ showVersion version)
+                  (long "version" <> help "Show version")
 
 overrideConfig :: EConfig -> Options -> EConfig
 overrideConfig config Options{..} =
@@ -192,7 +198,7 @@ overrideConfig config Options{..} =
       cfg & sConf . deployer %~ (`fromMaybe` cliDeployer)
 
     overrideSender cfg =
-      cfg & sConf . sender %~ (`fromMaybe` NE.nonEmpty cliSender)
+      cfg & sConf . sender %~ (`fromMaybe` (Just $ Set.fromList cliSender))
 
     overrideSeed cfg =
       cfg & cConf . seed %~ (cliSeed <|>)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -198,7 +198,9 @@ overrideConfig config Options{..} =
       cfg & sConf . deployer %~ (`fromMaybe` cliDeployer)
 
     overrideSender cfg =
-      cfg & sConf . sender %~ (`fromMaybe` (Just $ Set.fromList cliSender))
+      cfg & sConf . sender %~ (`fromMaybe` (if null cliSender
+                                               then Nothing
+                                               else Just $ Set.fromList cliSender))
 
     overrideSeed cfg =
       cfg & cConf . seed %~ (cliSeed <|>)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -66,8 +66,8 @@ main = do
       t <- getSystemTime
       let s = fromIntegral $ systemSeconds t
       -- save source coverage
-      saveCoverage False s dir sc cs (cpg._coverage)
-      saveCoverage True  s dir sc cs (cpg._coverage)
+      saveCoverage False s dir sc cs cpg._coverage
+      saveCoverage True  s dir sc cs cpg._coverage
 
   if isSuccessful cpg then exitSuccess else exitWith (ExitFailure 1)
 

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -97,7 +97,7 @@ testContractV fp v cfg = testContract' fp Nothing v cfg True
 
 testContract' :: FilePath -> Maybe ContractName -> Maybe SolcVersionComp -> Maybe FilePath -> Bool -> [(String, Campaign -> Bool)] -> TestTree
 testContract' fp n v cfg s as = testCase fp $ withSolcVersion v $ do
-  c <- set (sConf . quiet) True <$> maybe (pure testConfig) ((fmap (.econfig)) . parseConfig) cfg
+  c <- set (sConf . quiet) True <$> maybe (pure testConfig) (fmap (.econfig) . parseConfig) cfg
   let c' = c & sConf . quiet .~ True
              & (if s then cConf . testLimit .~ 10000 else id)
              & (if s then cConf . shrinkLimit .~ 4000 else id)

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -25,7 +25,7 @@ import Prelude hiding (lookup)
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCase, assertBool)
 
-import Control.Lens (view, set, (.~), (^.))
+import Control.Lens (view, set, (.~))
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.Random (getRandom)
 import Control.Monad.State.Strict (evalStateT)
@@ -52,7 +52,7 @@ import Echidna.Types.Test
 import Echidna.Types.Tx (Tx(..), TxCall(..), call)
 
 import EVM.Dapp (dappInfo, emptyDapp)
-import EVM.Solidity (contractName)
+import EVM.Solidity (SolcContract(..))
 
 testConfig :: EConfig
 testConfig = defaultConfig & sConf . quiet .~ True
@@ -83,11 +83,11 @@ runContract :: FilePath -> Maybe ContractName -> EConfig -> IO Campaign
 runContract f mc cfg = do
   g <- getRandom
   (v, sc, cs, w, ts, d, txs) <- prepareContract cfg (f :| []) mc g
-  let solcByName = fromList [(c ^. contractName, c) | c <- cs]
+  let solcByName = fromList [(c._contractName, c) | c <- cs]
   let dappInfo' = dappInfo "/" solcByName sc
   let env = Env { cfg = cfg, dapp = dappInfo' }
   -- start ui and run tests
-  runReaderT (campaign (pure ()) v w ts d txs) env
+  runReaderT (campaign (pure ()) v w ts (Just d) txs) env
 
 testContract :: FilePath -> Maybe FilePath -> [(String, Campaign -> Bool)] -> TestTree
 testContract fp cfg = testContract' fp Nothing Nothing cfg True
@@ -97,7 +97,7 @@ testContractV fp v cfg = testContract' fp Nothing v cfg True
 
 testContract' :: FilePath -> Maybe ContractName -> Maybe SolcVersionComp -> Maybe FilePath -> Bool -> [(String, Campaign -> Bool)] -> TestTree
 testContract' fp n v cfg s as = testCase fp $ withSolcVersion v $ do
-  c <- set (sConf . quiet) True <$> maybe (pure testConfig) (fmap econfig . parseConfig) cfg
+  c <- set (sConf . quiet) True <$> maybe (pure testConfig) ((fmap (.econfig)) . parseConfig) cfg
   let c' = c & sConf . quiet .~ True
              & (if s then cConf . testLimit .~ 10000 else id)
              & (if s then cConf . shrinkLimit .~ 4000 else id)
@@ -122,7 +122,7 @@ getResult n c =
     [x] -> Just x
     _   -> error "found more than one tests"
 
-  where findTest test = case view testType test of
+  where findTest test = case test.testType  of
                           PropertyTest t _        -> t == n
                           AssertionTest _ (t,_) _ -> t == n
                           CallTest t _            -> t == n
@@ -131,7 +131,7 @@ getResult n c =
 
 optnFor :: Text -> Campaign -> Maybe TestValue
 optnFor n c = case getResult n c of
-  Just t -> Just $ t ^. testValue
+  Just t -> Just t.testValue
   _      -> Nothing
 
 optimized :: Text -> Int256 -> Campaign -> Bool
@@ -142,7 +142,7 @@ optimized n v c = case optnFor n c of
 
 solnFor :: Text -> Campaign -> Maybe [Tx]
 solnFor n c = case getResult n c of
-  Just t -> if null $ t ^. testReproducer then Nothing else Just $ t ^. testReproducer
+  Just t -> if null t.testReproducer then Nothing else Just t.testReproducer
   _      -> Nothing
 
 solved :: Text -> Campaign -> Bool
@@ -159,16 +159,16 @@ solvedLen :: Int -> Text -> Campaign -> Bool
 solvedLen i t = (== Just i) . fmap length . solnFor t
 
 solvedUsing :: Text -> Text -> Campaign -> Bool
-solvedUsing f t = maybe False (any $ matchCall . view call) . solnFor t
+solvedUsing f t = maybe False (any $ matchCall . (.call)) . solnFor t
                  where matchCall (SolCall (f',_)) = f' == f
                        matchCall _                = False
 
 -- NOTE: this just verifies a call was found in the solution. Doesn't care about ordering/seq length
 solvedWith :: TxCall -> Text -> Campaign -> Bool
-solvedWith tx t = maybe False (any $ (== tx) . view call) . solnFor t
+solvedWith tx t = maybe False (any $ (== tx) . (.call)) . solnFor t
 
 solvedWithout :: TxCall -> Text -> Campaign -> Bool
-solvedWithout tx t = maybe False (all $ (/= tx) . view call) . solnFor t
+solvedWithout tx t = maybe False (all $ (/= tx) . (.call)) . solnFor t
 
 getGas :: Text -> Campaign -> Maybe (Int, [Tx])
 getGas t = lookup t . view gasInfo

--- a/src/test/Tests/Compile.hs
+++ b/src/test/Tests/Compile.hs
@@ -4,41 +4,36 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, assertBool)
 
 import Common (testConfig)
-import Control.Lens (Prism', preview)
 import Control.Monad (void)
 import Control.Monad.Catch (catch)
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.Maybe (isJust)
 import Data.Text (Text)
 import Echidna.Types.Config
-import Echidna.Types.Solidity (SolException, _ContractNotFound, _NoBytecode, _NoFuncs, _NoTests, _OnlyTests, _TestArgsFound, _ConstructorArgs, _DeploymentFailed)
+import Echidna.Types.Solidity (SolException(..))
 import Echidna.Solidity (loadWithCryticCompile)
 
 compilationTests :: TestTree
 compilationTests = testGroup "Compilation and loading tests"
   [ loadFails "bad/nocontract.sol" (Just "c") "failed to warn on contract not found" $
-      pmatch _ContractNotFound
+      \case ContractNotFound _ -> True; _ -> False
   , loadFails "bad/nobytecode.sol" Nothing    "failed to warn on abstract contract" $
-      pmatch _NoBytecode
+      \case NoBytecode _ -> True; _ -> False
   , loadFails "bad/nofuncs.sol"    Nothing    "failed to warn on no functions found" $
-      pmatch _NoFuncs
+      \case NoFuncs -> True; _ -> False
   , loadFails "bad/notests.sol"    Nothing    "failed to warn on no tests found" $
-      pmatch _NoTests
+      \case NoTests -> True; _ -> False
   , loadFails "bad/onlytests.sol"  Nothing    "failed to warn on no non-tests found" $
-      pmatch _OnlyTests
+      \case OnlyTests -> True; _ -> False
   , loadFails "bad/testargs.sol"   Nothing    "failed to warn on test args found" $
-      pmatch _TestArgsFound
+      \case TestArgsFound _ -> True; _ -> False
   , loadFails "bad/consargs.sol"   Nothing    "failed to warn on cons args found" $
-      pmatch _ConstructorArgs
+      \case ConstructorArgs _ -> True; _ -> False
   , loadFails "bad/revert.sol"     Nothing    "failed to warn on a failed deployment" $
-      pmatch _DeploymentFailed
+      \case DeploymentFailed _ _ -> True; _ -> False
   , loadFails "basic/eip-170.sol"  Nothing    "failed to warn on a failed deployment" $
-      pmatch _DeploymentFailed
+      \case DeploymentFailed _ _ -> True; _ -> False
   ]
 
 loadFails :: FilePath -> Maybe Text -> String -> (SolException -> Bool) -> TestTree
 loadFails fp c e p = testCase fp . catch tryLoad $ assertBool e . p where
   tryLoad = void $ loadWithCryticCompile testConfig._sConf (fp :| []) c
-
-pmatch :: Prism' s a -> s -> Bool
-pmatch p = isJust . preview p

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -3,19 +3,19 @@ module Tests.Config (configTests) where
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, assertBool, (@?=))
 
-import Control.Lens ((^.), sans)
+import Control.Lens (sans)
 import Control.Monad (void)
 import Data.Function ((&))
 
-import Echidna.Types.Config (EConfigWithUsage(..), cConf)
-import Echidna.Types.Campaign (knownCoverage)
+import Echidna.Types.Config (EConfigWithUsage(..), EConfig(..))
+import Echidna.Types.Campaign (CampaignConf(..))
 import Echidna.Config (defaultConfig, parseConfig)
 
 configTests :: TestTree
 configTests = testGroup "Configuration tests" $
   [ testCase file . void $ parseConfig file | file <- files ] ++
   [ testCase "parse \"coverage: true\"" $ do
-      config <- econfig <$> parseConfig "coverage/test.yaml"
+      config <- (.econfig) <$> parseConfig "coverage/test.yaml"
       assertCoverage config $ Just mempty
   , testCase "coverage enabled by default" $
       assertCoverage defaultConfig $ Just mempty
@@ -26,4 +26,4 @@ configTests = testGroup "Configuration tests" $
       assertBool ("unset options: " ++ show unset') $ null unset'
   ]
   where files = ["basic/config.yaml", "basic/default.yaml"]
-        assertCoverage config value = (config ^. cConf . knownCoverage) @?= value
+        assertCoverage config value = config._cConf._knownCoverage @?= value


### PR DESCRIPTION
This PR features various cleanup and simplifications in the entirety of code:
- Use `OverloadedRecordDot` as much as possible
- Use `</>` operator for path joining
- Use `Set`s instead of (NE)lists. This is good for generating random data as picking random elements from a large `Set` is way faster than lists
- Rewrite some complex one-liners to something that we can understand 😄
- Remove underscores from most of the structures and Template Haskell generated lenses. I think we can even go entirely without lenses as, in practice, we don't really do that much nested data manipulation and I'm not sure a few more lines of code are worth the added cost of knowing lenses. However, if we still find lenses useful, we should move on to a more modern solution such as `generic-lens` or `optics-core` in the future.