### PR TITLE
Configure libff with ALT_BN128 curve on aarch64 Linux

### DIFF
--- a/.github/scripts/install-libff.sh
+++ b/.github/scripts/install-libff.sh
@@ -30,6 +30,10 @@ if [ "$HOST_OS" = "macOS" ]; then
   sed -i '' 's/STATIC/SHARED/' depends/CMakeLists.txt
 fi
 
+if [ "$HOST_OS" = "Linux" ] && [ "$(uname -m)" = "aarch64" ]; then
+  ARGS="$ARGS -DCURVE=ALT_BN128"
+fi
+
 mkdir -p build
 cd build
 CXXFLAGS="-fPIC $CXXFLAGS" cmake $ARGS ..


### PR DESCRIPTION
The default curve is only buildable on Intel systems. As a side effect, this makes the Dockerfile buildable on aarch64 systems.