### PR TITLE
Add numeric constants as bytes32

### DIFF
--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -9,6 +9,7 @@ import Control.Monad (join, liftM2, liftM3, foldM, replicateM)
 import Control.Monad.Random.Strict (MonadRandom, getRandom, getRandoms, getRandomR)
 import Control.Monad.Random.Strict qualified as R
 import Data.Binary.Put (runPut, putWord32be)
+import Data.Binary (encode)
 import Data.BinaryWord (unsignedWord)
 import Data.Bits (bit)
 import Data.Bool (bool)
@@ -59,6 +60,11 @@ mkValidAbiUInt i x = if x < bit i then Just $ AbiUInt i x else Nothing
 makeNumAbiValues :: Integer -> [AbiValue]
 makeNumAbiValues i = let l f = f <$> commonTypeSizes <*> fmap fromIntegral ([i-1..i+1] ++ [(-i)-1 .. (-i)+1]) in
     catMaybes (l mkValidAbiInt ++ l mkValidAbiUInt)
+
+makeBytes32AbiValues :: Integer -> [AbiValue]
+makeBytes32AbiValues i = let l f = f <$> fmap fromIntegral [i]
+                             bs n = (toStrict $ encode (n :: Int)) in
+                          l (\n -> AbiBytes 32 $ BS.append (bs n) (BS.replicate (32 - BS.length (bs n)) 0))
 
 makeArrayAbiValues :: BS.ByteString -> [AbiValue]
 makeArrayAbiValues b = let size = BS.length b in [AbiString b, AbiBytesDynamic b] ++

--- a/lib/Echidna/Processor.hs
+++ b/lib/Echidna/Processor.hs
@@ -25,7 +25,7 @@ import Text.Read (readMaybe)
 import EVM.ABI (AbiValue(..))
 import EVM.Types (Addr(..))
 
-import Echidna.ABI (hashSig, makeNumAbiValues, makeArrayAbiValues)
+import Echidna.ABI (hashSig, makeNumAbiValues, makeArrayAbiValues, makeBytes32AbiValues)
 import Echidna.Types.Signature (ContractName, FunctionName, FunctionHash)
 
 -- | Things that can go wrong trying to run a processor. Read the 'Show'
@@ -53,7 +53,7 @@ enhanceConstants :: SlitherInfo -> [AbiValue]
 enhanceConstants si =
   nubOrd . concatMap enh . concat . concat . M.elems $ M.elems <$> si.constantValues
   where
-    enh (AbiUInt _ n) = makeNumAbiValues (fromIntegral n)
+    enh (AbiUInt _ n) = makeNumAbiValues (fromIntegral n) ++ makeBytes32AbiValues (fromIntegral n)
     enh (AbiInt _ n) = makeNumAbiValues (fromIntegral n)
     enh (AbiString s) = makeArrayAbiValues s
     enh v = [v]


### PR DESCRIPTION
This can be solved:
```solidity
pragma solidity ^0.8.17;

contract Test {
    uint256 internal flag;

    function set(bytes32 x) external {
        assembly {
            if iszero(xor(x, 0x69)) { sstore(flag.slot, 0x01) }
        }
    }

    function echidna_flag() external view returns (bool) {
        return flag != 1;
    }
}
```