### PR TITLE
Use code hash instead of bytecode metadata

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -1,7 +1,6 @@
 module Echidna where
 
 import Control.Monad.Catch (MonadThrow(..))
-import Data.HashMap.Strict qualified as HM
 import Data.List (find)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map
@@ -64,7 +63,7 @@ prepareContract cfg fs c g = do
   let (vm, world, ts) = prepareForTest solConf p c si
 
   -- get signatures
-  let sigs = Set.fromList $ concatMap NE.toList (HM.elems world.highSignatureMap)
+  let sigs = Set.fromList $ concatMap NE.toList (Map.elems world.highSignatureMap)
 
   let ads = addresses solConf
   let ads' = AbiAddress <$> Map.keys vm._env._contracts

--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -12,8 +12,6 @@ import Data.Text
 import Data.Text.Encoding (decodeUtf8)
 import Numeric (showHex)
 
-import EVM.Types (keccak')
-
 import Echidna.ABI (ppAbiValue, GenDict(..))
 import Echidna.Types.Coverage (CoverageInfo)
 import Echidna.Types.Campaign qualified as C
@@ -98,7 +96,7 @@ encodeCampaign C.Campaign{..} = encode
            , _error = Nothing
            , _tests = mapTest <$> _tests
            , seed = _genDict._defSeed
-           , coverage = mapKeys (("0x" ++) . (`showHex` "") . keccak') $ DF.toList <$>_coverage
+           , coverage = mapKeys (("0x" ++) . (`showHex` "")) $ DF.toList <$> _coverage
            , gasInfo = toList _gasInfo
            }
 

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -7,7 +7,7 @@ import Control.Monad.Catch (MonadThrow(..))
 import Control.Monad.Extra (whenM)
 import Control.Monad.State.Strict (execStateT)
 import Data.Foldable (toList)
-import Data.HashMap.Strict qualified as M
+import Data.Map qualified as M
 import Data.List (find, partition, isSuffixOf, (\\))
 import Data.List.NonEmpty qualified as NE
 import Data.List.NonEmpty.Extra qualified as NEE
@@ -27,7 +27,7 @@ import EVM hiding (contracts, path)
 import EVM qualified (contracts)
 import EVM.ABI
 import EVM.Solidity
-import EVM.Types (Addr)
+import EVM.Types (Addr, keccak')
 import EVM.Dapp (dappInfo)
 
 import Echidna.ABI (encodeSig, encodeSigWithName, hashSig, fallback, commonTypeSizes, mkValidAbiInt, mkValidAbiUInt)
@@ -37,7 +37,7 @@ import Echidna.Fetch (deployContracts, deployBytecodes)
 import Echidna.Processor
 import Echidna.RPC (loadEthenoBatch)
 import Echidna.Test (createTests, isAssertionMode, isPropertyMode, isDapptestMode)
-import Echidna.Types.Signature (ContractName, FunctionHash, SolSignature, SignatureMap, getBytecodeMetadata)
+import Echidna.Types.Signature (ContractName, FunctionHash, SolSignature, SignatureMap)
 import Echidna.Types.Solidity hiding (deployBytecodes, deployContracts)
 import Echidna.Types.Test (EchidnaTest(..))
 import Echidna.Types.Tx (basicTx, createTxWithValue, unlimitedGasPerBlock, initialTimestamp, initialBlockNumber)
@@ -176,8 +176,8 @@ loadSpecified solConf name cs = do
   -- Filter again for dapptest tests or assertions checking if enabled
   let neFuns = filterMethods (c._contractName) fs (fallback NE.:| funs)
   -- Construct ABI mapping for World
-  let abiMapping = if ma then M.fromList $ cs <&> \cc -> (getBytecodeMetadata cc._runtimeCode, filterMethods (cc._contractName) fs $ abiOf pref cc)
-                         else M.singleton (getBytecodeMetadata c._runtimeCode) fabiOfc
+  let abiMapping = if ma then M.fromList $ cs <&> \cc -> (keccak' cc._runtimeCode, filterMethods (cc._contractName) fs $ abiOf pref cc)
+                         else M.singleton (keccak' c._runtimeCode) fabiOfc
 
 
   -- Set up initial VM, either with chosen contract or Etheno initialization file

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -11,7 +11,6 @@ import Echidna.Types
 import Echidna.Types.Corpus
 import Echidna.Types.Coverage (CoverageMap)
 import Echidna.Types.Test (EchidnaTest)
-import Echidna.Types.Signature (BytecodeMemo)
 import Echidna.Types.Tx (Tx)
 
 -- | Configuration for running an Echidna 'Campaign'.
@@ -54,13 +53,11 @@ data Campaign = Campaign { _tests       :: [EchidnaTest]
                            -- ^ List of transactions with maximum coverage
                          , _ncallseqs   :: Int
                            -- ^ Number of times the callseq is called
-                         , _bcMemo        :: BytecodeMemo
-                           -- ^ Stored results of getBytecodeMetadata on all contracts
                          }
 makeLenses ''Campaign
 
 defaultCampaign :: Campaign
-defaultCampaign = Campaign mempty mempty mempty defaultDict False mempty 0 mempty
+defaultCampaign = Campaign mempty mempty mempty defaultDict False mempty 0
 
 defaultTestLimit :: Int
 defaultTestLimit = 50000

--- a/lib/Echidna/Types/Coverage.hs
+++ b/lib/Echidna/Types/Coverage.hs
@@ -1,11 +1,11 @@
 module Echidna.Types.Coverage where
 
 import Control.Lens
-import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
 import Data.Set (Set, size, map)
 
 import Echidna.Types.Tx (TxResult)
+import EVM.Types (W256)
 
 -- Program Counter directly obtained from the EVM
 type PC = Int
@@ -16,7 +16,7 @@ type FrameCount = Int
 -- Basic coverage information
 type CoverageInfo = (PC, OpIx, FrameCount, TxResult)
 -- Map with the coverage information needed for fuzzing and source code printing
-type CoverageMap = Map ByteString (Set CoverageInfo)
+type CoverageMap = Map W256 (Set CoverageInfo)
 
 -- | Given good point coverage, count unique points.
 coveragePoints :: CoverageMap -> Int

--- a/lib/Echidna/Types/Signature.hs
+++ b/lib/Echidna/Types/Signature.hs
@@ -1,19 +1,12 @@
-{-# LANGUAGE GADTs #-}
-
 module Echidna.Types.Signature where
 
-import Data.ByteString (ByteString)
-import Data.ByteString qualified as BS
-import Data.Foldable (find)
-import Data.HashMap.Strict (HashMap)
 import Data.List.NonEmpty (NonEmpty)
-import Data.Map qualified as M
-import Data.Maybe (fromMaybe)
+import Data.Map (Map)
 import Data.Text (Text)
 import GHC.Word (Word32)
 
 import EVM.ABI (AbiType, AbiValue)
-import EVM.Types (Addr)
+import EVM.Types (Addr, W256)
 
 -- | Name of the contract
 type ContractName = Text
@@ -34,33 +27,4 @@ type SolCall     = (FunctionName, [AbiValue])
 -- | A contract is just an address with an ABI (for our purposes).
 type ContractA = (Addr, NonEmpty SolSignature)
 
--- | Used to memoize results of getBytecodeMetadata
-type BytecodeMemo = M.Map ByteString ByteString
-
-type SignatureMap = HashMap ByteString (NonEmpty SolSignature)
-
-getBytecodeMetadata :: ByteString -> ByteString
-getBytecodeMetadata bs =
-  let stripCandidates = flip BS.breakSubstring bs <$> knownBzzrPrefixes in
-    case find ((/= mempty) . snd) stripCandidates of
-      Nothing     -> bs -- if no metadata is found, return the complete bytecode
-      Just (_, m) -> m
-
-lookupBytecodeMetadata :: BytecodeMemo -> ByteString -> ByteString
-lookupBytecodeMetadata memo bs = fromMaybe (getBytecodeMetadata bs) (memo M.!? bs)
-
--- | Precalculate getBytecodeMetadata for all contracts in a list
-makeBytecodeMemo :: [ByteString] -> BytecodeMemo
-makeBytecodeMemo bss = M.fromList $ bss `zip` (getBytecodeMetadata <$> bss)
-
-knownBzzrPrefixes :: [ByteString]
-knownBzzrPrefixes = [
-  -- a1 65 "bzzr0" 0x58 0x20 (solc <= 0.5.8)
-  BS.pack [0xa1, 0x65, 98, 122, 122, 114, 48, 0x58, 0x20],
-  -- a2 65 "bzzr0" 0x58 0x20 (solc >= 0.5.9)
-  BS.pack [0xa2, 0x65, 98, 122, 122, 114, 48, 0x58, 0x20],
-  -- a2 65 "bzzr1" 0x58 0x20 (solc >= 0.5.11)
-  BS.pack [0xa2, 0x65, 98, 122, 122, 114, 49, 0x58, 0x20],
-  -- a2 64 "ipfs" 0x58 0x22 (solc >= 0.6.0)
-  BS.pack [0xa2, 0x64, 0x69, 0x70, 0x66, 0x73, 0x58, 0x22]
-  ]
+type SignatureMap = Map W256 (NonEmpty SolSignature)


### PR DESCRIPTION
~~This preserves the same properties but requires less effort.~~
Apparently, I was wrong and it doesn't work for contracts with immutables:
> It is important to note that the contract creation code generated by the compiler will modify the contract’s runtime code before it is returned by replacing all references to immutables by the values assigned to them. This is important if you are comparing the runtime code generated by the compiler with the one actually stored in the blockchain.
https://ethereum.stackexchange.com/questions/82240/what-is-the-immutable-keyword-in-solidity