### PR TITLE
ci: remove `mstksg/get-package`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install automake
 
-      - name: Get Packages (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get -q update
-          sudo apt-get -q install autoconf automake libtool
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,21 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.local/
-          key: ${{ runner.os }}-local-v4
+          key: ${{ runner.os }}-local-v5-${{ hashFiles('.github/scripts/install-*') }}
 
       - name: Cache Stack
         uses: actions/cache@v3
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-v4
+          path: |
+            ~/.stack
+            .stack-work
+          key: ${{ runner.os }}-stack-v5-${{ hashFiles('package.yaml', 'stack.yaml') }}
 
       - name: Cache Cabal
         uses: actions/cache@v3
         with:
           path: ~/.cabal
-          key: ${{ runner.os }}-cabal-v4
+          key: ${{ runner.os }}-cabal-v5-${{ hashFiles('package.yaml', 'stack.yaml') }}
 
       - name: Build Libraries
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,17 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-latest
-        include:
-          - os: ubuntu-20.04
-            apt-get: autoconf automake libtool
-          - os: macos-latest
-            brew: automake
 
     steps:
-      - name: Get Packages
-        uses: mstksg/get-package@v1
-        with:
-          brew: ${{ matrix.brew }}
-          apt-get: ${{ matrix.apt-get }}
+      - name: Get Packages (macOS)
+        if: runner.os == 'macOS'
+        run: brew install automake
+
+      - name: Get Packages (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get -q update
+          sudo apt-get -q install autoconf automake libtool
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This action has not been updated since 2019, and is currently causing some deprecation warnings to show up. This replaces it with a few run steps for each OS.