### PR TITLE
Lock the seed for extreme.sol test

### DIFF
--- a/tests/solidity/values/extreme.yaml
+++ b/tests/solidity/values/extreme.yaml
@@ -2,3 +2,4 @@ testLimit: 5000
 shrinkLimit: 100
 testMode: assertion
 seqLen: 1
+seed: 1337


### PR DESCRIPTION
Locking the seed should make the test deterministic. Closes https://github.com/crytic/echidna/issues/916.