### PR TITLE
Split and refactor prepareContract

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -258,7 +258,7 @@ campaign
   -> VM                  -- ^ Initial VM state
   -> World               -- ^ Initial world state
   -> [EchidnaTest]       -- ^ Tests to evaluate
-  -> Maybe GenDict       -- ^ Optional generation dictionary
+  -> GenDict             -- ^ Generation dictionary
   -> [[Tx]]              -- ^ Initial corpus of transactions
   -> m Campaign
 campaign u vm world ts dict initialCorpus = do
@@ -270,9 +270,8 @@ campaign u vm world ts dict initialCorpus = do
   liftIO $ writeIORef metaCacheRef (memo (vm._env._contracts <> external))
 
   let c = fromMaybe mempty conf.knownCoverage
-  let effectiveSeed = fromMaybe dict'.defSeed conf.seed
-      effectiveGenDict = dict' { defSeed = effectiveSeed }
-      dict' = fromMaybe defaultDict dict
+  let effectiveSeed = fromMaybe dict.defSeed conf.seed
+      effectiveGenDict = dict { defSeed = effectiveSeed }
       camp = Campaign ts c mempty effectiveGenDict False Set.empty 0
   execStateT (evalRandT (lift u >> runCampaign) (mkStdGen effectiveSeed)) camp
   where

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -48,17 +48,17 @@ ui :: (MonadCatch m, MonadRandom m, MonadReader Env m, MonadUnliftIO m)
    => VM             -- ^ Initial VM state
    -> World          -- ^ Initial world state
    -> [EchidnaTest]  -- ^ Tests to evaluate
-   -> Maybe GenDict
+   -> GenDict
    -> [[Tx]]
    -> m Campaign
-ui vm world ts d txs = do
+ui vm world ts dict initialCorpus = do
   conf <- asks (.cfg)
   let uiConf = conf.uiConf
   ref <- liftIO $ newIORef defaultCampaign
   let updateRef = get >>= liftIO . atomicWriteIORef ref
       secToUsec = (* 1000000)
       timeoutUsec = secToUsec $ fromMaybe (-1) uiConf.maxTime
-      runCampaign = timeout timeoutUsec (campaign updateRef vm world ts d txs)
+      runCampaign = timeout timeoutUsec (campaign updateRef vm world ts dict initialCorpus)
   terminalPresent <- liftIO isTerminal
   let effectiveMode = case uiConf.operationMode of
         Interactive | not terminalPresent -> NonInteractive Text

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -37,7 +37,7 @@ import System.IO (hPutStrLn, stderr)
 import Text.Read (readMaybe)
 
 import EVM (Contract(..), bytecode, ContractCode (RuntimeCode), RuntimeCode (ConcreteRuntimeCode), initialContract)
-import EVM.Dapp (dappInfo, emptyDapp)
+import EVM.Dapp (dappInfo)
 import EVM.Solidity (SolcContract(..), SourceCache(..))
 import EVM.Types (Addr, keccak', W256)
 
@@ -53,6 +53,7 @@ import Echidna.Campaign (isSuccessful)
 import Echidna.UI
 import Echidna.Output.Source
 import Echidna.Output.Corpus
+import Echidna.Solidity (compileContracts, selectSourceCache)
 import Etherscan qualified
 
 main :: IO ()
@@ -86,22 +87,25 @@ main = do
           Nothing ->
             pure (Nothing, Nothing)
 
+  (contracts, sourceCaches) <- compileContracts cfg.solConf cliFilePath
+  let sourceCache = selectSourceCache cliSelectedContract sourceCaches
+  let solcByName = Map.fromList [(c.contractName, c) | c <- contracts]
+
   cacheContractsRef <- newIORef $ fromMaybe mempty loadedContractsCache
   cacheSlotsRef <- newIORef $ fromMaybe mempty loadedSlotsCache
   cacheMetaRef <- newIORef mempty
   let env = Env { cfg = cfg
-                , dapp = emptyDapp -- TODO: fixme
+                  -- TODO put in real path
+                , dapp = dappInfo "/" solcByName sourceCache
                 , metadataCache = cacheMetaRef
                 , fetchContractCache = cacheContractsRef
                 , fetchSlotCache = cacheSlotsRef }
-  (vm, sourceCache, contracts, world, ts, dict) <-
-    prepareContract env cliFilePath cliSelectedContract seed
-  let solcByName = Map.fromList [(c.contractName, c) | c <- contracts]
-  -- TODO put in real path
-  let dappInfo' = dappInfo "/" solcByName sourceCache
-  corpus <- prepareCorpus env world
+
+  (vm, world, echidnaTests, dict) <- prepareContract env contracts cliFilePath cliSelectedContract seed
+
+  initialCorpus <- loadInitialCorpus env world
   -- start ui and run tests
-  campaign <- runReaderT (ui vm world ts (Just dict) corpus) (env { dapp = dappInfo' })
+  campaign <- runReaderT (ui vm world echidnaTests dict initialCorpus) env
 
   contractsCache <- readIORef cacheContractsRef
   slotsCache <- readIORef cacheSlotsRef


### PR DESCRIPTION
This fixes `DappInfo` construction for `Env` and closes https://github.com/crytic/echidna/issues/610. The issue talks about having a custom type, but I feel this is just putting the problem in the other place rather than solving it. We should aim to have composable functions with smaller types.