### PR TITLE
Multicore

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -1,6 +1,7 @@
 module Echidna where
 
 import Control.Monad.Catch (MonadThrow(..))
+import Data.IORef (writeIORef)
 import Data.List (find)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
@@ -18,12 +19,11 @@ import Echidna.Output.Corpus
 import Echidna.Processor
 import Echidna.Solidity
 import Echidna.Test (createTests)
-import Echidna.Types.Campaign hiding (corpus)
+import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Random
 import Echidna.Types.Signature
 import Echidna.Types.Solidity
-import Echidna.Types.Test
 import Echidna.Types.Tx
 import Echidna.Types.World
 
@@ -44,7 +44,7 @@ prepareContract
   -> NonEmpty FilePath
   -> Maybe ContractName
   -> Seed
-  -> IO (VM, World, [EchidnaTest], GenDict)
+  -> IO (VM, World, GenDict)
 prepareContract env contracts solFiles specifiedContract seed = do
   let solConf = env.cfg.solConf
 
@@ -82,7 +82,8 @@ prepareContract env contracts solFiles specifiedContract seed = do
                      seed
                      (returnTypes contracts)
 
-  pure (vm, world, echidnaTests, dict)
+  writeIORef env.testsRef echidnaTests
+  pure (vm, world, dict)
 
 loadInitialCorpus :: Env -> World -> IO [[Tx]]
 loadInitialCorpus env world = do

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -126,9 +126,8 @@ runWorker callback vm world dict workerId initialCorpus testLimit = do
                           Large n -> n < shrinkLimit
                           _       -> False
 
-    if | stopOnFail && any final tests -> do
-         lift callback
-         pure FastFailed
+    if | stopOnFail && any final tests ->
+         lift callback >> pure FastFailed
 
        | (null tests || any isOpen tests) && ncalls < testLimit ->
          fuzz >> continue
@@ -136,9 +135,8 @@ runWorker callback vm world dict workerId initialCorpus testLimit = do
        | any shrinkable tests ->
          continue
 
-       | otherwise -> do
-         lift callback
-         pure TestLimitReached
+       | otherwise ->
+         lift callback >> pure TestLimitReached
 
   fuzz = randseq vm.env.contracts world >>= callseq vm
 

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -2,11 +2,12 @@
 
 module Echidna.Campaign where
 
-import Optics.Core
+import Optics.Core hiding ((|>))
 
+import Control.Concurrent (writeChan)
 import Control.DeepSeq (force)
-import Control.Monad (replicateM, when, unless, void)
-import Control.Monad.Catch (MonadCatch(..), MonadThrow(..))
+import Control.Monad (replicateM, when, void, forM_)
+import Control.Monad.Catch (MonadCatch(..), MonadThrow(..), catchAll)
 import Control.Monad.Random.Strict (MonadRandom, RandT, evalRandT)
 import Control.Monad.Reader (MonadReader, asks, liftIO, ask)
 import Control.Monad.State.Strict
@@ -15,17 +16,16 @@ import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Random.Strict (liftCatch)
 import Data.Binary.Get (runGetOrFail)
 import Data.ByteString.Lazy qualified as LBS
-import Data.IORef (readIORef, writeIORef)
+import Data.IORef (readIORef, writeIORef, atomicModifyIORef')
 import Data.Map qualified as Map
 import Data.Map (Map, (\\))
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Maybe (isJust, mapMaybe, fromMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import System.Random (mkStdGen)
 
-import EVM hiding (Env, Frame(state), VM(state))
-import EVM (VM)
+import EVM hiding (Env, Frame(state))
 import EVM.ABI (getAbi, AbiType(AbiAddressType), AbiValue(AbiAddress))
 import EVM.Types (Addr, Expr(ConcreteBuf))
 
@@ -38,134 +38,131 @@ import Echidna.Test
 import Echidna.Transaction
 import Echidna.Types (Gas)
 import Echidna.Types.Buffer (forceBuf)
-import Echidna.Types.Corpus (Corpus)
 import Echidna.Types.Campaign
+import Echidna.Types.Corpus (Corpus, corpusSize)
+import Echidna.Types.Coverage (scoveragePoints)
 import Echidna.Types.Config
 import Echidna.Types.Signature (makeBytecodeCache, FunctionName)
 import Echidna.Types.Test
 import Echidna.Types.Tx (TxCall(..), Tx(..), call)
 import Echidna.Types.World (World)
+import Echidna.Utility (getTimestamp)
 
 instance MonadThrow m => MonadThrow (RandT g m) where
   throwM = lift . throwM
 instance MonadCatch m => MonadCatch (RandT g m) where
   catch = liftCatch catch
 
--- | Given a 'Campaign', checks if we can attempt any solves or shrinks without exceeding
--- the limits defined in our 'CampaignConf'.
-isDone :: MonadReader Env m => GenericCampaign a -> m Bool
-isDone c | null c.tests = do
-  conf <- asks (.cfg.campaignConf)
-  pure $ c.ncallseqs * conf.seqLen >= conf.testLimit
-isDone c = do
-  conf <- asks (.cfg.campaignConf)
-  let
-    result = \case
-      Open i   -> if i >= conf.testLimit then Just True else Nothing
-      Passed   -> Just True
-      Large i  -> if i >= conf.shrinkLimit then Just False else Nothing
-      Solved   -> Just False
-      Failed _ -> Just False
-    testResults = result . (.state) <$> c.tests
-    done = if conf.stopOnFail then Just False `elem` testResults
-                              else all isJust testResults
-  pure done
-
 -- | Given a 'Campaign', check if the test results should be reported as a
 -- success or a failure.
-isSuccessful :: Campaign -> Bool
-isSuccessful Campaign{tests} =
-  all (\case { Passed -> True; Open _ -> True; _ -> False; }) ((.state) <$> tests)
+isSuccessful :: [EchidnaTest] -> Bool
+isSuccessful tests =
+  all (\case { Passed -> True; Open -> True; _ -> False; }) ((.state) <$> tests)
 
 -- | Run all the transaction sequences from the corpus and accumulate campaign
 -- state. Can be used to minimize corpus as the final campaign state will
 -- contain minized corpus without sequences that didn't increase the coverage.
 replayCorpus
-  :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m, MonadState Campaign m)
-  => VM     -- ^ Initial VM state
-  -> [[Tx]] -- ^ Corpus to replay
+  :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m, MonadState WorkerState m)
+  => VM     -- ^ VM to start replaying from
+  -> [[Tx]] -- ^ corpus to replay
   -> m ()
-replayCorpus vm = mapM_ (callseq vm)
+replayCorpus vm txSeqs =
+  forM_ (zip [1..] txSeqs) $ \(i, txSeq) -> do
+    _ <- callseq vm txSeq
+    pushEvent (TxSequenceReplayed i (length txSeqs))
 
 -- | Run a fuzzing campaign given an initial universe state, some tests, and an
 -- optional dictionary to generate calls with. Return the 'Campaign' state once
 -- we can't solve or shrink anything.
-runCampaign
+runWorker
   :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m)
-  => StateT Campaign m Bool
+  => StateT WorkerState m (Maybe WorkerStopReason)
   -- ^ Callback to run after each state update (for instrumentation)
-  -> VM            -- ^ Initial VM state
-  -> World         -- ^ Initial world state
-  -> [EchidnaTest] -- ^ Tests to evaluate
-  -> GenDict       -- ^ Generation dictionary
-  -> [[Tx]]        -- ^ Initial corpus of transactions
-  -> m Campaign
-runCampaign callback vm world tests dict initialCorpus = do
-  conf <- asks (.cfg.campaignConf)
+  -> VM      -- ^ Initial VM state
+  -> World   -- ^ Initial world state
+  -> GenDict -- ^ Generation dictionary
+  -> Int     -- ^ Worker id starting from 0
+  -> [[Tx]]  -- ^ Initial corpus of transactions
+  -> Int     -- ^ Test limit for this worker
+  -> m WorkerState
+runWorker callback vm world dict workerId initialCorpus testLimit = do
   metaCacheRef <- asks (.metadataCache)
   fetchContractCacheRef <- asks (.fetchContractCache)
   external <- liftIO $ Map.mapMaybe id <$> readIORef fetchContractCacheRef
   liftIO $ writeIORef metaCacheRef (mkMemo (vm.env.contracts <> external))
 
   let
-    covMap = fromMaybe mempty conf.knownCoverage
-    effectiveSeed = fromMaybe dict.defSeed conf.seed
+    effectiveSeed = dict.defSeed + workerId
     effectiveGenDict = dict { defSeed = effectiveSeed }
-    campaign = Campaign { tests = tests
-                        , coverage = covMap
-                        , gasInfo = mempty
-                        , genDict = effectiveGenDict
-                        , newCoverage = False
-                        , corpus = Set.empty
-                        , ncallseqs = 0
-                        }
+    initialState =
+      WorkerState { workerId
+                  , gasInfo = mempty
+                  , genDict = effectiveGenDict
+                  , newCoverage = False
+                  , ncallseqs = 0
+                  , ncalls = 0
+                  }
 
-  flip execStateT campaign $ do
+  flip execStateT initialState $ do
     flip evalRandT (mkStdGen effectiveSeed) $ do
-      void $ lift callback
-      void $ replayCorpus vm initialCorpus
-      run
+      catchAll
+        (do void $ lift callback
+            void $ replayCorpus vm initialCorpus
+            stopReason <- run
+            pushEvent $ WorkerStopped stopReason
+        )
+        (pushEvent . WorkerStopped . Crashed . show)
 
   where
   run = do
-    testStates <- gets (fmap (.state) . (.tests))
-    CampaignConf{testLimit, stopOnFail, seqLen, shrinkLimit} <- asks (.cfg.campaignConf)
-    Campaign{ncallseqs} <- get
+    tests <- liftIO . readIORef =<< asks (.testsRef)
+    CampaignConf{stopOnFail, shrinkLimit} <- asks (.cfg.campaignConf)
+    ncalls <- gets (.ncalls)
+
     let
-      stopEarlier =
-        stopOnFail && any (\case Solved -> True; Failed _ -> True; _ -> False)
-                          testStates
-    if | stopEarlier ->
+      final test = case test.state of
+                     Solved   -> True
+                     Failed _ -> True
+                     _        -> False
+
+      shrinkable test = case test.state of
+                          Large n -> n < shrinkLimit
+                          _       -> False
+
+    if | stopOnFail && any final tests -> do
          void $ lift callback
-       | any (\case Open n -> n <= testLimit; _ -> False) testStates ->
+         pure FastFailed
+
+       | (null tests || any isOpen tests) && ncalls < testLimit ->
          fuzz >> continue
-       | any (\case Large n -> n < shrinkLimit; _ -> False) testStates ->
+
+       | any shrinkable tests ->
          continue
-       | null testStates && (seqLen * ncallseqs) <= testLimit ->
-         fuzz >> continue
-       | otherwise ->
+
+       | otherwise -> do
          void $ lift callback
+         pure TestLimitReached
 
   fuzz = randseq vm.env.contracts world >>= callseq vm
 
   continue = do
     runUpdate (shrinkTest vm)
-    stop <- lift callback
-    unless stop run
+    maybeStop <- lift callback
+    maybe run pure maybeStop
 
   mkMemo = makeBytecodeCache . map (forceBuf . (^. bytecode)) . Map.elems
 
 -- | Generate a new sequences of transactions, either using the corpus or with
 -- randomly created transactions
 randseq
-  :: (MonadRandom m, MonadReader Env m, MonadState Campaign m, MonadIO m)
+  :: (MonadRandom m, MonadReader Env m, MonadState WorkerState m, MonadIO m)
   => Map Addr Contract
   -> World
   -> m [Tx]
 randseq deployedContracts world = do
   env <- ask
   memo <- liftIO $ readIORef env.metadataCache
-  campaign <- get
 
   let
     mutConsts = env.cfg.campaignConf.mutConsts
@@ -174,7 +171,7 @@ randseq deployedContracts world = do
 
   -- TODO: include reproducer when optimizing
   --let rs = filter (not . null) $ map (.testReproducer) $ ca._tests
-  --
+
   -- Generate new random transactions
   randTxs <- replicateM seqLen (genTx memo world txConf deployedContracts)
   -- Generate a random mutator
@@ -182,22 +179,24 @@ randseq deployedContracts world = do
                          else seqMutatorsStateful (fromConsts mutConsts)
   -- Fetch the mutator
   let mut = getCorpusMutation cmut
-  if null campaign.corpus
+  corpus <- liftIO $ readIORef env.corpusRef
+  if null corpus
     then pure randTxs -- Use the generated random transactions
-    else mut seqLen campaign.corpus randTxs -- Apply the mutator
+    else mut seqLen corpus randTxs -- Apply the mutator
 
 -- | Runs a transaction sequence and checks if any test got falsified or can be
 -- minimized. Stores any useful data in the campaign state if coverage increased.
 callseq
-  :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m, MonadState Campaign m)
+  :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m, MonadState WorkerState m)
   => VM
   -> [Tx]
   -> m VM
 callseq vm txSeq = do
-  conf <- asks (.cfg.campaignConf)
+  env <- ask
   -- First, we figure out whether we need to execute with or without coverage
   -- optimization and gas info, and pick our execution function appropriately
   let
+    conf = env.cfg.campaignConf
     coverageEnabled = isJust conf.knownCoverage
     execFunc =
       if coverageEnabled
@@ -208,46 +207,53 @@ callseq vm txSeq = do
            put (vm', ca)
            pure r
   -- Then, we get the current campaign state
-  camp <- get
+  campaign <- get
 
   -- Run each call sequentially. This gives us the result of each call
   -- and the new state
-  (res, (vm', camp')) <- runStateT (evalSeq vm execFunc txSeq) (vm, camp)
+  (res, (vm', campaign')) <- runStateT (evalSeq vm execFunc txSeq) (vm, campaign)
 
   let
     -- compute the addresses not present in the old VM via set difference
     newAddrs = Map.keys $ vm'.env.contracts \\ vm.env.contracts
     -- and construct a set to union to the constants table
     diffs = Map.fromList [(AbiAddressType, Set.fromList $ AbiAddress <$> newAddrs)]
-    -- Now we try to parse the return values as solidity constants, and add then to the 'GenDict'
-    results = returnValues (map (\(t, (vr, _)) -> (t, vr)) res) camp'.genDict.rTypes
+    -- Now we try to parse the return values as solidity constants, and add them to 'GenDict'
+    results = returnValues (map (\(t, (vr, _)) -> (t, vr)) res) campaign'.genDict.rTypes
     -- union the return results with the new addresses
     additions = Map.unionWith Set.union diffs results
     -- append to the constants dictionary
-    updatedDict = camp'.genDict
-      { constants = Map.unionWith Set.union additions camp'.genDict.constants
+    updatedDict = campaign'.genDict
+      { constants = Map.unionWith Set.union additions campaign'.genDict.constants
       , dictValues = Set.union (mkDictValues $ Set.unions $ Map.elems additions)
-                               camp'.genDict.dictValues
+                               campaign'.genDict.dictValues
       }
 
+  -- If there is new coverage, add the transaction list to the corpus
+  when campaign'.newCoverage $ do
+    -- Even if this takes a bit of time, this is okay as finding new coverage
+    -- is expected to be infrequent in the long term
+    newSize <- liftIO $ atomicModifyIORef' env.corpusRef $ \corp ->
+      -- Corpus is a bit too lazy, force the evaluation to reduce the memory usage
+      let !corp' = force $ addToCorpus (campaign'.ncallseqs + 1) res corp
+      in (corp', corpusSize corp')
+
+    cov <- liftIO . readIORef =<< asks (.coverageRef)
+    points <- liftIO $ scoveragePoints cov
+    pushEvent (NewCoverage points (length cov) newSize)
+
   -- Update the campaign state
-  put camp'
+  put campaign'
     { genDict = updatedDict
       -- Update the gas estimation
     , gasInfo =
         if conf.estimateGas
-           then updateGasInfo res [] camp'.gasInfo
-           else camp'.gasInfo
-      -- If there is new coverage, add the transaction list to the corpus
-    , corpus =
-        if camp'.newCoverage
-           -- corpus is a bit too lazy, force the evaluation to reduce the memory usage
-           then force $ addToCorpus (camp'.ncallseqs + 1) res camp'.corpus
-           else camp'.corpus
+           then updateGasInfo res [] campaign'.gasInfo
+           else campaign'.gasInfo
       -- Reset the new coverage flag
     , newCoverage = False
       -- Keep track of the number of calls to `callseq`
-    , ncallseqs = camp'.ncallseqs + 1
+    , ncallseqs = campaign'.ncallseqs + 1
     }
 
   pure vm'
@@ -283,13 +289,13 @@ callseq vm txSeq = do
 -- | Execute a transaction, capturing the PC and codehash of each instruction
 -- executed, saving the transaction if it finds new coverage.
 execTxOptC
-  :: (MonadIO m, MonadReader Env m, MonadState (VM, Campaign) m, MonadThrow m)
+  :: (MonadIO m, MonadReader Env m, MonadState (VM, WorkerState) m, MonadThrow m)
   => Tx
   -> m (VMResult, Gas)
 execTxOptC tx = do
-  (vm, camp@Campaign{coverage = oldCov}) <- get
-  ((res, (cov', grew)), vm') <- runStateT (execTxWithCov tx oldCov) vm
-  put (vm', camp { coverage = cov' })
+  (vm, camp) <- get
+  ((res, grew), vm') <- runStateT (execTxWithCov tx) vm
+  put (vm', camp)
   when grew $ do
     let dict' = case tx.call of
           SolCall c -> gaddCalls (Set.singleton c) camp.genDict
@@ -320,7 +326,7 @@ updateGasInfo ((t, _):ts) tseq gi = updateGasInfo ts (t:tseq) gi
 -- of transactions, constantly checking if we've solved any tests or can shrink
 -- known solves.
 evalSeq
-  :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m, MonadState (VM, Campaign) m)
+  :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m, MonadState (VM, WorkerState) m)
   => VM
   -> (Tx -> m a)
   -> [Tx]
@@ -329,7 +335,7 @@ evalSeq vmForShrink e = go [] where
   go r xs = do
     (v', camp) <- get
     camp' <- execStateT (runUpdate (updateTest vmForShrink (v', reverse r))) camp
-    put (v', camp')
+    put (v', camp' { ncalls = camp'.ncalls + 1 })
     case xs of
       []     -> pure []
       (y:ys) -> e y >>= \a -> ((y, a) :) <$> go (y:r) ys
@@ -337,12 +343,16 @@ evalSeq vmForShrink e = go [] where
 -- | Given a rule for updating a particular test's state, apply it to each test
 -- in a 'Campaign'.
 runUpdate
-  :: (MonadReader Env m, MonadState Campaign m)
-  => (EchidnaTest -> m EchidnaTest)
+  :: (MonadIO m, MonadReader Env m, MonadState WorkerState m)
+  => (EchidnaTest -> m (Maybe EchidnaTest))
   -> m ()
 runUpdate f = do
-  tests' <- mapM f =<< gets (.tests)
-  modify' $ \c -> c { tests = tests' }
+  testsRef <- asks (.testsRef)
+  tests <- liftIO $ readIORef testsRef
+  updates <- mapM f tests
+  when (any isJust updates) $
+    liftIO $ atomicModifyIORef' testsRef $ \sharedTests ->
+      (uncurry fromMaybe <$> zip sharedTests updates, ())
 
 -- | Given an initial 'VM' state and a @('SolTest', 'TestState')@ pair, as well
 -- as possibly a sequence of transactions and the state after evaluation, see if:
@@ -352,25 +362,41 @@ runUpdate f = do
 -- (3): The test is unshrunk, and we can shrink it
 -- Then update accordingly, keeping track of how many times we've tried to solve or shrink.
 updateTest
-  :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m)
+  :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m, MonadState WorkerState m)
   => VM
   -> (VM, [Tx])
   -> EchidnaTest
-  -> m EchidnaTest
+  -> m (Maybe EchidnaTest)
 updateTest vmForShrink (vm, xs) test = do
-  limit <- asks (.cfg.campaignConf.testLimit)
   dappInfo <- asks (.dapp)
   case test.state of
-    Open i | i > limit -> case test.testType of
-      OptimizationTest _ _ -> pure $ test { state = Large (-1) }
-      _                    -> pure $ test { state = Passed }
-    Open i -> do
+    Open -> do
       (testValue, vm') <- evalStateT (checkETest test) vm
-      let events = extractEvents False dappInfo vm'
-      let results = getResultFromVM vm'
-      pure $ updateOpenTest test xs i (testValue, events, results)
-    _ ->
+      let
+        events = extractEvents False dappInfo vm'
+        results = getResultFromVM vm'
+        test' = updateOpenTest test xs (testValue, events, results)
+      case test'.state of
+        Large _ -> do
+          pushEvent (TestFalsified test')
+          pure (Just test')
+        _ | test'.value > test.value -> do
+          pushEvent (TestOptimized test')
+          pure (Just test')
+        _ -> pure Nothing
+    Large _ ->
       -- TODO: We shrink already in `step`, but we shrink here too. It makes
       -- shrink go faster when some tests are still fuzzed. It's not incorrect
       -- but requires passing `vmForShrink` and feels a bit wrong.
       shrinkTest vmForShrink test
+    _ -> pure Nothing
+
+pushEvent
+  :: (MonadReader Env m, MonadState WorkerState m, MonadIO m)
+  => CampaignEvent
+  -> m ()
+pushEvent event = do
+  workerId <- gets (.workerId)
+  time <- liftIO getTimestamp
+  chan <- asks (.eventQueue)
+  liftIO $ writeChan chan (workerId, time, event)

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -96,7 +96,7 @@ instance FromJSON EConfigWithUsage where
         <*> v ..:? "corpusDir" ..!= Nothing
         <*> v ..:? "mutConsts" ..!= defaultMutationConsts
         <*> v ..:? "coverageFormats" ..!= [Txt,Html,Lcov]
-        <*> v ..:? "jobs"
+        <*> v ..:? "workers"
 
       solConfParser = SolConf
         <$> v ..:? "contractAddr"    ..!= defaultContractAddr

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -96,6 +96,7 @@ instance FromJSON EConfigWithUsage where
         <*> v ..:? "corpusDir" ..!= Nothing
         <*> v ..:? "mutConsts" ..!= defaultMutationConsts
         <*> v ..:? "coverageFormats" ..!= [Txt,Html,Lcov]
+        <*> v ..:? "jobs"
 
       solConfParser = SolConf
         <$> v ..:? "contractAddr"    ..!= defaultContractAddr

--- a/lib/Echidna/Output/Source.hs
+++ b/lib/Echidna/Output/Source.hs
@@ -15,7 +15,7 @@ import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
 import Data.Text.IO (writeFile)
 import Data.Vector qualified as V
-import Data.Vector.Unboxed qualified as VU
+import Data.Vector.Unboxed.Mutable qualified as VU
 import HTMLEntities.Text qualified as HTML
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
@@ -24,7 +24,7 @@ import Text.Printf (printf)
 import EVM.Debug (srcMapCodePos)
 import EVM.Solidity (SourceCache(..), SrcMap, SolcContract(..))
 
-import Echidna.Types.Coverage (CoverageMap, FrozenCoverageMap, OpIx, unpackTxResults)
+import Echidna.Types.Coverage (OpIx, unpackTxResults, CoverageMap)
 import Echidna.Types.Tx (TxResult(..))
 import Echidna.Types.Signature (getBytecodeMetadata)
 
@@ -50,10 +50,9 @@ saveCoverage
   -> CoverageMap
   -> IO ()
 saveCoverage fileType seed d sc cs covMap = do
-  frozenCovMap <- mapM VU.freeze covMap
   let extension = coverageFileExtension fileType
       fn = d </> "covered." <> show seed <> extension
-      cc = ppCoveredCode fileType sc cs frozenCovMap
+  cc <- ppCoveredCode fileType sc cs covMap
   createDirectoryIfMissing True d
   writeFile fn cc
 
@@ -76,43 +75,44 @@ coverageFileExtension Html = ".html"
 coverageFileExtension Txt = ".txt"
 
 -- | Pretty-print the covered code
-ppCoveredCode :: CoverageFileType -> SourceCache -> [SolcContract] -> FrozenCoverageMap -> Text
-ppCoveredCode fileType sc cs s | null s = "Coverage map is empty"
-                               | otherwise =
+ppCoveredCode :: CoverageFileType -> SourceCache -> [SolcContract] -> CoverageMap -> IO Text
+ppCoveredCode fileType sc cs s | null s = pure "Coverage map is empty"
+  | otherwise = do
   let allFiles = zipWith (\(srcPath, _rawSource) srcLines -> (srcPath, V.map decodeUtf8 srcLines))
                    sc.files
                    sc.lines
       -- ^ Collect all the possible lines from all the files
-      covLines = srcMapCov sc s cs
+  covLines <- srcMapCov sc s cs
       -- ^ List of covered lines during the fuzzing campaing
-      runtimeLinesMap = buildRuntimeLinesMap sc cs
-      -- ^ Excludes lines such as comments or blanks
-      ppFile (srcPath, srcLines) =
-        let runtimeLines = fromMaybe mempty $ Map.lookup srcPath runtimeLinesMap
-            marked = markLines fileType srcLines runtimeLines (fromMaybe Map.empty (Map.lookup srcPath covLines))
-        in T.unlines (changeFileName srcPath : changeFileLines (V.toList marked))
-      -- ^ Pretty print individual file coverage
-      topHeader = case fileType of
-        Lcov -> "TN:\n"
-        Html -> "<style> code { white-space: pre-wrap; display: block; background-color: #eee; }" <>
-                ".executed { background-color: #afa; }" <>
-                ".reverted { background-color: #ffa; }" <>
-                ".unexecuted { background-color: #faa; }" <>
-                ".neutral { background-color: #eee; }" <>
-                "</style>"
-        Txt  -> ""
-      -- ^ Text to add to top of the file
-      changeFileName fn = case fileType of
-        Lcov -> "SF:" <> fn
-        Html -> "<b>" <> HTML.text fn <> "</b>"
-        Txt  -> fn
-      -- ^ Alter file name, in the case of html turning it into bold text
-      changeFileLines ls = case fileType of
-        Lcov -> ls ++ ["end_of_record"]
-        Html -> "<code>" : ls ++ ["", "</code>","<br />"]
-        Txt  -> ls
-      -- ^ Alter file contents, in the case of html encasing it in <code> and adding a line break
-  in topHeader <> T.unlines (map ppFile allFiles)
+  let
+    runtimeLinesMap = buildRuntimeLinesMap sc cs
+    -- ^ Excludes lines such as comments or blanks
+    ppFile (srcPath, srcLines) =
+      let runtimeLines = fromMaybe mempty $ Map.lookup srcPath runtimeLinesMap
+          marked = markLines fileType srcLines runtimeLines (fromMaybe Map.empty (Map.lookup srcPath covLines))
+      in T.unlines (changeFileName srcPath : changeFileLines (V.toList marked))
+    -- ^ Pretty print individual file coverage
+    topHeader = case fileType of
+      Lcov -> "TN:\n"
+      Html -> "<style> code { white-space: pre-wrap; display: block; background-color: #eee; }" <>
+              ".executed { background-color: #afa; }" <>
+              ".reverted { background-color: #ffa; }" <>
+              ".unexecuted { background-color: #faa; }" <>
+              ".neutral { background-color: #eee; }" <>
+              "</style>"
+      Txt  -> ""
+    -- ^ Text to add to top of the file
+    changeFileName fn = case fileType of
+      Lcov -> "SF:" <> fn
+      Html -> "<b>" <> HTML.text fn <> "</b>"
+      Txt  -> fn
+    -- ^ Alter file name, in the case of html turning it into bold text
+    changeFileLines ls = case fileType of
+      Lcov -> ls ++ ["end_of_record"]
+      Html -> "<code>" : ls ++ ["", "</code>","<br />"]
+      Txt  -> ls
+    -- ^ Alter file contents, in the case of html encasing it in <code> and adding a line break
+  pure $ topHeader <> T.unlines (map ppFile allFiles)
 
 -- | Mark one particular line, from a list of lines, keeping the order of them
 markLines :: CoverageFileType -> V.Vector Text -> S.Set Int -> Map Int [TxResult] -> V.Vector Text
@@ -158,11 +158,11 @@ getMarker ErrorOutOfGas = 'o'
 getMarker _             = 'e'
 
 -- | Given a source cache, a coverage map, a contract returns a list of covered lines
-srcMapCov :: SourceCache -> FrozenCoverageMap -> [SolcContract] -> Map FilePathText (Map Int [TxResult])
-srcMapCov sc covMap contracts =
-  Map.unionsWith Map.union $ linesCovered <$> contracts
+srcMapCov :: SourceCache -> CoverageMap -> [SolcContract] -> IO (Map FilePathText (Map Int [TxResult]))
+srcMapCov sc covMap contracts = do
+  Map.unionsWith Map.union <$> mapM linesCovered contracts
   where
-  linesCovered :: SolcContract -> Map Text (Map Int [TxResult])
+  linesCovered :: SolcContract -> IO (Map Text (Map Int [TxResult]))
   linesCovered c =
     case Map.lookup (getBytecodeMetadata c.runtimeCode) covMap of
       Just vec -> VU.foldl' (\acc covInfo -> case covInfo of

--- a/lib/Echidna/Shrink.hs
+++ b/lib/Echidna/Shrink.hs
@@ -25,30 +25,30 @@ shrinkTest
   :: (MonadIO m, MonadCatch m, MonadRandom m, MonadReader Env m)
   => VM
   -> EchidnaTest
-  -> m EchidnaTest
+  -> m (Maybe EchidnaTest)
 shrinkTest vm test = do
   env <- ask
   case test.state of
     Large i | i >= env.cfg.campaignConf.shrinkLimit ->
-      pure $ test { state = Solved }
+      pure $ Just test { state = Solved }
     Large i ->
       if length test.reproducer > 1 || any canShrinkTx test.reproducer then do
         maybeShrunk <- evalStateT (shrinkSeq (checkETest test) test.value test.reproducer) vm
         pure $ case maybeShrunk of
           Just (txs, val, vm') -> do
-            test { state = Large (i + 1)
+            Just test { state = Large (i + 1)
                  , reproducer = txs
                  , events = extractEvents False env.dapp vm'
                  , result = getResultFromVM vm'
                  , value = val }
           Nothing ->
             -- No success with shrinking this time, just bump trials
-            test { state = Large (i + 1) }
+            Just test { state = Large (i + 1) }
       else
-        pure $ test { state = if isOptimizationTest test.testType
+        pure $ Just test { state = if isOptimizationTest test.testType
                                  then Large (i + 1)
                                  else Solved }
-    _ -> pure test
+    _ -> pure Nothing
 
 -- | Given a call sequence that solves some Echidna test, try to randomly
 -- generate a smaller one that still solves that test.

--- a/lib/Echidna/Shrink.hs
+++ b/lib/Echidna/Shrink.hs
@@ -29,7 +29,7 @@ shrinkTest
 shrinkTest vm test = do
   env <- ask
   case test.state of
-    Large i | i >= env.cfg.campaignConf.shrinkLimit ->
+    Large i | i >= env.cfg.campaignConf.shrinkLimit && not (isOptimizationTest test) ->
       pure $ Just test { state = Solved }
     Large i ->
       if length test.reproducer > 1 || any canShrinkTx test.reproducer then do

--- a/lib/Echidna/Shrink.hs
+++ b/lib/Echidna/Shrink.hs
@@ -45,7 +45,7 @@ shrinkTest vm test = do
             -- No success with shrinking this time, just bump trials
             Just test { state = Large (i + 1) }
       else
-        pure $ Just test { state = if isOptimizationTest test.testType
+        pure $ Just test { state = if isOptimizationTest test
                                  then Large (i + 1)
                                  else Solved }
     _ -> pure Nothing

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -52,7 +52,7 @@ getSignatures hmm (Just lmm) =
 
 -- | Generate a random 'Transaction' with either synthesis or mutation of dictionary entries.
 genTx
-  :: (MonadRandom m, MonadState Campaign m)
+  :: (MonadRandom m, MonadState WorkerState m)
   => MetadataCache
   -> World
   -> TxConf

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -55,7 +55,7 @@ data WorkerStopReason
   = TestLimitReached
   | TimeLimitReached
   | FastFailed
-  | Killed
+  | Killed !String
   | Crashed !String
   deriving Show
 
@@ -83,8 +83,8 @@ ppCampaignEvent = \case
     "Time limit reached. Stopping."
   WorkerStopped FastFailed ->
     "A test was falsified. Stopping."
-  WorkerStopped Killed ->
-    "Killed. Stopping."
+  WorkerStopped (Killed e) ->
+    "Killed (" <> e <>"). Stopping."
   WorkerStopped (Crashed e) ->
     "Crashed:\n\n" <>
     e <>

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -2,13 +2,14 @@ module Echidna.Types.Campaign where
 
 import Data.Map (Map)
 import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Word (Word8)
 
-import Echidna.ABI (GenDict, emptyDict)
+import Echidna.ABI (GenDict, emptyDict, encodeSig)
 import Echidna.Output.Source (CoverageFileType)
 import Echidna.Types
-import Echidna.Types.Corpus
-import Echidna.Types.Coverage (CoverageMap, FrozenCoverageMap)
-import Echidna.Types.Test (EchidnaTest)
+import Echidna.Types.Coverage (CoverageMap)
+import Echidna.Types.Test (TestType (..), EchidnaTest(..))
 import Echidna.Types.Tx (Tx)
 
 -- | Configuration for running an Echidna 'Campaign'.
@@ -37,31 +38,83 @@ data CampaignConf = CampaignConf
     -- ^ Directory to load and save lists of transactions
   , coverageFormats :: [CoverageFileType]
     -- ^ List of file formats to save coverage reports
+  , jobs            :: Maybe Word8
   }
 
-type FrozenCampaign = GenericCampaign FrozenCoverageMap
+data CampaignEvent
+  = TestFalsified !EchidnaTest
+  | TestOptimized !EchidnaTest
+  | NewCoverage !Int !Int !Int
+  | TxSequenceReplayed !Int !Int
+  | WorkerStopped WorkerStopReason
+  -- ^ This is a terminal event. Worker exits and won't push any events after
+  -- this one
+  deriving Show
 
-type Campaign = GenericCampaign CoverageMap
+data WorkerStopReason
+  = TestLimitReached
+  | TimeLimitReached
+  | FastFailed
+  | Killed
+  | Crashed !String
+  deriving Show
+
+ppCampaignEvent :: CampaignEvent -> String
+ppCampaignEvent = \case
+  TestFalsified test ->
+    let name = case test.testType of
+                 PropertyTest n _ -> n
+                 AssertionTest _ n _ -> encodeSig n
+                 CallTest n _ -> n
+                 _ -> error "impossible"
+    in "Test " <> T.unpack name <> " falsified!"
+  TestOptimized test ->
+    let name = case test.testType of OptimizationTest n _ -> n; _ -> error "fixme"
+    in "New maximum value of " <> T.unpack name <> ": " <> show test.value
+  NewCoverage points codehashes corpus ->
+    "New coverage: " <> show points <> " instr, "
+      <> show codehashes <> " contracts, "
+      <> show corpus <> " seqs in corpus"
+  TxSequenceReplayed current total ->
+    "Sequence replayed from corpus (" <> show current <> "/" <> show total <> ")"
+  WorkerStopped TestLimitReached ->
+    "Test limit reached. Stopping."
+  WorkerStopped TimeLimitReached ->
+    "Time limit reached. Stopping."
+  WorkerStopped FastFailed ->
+    "A test was falsified. Stopping."
+  WorkerStopped Killed ->
+    "Killed. Stopping."
+  WorkerStopped (Crashed e) ->
+    "Crashed:\n\n" <>
+    e <>
+    "\n\nPlease report it to https://github.com/crytic/echidna/issues"
+
 -- | The state of a fuzzing campaign.
-data GenericCampaign a = Campaign
-  { tests       :: ![EchidnaTest]
-    -- ^ Tests being evaluated
-  , coverage    :: !a
-    -- ^ Coverage captured (NOTE: we don't always record this)
+data WorkerState = WorkerState
+  { workerId    :: !Int
+    -- ^ Worker ID starting from 0
   , gasInfo     :: !(Map Text (Gas, [Tx]))
     -- ^ Worst case gas (NOTE: we don't always record this)
   , genDict     :: !GenDict
     -- ^ Generation dictionary
   , newCoverage :: !Bool
     -- ^ Flag to indicate new coverage found
-  , corpus      :: !Corpus
-    -- ^ List of transactions with maximum coverage
   , ncallseqs   :: !Int
     -- ^ Number of times the callseq is called
+  , ncalls      :: !Int
+    -- ^ Number of calls executed while fuzzing
   }
 
-defaultCampaign :: Monoid a => GenericCampaign a
-defaultCampaign = Campaign mempty mempty mempty emptyDict False mempty 0
+initialWorkerState :: WorkerState
+initialWorkerState =
+  WorkerState { workerId = 0
+              , gasInfo = mempty
+              , genDict = emptyDict
+              , newCoverage = False
+              , ncallseqs = 0
+              , ncalls = 0
+              }
 
 defaultTestLimit :: Int
 defaultTestLimit = 50000

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -38,7 +38,7 @@ data CampaignConf = CampaignConf
     -- ^ Directory to load and save lists of transactions
   , coverageFormats :: [CoverageFileType]
     -- ^ List of file formats to save coverage reports
-  , jobs            :: Maybe Word8
+  , workers         :: Maybe Word8
   }
 
 data CampaignEvent

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -18,8 +18,8 @@ import Echidna.Types.Corpus (Corpus)
 import Echidna.Types.Coverage (CoverageMap)
 import Echidna.Types.Signature (MetadataCache)
 import Echidna.Types.Solidity (SolConf)
-import Echidna.Types.Tx (TxConf)
 import Echidna.Types.Test (TestConf, EchidnaTest)
+import Echidna.Types.Tx (TxConf)
 
 data OperationMode = Interactive | NonInteractive OutputFormat deriving (Show, Eq)
 data OutputFormat = Text | JSON | None deriving (Show, Eq)
@@ -64,9 +64,8 @@ data Env = Env
   { cfg :: EConfig
   , dapp :: DappInfo
 
-  -- | Shared between all workers. Events are fairly rare so contention should
-  -- be minimal. Alternatively, think about a per-worker queue and listening
-  -- on all channels somehow.
+  -- | Shared between all workers. Events are fairly rare so contention is
+  -- minimal.
   , eventQueue :: Chan (Int, LocalTime, CampaignEvent)
 
   , testsRef :: IORef [EchidnaTest]

--- a/lib/Echidna/Types/Coverage.hs
+++ b/lib/Echidna/Types/Coverage.hs
@@ -5,7 +5,6 @@ import Data.ByteString (ByteString)
 import Data.List (foldl')
 import Data.Map qualified as Map
 import Data.Map.Strict (Map)
-import Data.Vector.Unboxed qualified as VU
 import Data.Vector.Unboxed.Mutable (IOVector)
 import Data.Vector.Unboxed.Mutable qualified as V
 import Data.Word (Word64)
@@ -14,9 +13,6 @@ import Echidna.Types.Tx (TxResult)
 
 -- | Map with the coverage information needed for fuzzing and source code printing
 type CoverageMap = Map ByteString (IOVector CoverageInfo)
-
--- | Immutable CoverageMap used to pass into pure functions
-type FrozenCoverageMap = Map ByteString (VU.Vector CoverageInfo)
 
 -- | Basic coverage information
 type CoverageInfo = (OpIx, StackDepths, TxResults)
@@ -36,10 +32,6 @@ type TxResults = Word64
 scoveragePoints :: CoverageMap -> IO Int
 scoveragePoints cm = do
   sum <$> mapM (V.foldl' countCovered 0) (Map.elems cm)
-
-scoveragePointsFrozen :: FrozenCoverageMap -> Int
-scoveragePointsFrozen cm =
-  sum $ VU.foldl' countCovered 0 <$> Map.elems cm
 
 countCovered :: Int -> CoverageInfo -> Int
 countCovered acc (opIx,_,_) = if opIx == -1 then acc else acc + 1

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -88,9 +88,9 @@ data EchidnaTest = EchidnaTest
   , events     :: Events
   } deriving (Eq, Show)
 
-isOptimizationTest :: TestType -> Bool
-isOptimizationTest (OptimizationTest _ _) = True
-isOptimizationTest _                      = False
+isOptimizationTest :: EchidnaTest -> Bool
+isOptimizationTest EchidnaTest{testType = OptimizationTest _ _} = True
+isOptimizationTest _ = False
 
 isOpen :: EchidnaTest -> Bool
 isOpen t = case t.state of

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -30,7 +30,7 @@ data TestConf = TestConf
 -- | State of a particular Echidna test. N.B.: 'Solved' means a falsifying
 -- call sequence was found.
 data TestState
-  = Open !Int  -- ^ Maybe solvable, tracking attempts already made
+  = Open
   | Large !Int -- ^ Solved, maybe shrinable, tracking shrinks tried
   | Passed     -- ^ Presumed unsolvable
   | Solved     -- ^ Solved with no need for shrinking
@@ -41,7 +41,7 @@ data TestValue
   = BoolValue Bool
   | IntValue Int256
   | NoValue
-  deriving Eq
+  deriving (Eq, Ord)
 
 instance Show TestValue where
   show (BoolValue x) = show x
@@ -63,8 +63,16 @@ instance Eq TestType where
   Exploration          == Exploration            = True
   _                    == _                      = False
 
+instance Show TestType where
+  show = \case
+    PropertyTest t _     -> show t
+    AssertionTest _ s _  -> show s
+    OptimizationTest s _ -> show s
+    CallTest t _         -> show t
+    Exploration          -> "Exploration"
+
 instance Eq TestState where
-  Open i  == Open j  = i == j
+  Open    == Open    = True
   Large i == Large j = i == j
   Passed  == Passed  = True
   Solved  == Solved  = True
@@ -78,7 +86,7 @@ data EchidnaTest = EchidnaTest
   , reproducer :: [Tx]
   , result     :: TxResult
   , events     :: Events
-  } deriving Eq
+  } deriving (Eq, Show)
 
 isOptimizationTest :: TestType -> Bool
 isOptimizationTest (OptimizationTest _ _) = True
@@ -86,8 +94,8 @@ isOptimizationTest _                      = False
 
 isOpen :: EchidnaTest -> Bool
 isOpen t = case t.state of
-  Open _ -> True
-  _      -> False
+  Open -> True
+  _    -> False
 
 didFail :: EchidnaTest -> Bool
 didFail t = case t.state of
@@ -105,7 +113,7 @@ instance ToJSON TestState where
     object $ ("passed", toJSON passed) : maybeToList desc
     where
     (passed, desc) = case s of
-      Open _   -> (True, Nothing)
+      Open     -> (True, Nothing)
       Passed   -> (True, Nothing)
       Large _  -> (False, Nothing)
       Solved   -> (False, Nothing)

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -190,7 +190,7 @@ ui vm world dict initialCorpus = do
 
       case outputFormat of
         JSON ->
-          liftIO $ BS.putStr =<< Echidna.Output.JSON.encodeCampaign states
+          liftIO $ BS.putStr =<< Echidna.Output.JSON.encodeCampaign env states
         Text -> do
           liftIO . putStrLn =<< ppCampaign states
         None ->

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -83,7 +83,7 @@ ui vm world dict initialCorpus = do
 
     chunkSize = ceiling
       (fromIntegral (length initialCorpus) / fromIntegral nworkers :: Double)
-    corpusChunks = chunksOf chunkSize initialCorpus ++ repeat []
+    corpusChunks = (if chunkSize > 0 then chunksOf chunkSize initialCorpus else []) ++ repeat []
 
   workers <- forM (zip corpusChunks [0..(nworkers-1)]) $
     uncurry (spawnWorker env perWorkerTestLimit)

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -7,178 +7,243 @@ module Echidna.UI where
 import Brick
 import Brick.BChan
 import Brick.Widgets.Dialog qualified as B
-import Control.Monad.Catch (MonadCatch(..), catchAll)
-import Control.Monad.Reader (MonadReader (ask), runReader, asks)
-import Control.Monad.State (modify')
+import Data.Sequence ((|>))
 import Graphics.Vty (Config, Event(..), Key(..), Modifier(..), defaultConfig, inputMap, mkVty)
 import Graphics.Vty qualified as Vty
 import System.Posix
-
 import Echidna.UI.Widgets
-#else /* !INTERACTIVE_UI */
-import Control.Monad.Catch (MonadCatch(..))
-import Control.Monad.Reader (MonadReader, asks)
-import Control.Monad.State.Strict (get)
 #endif
 
-import Control.Monad
 import Control.Concurrent (killThread, threadDelay)
-import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad
+import Control.Monad.Catch
 import Control.Monad.Random.Strict (MonadRandom)
+import Control.Monad.Reader
+import Control.Monad.State.Strict hiding (state)
 import Data.ByteString.Lazy qualified as BS
-import Data.IORef
 import Data.Map (Map)
 import Data.Maybe (fromMaybe, isJust)
-import Data.Time (UTCTime, getCurrentTime)
-import Data.Vector.Unboxed qualified as VU
-import UnliftIO (MonadUnliftIO, hFlush, stdout)
-import UnliftIO.Timeout (timeout)
+import Data.Time
+import UnliftIO (MonadUnliftIO, newIORef, readIORef, atomicWriteIORef, hFlush, stdout, IORef, writeIORef, atomicModifyIORef')
 import UnliftIO.Concurrent hiding (killThread, threadDelay)
 
 import EVM (VM, Contract)
 import EVM.Types (Addr, W256)
 
 import Echidna.ABI
-import Echidna.Campaign (runCampaign)
+import Echidna.Campaign (runWorker, pushEvent)
 import Echidna.Output.JSON qualified
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Corpus (corpusSize)
 import Echidna.Types.Coverage (scoveragePoints)
-import Echidna.Types.Test (EchidnaTest(..), TestState(..), didFail, isOpen, isOptimizationTest)
+import Echidna.Types.Test (EchidnaTest(..), didFail, isOptimizationTest, TestType, TestState (..))
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.World (World)
 import Echidna.UI.Report
-import Echidna.Utility (timePrefix)
+import Echidna.Utility (timePrefix, getTimestamp)
 
 data UIEvent =
-  CampaignUpdated UTCTime FrozenCampaign
-  | CampaignTimedout FrozenCampaign
-  | CampaignCrashed String
-  | FetchCacheUpdated (Map Addr (Maybe Contract)) (Map Addr (Map W256 (Maybe W256)))
+  CampaignUpdated LocalTime [EchidnaTest] [WorkerState]
+  | FetchCacheUpdated (Map Addr (Maybe Contract))
+                      (Map Addr (Map W256 (Maybe W256)))
+  | WorkerEvent (Int, LocalTime, CampaignEvent)
+
+type Worker = (IORef WorkerState, MVar ())
 
 -- | Set up and run an Echidna 'Campaign' and display interactive UI or
 -- print non-interactive output in desired format at the end
 ui
   :: (MonadCatch m, MonadRandom m, MonadReader Env m, MonadUnliftIO m)
-  => VM             -- ^ Initial VM state
-  -> World          -- ^ Initial world state
-  -> [EchidnaTest]  -- ^ Tests to evaluate
+  => VM            -- ^ Initial VM state
+  -> World         -- ^ Initial world state
   -> GenDict
   -> [[Tx]]
-  -> m Campaign
-ui vm world ts dict initialCorpus = do
+  -> m [WorkerState]
+ui vm world dict initialCorpus = do
+  env <- ask
   conf <- asks (.cfg)
-  ref <- liftIO $ newIORef defaultCampaign
-  stop <- newEmptyMVar
-  let
-    updateRef = do
-      shouldStop <- liftIO $ isJust <$> tryReadMVar stop
-      get >>= liftIO . atomicWriteIORef ref
-      pure shouldStop
-
-    secToUsec = (* 1000000)
-    timeoutUsec = secToUsec $ fromMaybe (-1) conf.uiConf.maxTime
-    runCampaign' = timeout timeoutUsec (runCampaign updateRef vm world ts dict initialCorpus)
-#ifdef INTERACTIVE_UI
   terminalPresent <- liftIO isTerminal
-#else
-  let terminalPresent = False
-#endif
-  let effectiveMode = case conf.uiConf.operationMode of
-        Interactive | not terminalPresent -> NonInteractive Text
-        other -> other
+
+  let
+    -- default to one worker if not configured
+    jobs = fromIntegral $ fromMaybe 1 conf.campaignConf.jobs
+
+    effectiveMode = case conf.uiConf.operationMode of
+      Interactive | not terminalPresent -> NonInteractive Text
+      other -> other
+
+    -- Distribute over all workers, could be slightly bigger overall due to
+    -- ceiling but this doesn't matter
+    perWorkerTestLimit = ceiling
+      (fromIntegral conf.campaignConf.testLimit / fromIntegral jobs :: Double)
+
+  workers <- forM [0..(jobs-1)] (spawnWorker perWorkerTestLimit)
+
+  -- Run a thread that will order all workers to exit when timeout is reached
+  case conf.uiConf.maxTime of
+    Just seconds -> void . liftIO . forkIO $ do
+      threadDelay (seconds * 1_000_000)
+      stopWorkers workers TimeLimitReached
+    Nothing -> pure ()
+
+  -- A var used to block and wait for listener to finish
+  listenerStopVar <- newEmptyMVar
+
   case effectiveMode of
 #ifdef INTERACTIVE_UI
     Interactive -> do
-      bc <- liftIO $ newBChan 100
-      let updateUI e = readIORef ref >>= freezeCampaign >>= writeBChan bc . e
-      env <- ask
-      ticker <- liftIO $ forkIO $
-        -- run UI update every 100ms
-        forever $ do
-          threadDelay 100000
-          now <- getCurrentTime
-          updateUI (CampaignUpdated now)
-          c <- readIORef env.fetchContractCache
-          s <- readIORef env.fetchSlotCache
-          writeBChan bc (FetchCacheUpdated c s)
-      _ <- forkFinally -- run worker
-        (void $ do
-          catchAll
-            (runCampaign' >>= \case
-              Nothing -> liftIO $ updateUI CampaignTimedout
-              Just _ -> liftIO $ do
-                now <- getCurrentTime
-                updateUI (CampaignUpdated now)
-            )
-            (liftIO . writeBChan bc . CampaignCrashed . show)
-        )
-        (const $ liftIO $ killThread ticker)
+      -- Channel to push events to update UI
+      uiChannel <- liftIO $ newBChan 1000
+      let forwardEvent = writeBChan uiChannel . WorkerEvent
+      liftIO $ spawnListener env forwardEvent jobs listenerStopVar
+
+      ticker <- liftIO . forkIO . forever $ do
+        threadDelay 200_000 -- 200 ms
+
+        now <- getTimestamp
+        tests <- readIORef env.testsRef
+        states <- workerStates workers
+        writeBChan uiChannel (CampaignUpdated now tests states)
+
+        -- TODO: remove and use events for this
+        c <- readIORef env.fetchContractCache
+        s <- readIORef env.fetchSlotCache
+        writeBChan uiChannel (FetchCacheUpdated c s)
+
+      -- UI initialization
       let buildVty = do
             v <- mkVty =<< vtyConfig
             Vty.setMode (Vty.outputIface v) Vty.Mouse True
             pure v
       initialVty <- liftIO buildVty
-      app <- customMain initialVty buildVty (Just bc) <$> monitor
+      app <- customMain initialVty buildVty (Just uiChannel) <$> monitor
+
       liftIO $ do
-        now <- getCurrentTime
+        tests <- readIORef env.testsRef
+        now <- getTimestamp
         void $ app UIState
-          { campaign = defaultCampaign
+          { campaigns = [initialWorkerState] -- ugly, fix me
+          , workersAlive = jobs
           , status = Uninitialized
           , timeStarted = now
+          , timeStopped = Nothing
           , now = now
           , fetchedContracts = mempty
           , fetchedSlots = mempty
-          , fetchedDialog = B.dialog (Just "Fetched contracts/slots") Nothing 80
+          , fetchedDialog = B.dialog (Just " Fetched contracts/slots ") Nothing 80
           , displayFetchedDialog = False
+          , workerEvents = mempty
+          , corpusSize = 0
+          , coverage = 0
+          , numCodehashes = 0
+          , lastNewCov = now
+          , tests
           }
-      final <- liftIO $ readIORef ref
-      liftIO . putStrLn =<< ppCampaign final
-      pure final
+
+      -- Exited from the UI, stop the workers, not needed anymore
+      stopWorkers workers Killed
+
+      -- wait for all events to be processed
+      takeMVar listenerStopVar
+
+      liftIO $ killThread ticker
+
+      states <- workerStates workers
+      liftIO . putStrLn =<< ppCampaign states
+
+      pure states
 #else
     Interactive -> error "Interactive UI is not available"
 #endif
 
     NonInteractive outputFormat -> do
 #ifdef INTERACTIVE_UI
-      liftIO $ forM_ [sigINT, sigTERM] (\sig -> installHandler sig (Catch $ putMVar stop ()) Nothing)
+      -- Handles ctrl-c, TODO: this doesn't work on Windows
+      liftIO $ forM_ [sigINT, sigTERM] $ \sig ->
+        installHandler sig (Catch $ stopWorkers workers Killed) Nothing
 #endif
+      let forwardEvent = putStrLn . ppLogLine
+      liftIO $ spawnListener env forwardEvent jobs listenerStopVar
 
-      ticker <- liftIO $ forkIO $
-        -- print out status update every 3s
-        forever $ do
-          threadDelay $ 3*1000000
-          camp <- readIORef ref
-          time <- timePrefix
-          line <- statusLine conf.campaignConf camp
-          putStrLn $ time <> "[status] " <> line
-          hFlush stdout
-      result <- runCampaign'
+      let printStatus = do
+            states <- liftIO $ workerStates workers
+            time <- timePrefix <$> getTimestamp
+            line <- statusLine env states
+            putStrLn $ time <> "[status] " <> line
+            hFlush stdout
+
+      ticker <- liftIO . forkIO . forever $ do
+        threadDelay 3_000_000 -- 3 seconds
+        printStatus
+
+      -- wait for all events to be processed
+      takeMVar listenerStopVar
+
       liftIO $ killThread ticker
-      (final, timedout) <- case result of
-        Nothing -> do
-          final <- liftIO $ readIORef ref
-          pure (final, True)
-        Just final ->
-          pure (final, False)
+
+      -- print final status regardless the last scheduled update
+      liftIO printStatus
+
+      states <- liftIO $ workerStates workers
+
       case outputFormat of
         JSON ->
-          liftIO $ BS.putStr =<< Echidna.Output.JSON.encodeCampaign final
+          liftIO $ BS.putStr =<< Echidna.Output.JSON.encodeCampaign states
         Text -> do
-          liftIO . putStrLn =<< ppCampaign final
-          when timedout $ liftIO $ putStrLn "TIMEOUT!"
+          liftIO . putStrLn =<< ppCampaign states
         None ->
           pure ()
-      pure final
+      pure states
 
-freezeCampaign :: Campaign -> IO FrozenCampaign
-freezeCampaign camp = do
-  frozenCov <- mapM VU.freeze camp.coverage
-  pure camp { coverage = frozenCov }
+  where
+
+  spawnWorker testLimit workerId = do
+    stateRef <- newIORef initialWorkerState
+    stopWorker <- newEmptyMVar
+
+    -- Is ThreadId useful for anything?
+    void . forkIO . void $ do
+      -- TODO: split corpus into chunks and make each worker replay a chunk
+      runWorker (workerCallback stateRef stopWorker)
+                vm world dict workerId initialCorpus testLimit
+
+    pure (stateRef, stopWorker)
+
+  -- | This function is idempotent and can be called many times. This is
+  -- important in case there is a race to stop workers, the first reason wins.
+  stopWorkers workers reason =
+    forM_ workers $ \(_, stopWorker) -> tryPutMVar stopWorker reason
+
+  -- | Get a snapshot of all worker states
+  workerStates workers =
+    forM workers $ \(stateRef, _) -> readIORef stateRef
+
+  spawnListener
+    :: Env
+    -> ((Int, LocalTime, CampaignEvent) -> IO ())
+    -- ^ a function that forwards event to the UI
+    -> Int     -- ^ number of workers
+    -> MVar () -- ^ use to join this thread
+    -> IO ()
+  spawnListener env forwardEvent jobs stopVar =
+    void . forkIO $ do
+      loop jobs
+      putMVar stopVar ()
+    where
+    loop !workersAlive =
+      when (workersAlive > 0) $ do
+        event <- readChan env.eventQueue
+        forwardEvent event
+        case event of
+          (_, _, WorkerStopped _) -> loop (workersAlive - 1)
+          _                       -> loop workersAlive
+
+  workerCallback stateRef stopWorker = do
+    get >>= writeIORef stateRef
+    tryTakeMVar stopWorker
 
 #ifdef INTERACTIVE_UI
-
 vtyConfig :: IO Config
 vtyConfig = do
   config <- Vty.standardIOConfig
@@ -197,31 +262,56 @@ monitor = do
            else emptyWidget
       , runReader (campaignStatus uiState) conf ]
 
-    onEvent (AppEvent (CampaignUpdated now c')) =
-      modify' $ \state -> state { campaign = c', status = Running, now = now }
-    onEvent (AppEvent (CampaignTimedout c')) =
-      modify' $ \state -> state { campaign = c', status = Timedout }
-    onEvent (AppEvent (CampaignCrashed e)) = do
-      modify' $ \state -> state { status = Crashed e }
-    onEvent (AppEvent (FetchCacheUpdated contracts slots)) =
-      modify' $ \state -> state { fetchedContracts = contracts
-                                , fetchedSlots = slots }
-    onEvent (VtyEvent (EvKey (KChar 'f') _)) =
-      modify' $ \state -> state { displayFetchedDialog = not state.displayFetchedDialog }
-    onEvent (VtyEvent (EvKey KEsc _))                         = halt
-    onEvent (VtyEvent (EvKey (KChar 'c') l)) | MCtrl `elem` l = halt
-    onEvent (MouseDown (SBClick el n) _ _ _) =
-      case n of
-        TestsViewPort -> do
-          let vp = viewportScroll TestsViewPort
-          case el of
-            SBHandleBefore -> vScrollBy vp (-1)
-            SBHandleAfter  -> vScrollBy vp 1
-            SBTroughBefore -> vScrollBy vp (-10)
-            SBTroughAfter  -> vScrollBy vp 10
-            SBBar          -> pure ()
-        _ -> pure ()
-    onEvent _ = pure ()
+    onEvent = \case
+      AppEvent (CampaignUpdated now tests c') ->
+        modify' $ \state -> state { campaigns = c', status = Running, now, tests }
+      AppEvent (FetchCacheUpdated contracts slots) ->
+        modify' $ \state ->
+          state { fetchedContracts = contracts
+                , fetchedSlots = slots }
+      AppEvent (WorkerEvent event@(_,time,campaignEvent)) -> do
+        modify' $ \state -> state { workerEvents = state.workerEvents |> event }
+        case campaignEvent of
+          NewCoverage coverage numCodehashes size ->
+            modify' $ \state ->
+              state { coverage = max state.coverage coverage -- max not really needed
+                    , corpusSize = size
+                    , numCodehashes
+                    , lastNewCov = time
+                    }
+          WorkerStopped _ ->
+            modify' $ \state ->
+              state { workersAlive = state.workersAlive - 1
+                    , timeStopped = if state.workersAlive == 1
+                                       then Just time else Nothing
+                    }
+
+          _ -> pure ()
+      VtyEvent (EvKey (KChar 'f') _) ->
+        modify' $ \state ->
+          state { displayFetchedDialog = not state.displayFetchedDialog }
+      VtyEvent (EvKey KEsc _)                         -> halt
+      VtyEvent (EvKey (KChar 'c') l) | MCtrl `elem` l -> halt
+      MouseDown (SBClick el n) _ _ _ ->
+        case n of
+          TestsViewPort -> do
+            let vp = viewportScroll TestsViewPort
+            case el of
+              SBHandleBefore -> vScrollBy vp (-1)
+              SBHandleAfter  -> vScrollBy vp 1
+              SBTroughBefore -> vScrollBy vp (-10)
+              SBTroughAfter  -> vScrollBy vp 10
+              SBBar          -> pure ()
+          LogViewPort -> do
+            let vp = viewportScroll LogViewPort
+            case el of
+              SBHandleBefore -> vScrollBy vp (-1)
+              SBHandleAfter  -> vScrollBy vp 1
+              SBTroughBefore -> vScrollBy vp (-10)
+              SBTroughAfter  -> vScrollBy vp 10
+              SBBar          -> pure ()
+          _ -> pure ()
+      _ -> pure ()
 
   env <- ask
   pure $ App { appDraw = drawUI env
@@ -230,24 +320,29 @@ monitor = do
              , appAttrMap = const attrs
              , appChooseCursor = neverShowCursor
              }
+#endif
 
 -- | Heuristic check that we're in a sensible terminal (not a pipe)
 isTerminal :: IO Bool
-isTerminal = (&&) <$> queryTerminal (Fd 0) <*> queryTerminal (Fd 1)
-
+isTerminal =
+#ifdef INTERACTIVE_UI
+  (&&) <$> queryTerminal (Fd 0) <*> queryTerminal (Fd 1)
+#else
+  pure False
 #endif
 
 -- | Composes a compact text status line of the campaign
-statusLine :: CampaignConf -> Campaign -> IO String
-statusLine campaignConf camp = do
-  points <- scoveragePoints camp.coverage
-  pure $ "tests: " <> show (length $ filter didFail camp.tests) <> "/" <> show (length camp.tests)
-    <> ", fuzzing: " <> show fuzzRuns <> "/" <> show campaignConf.testLimit
-    <> ", values: " <> show (map (.value) $ filter (\t -> isOptimizationTest t.testType) camp.tests)
+statusLine
+  :: Env
+  -> [WorkerState]
+  -> IO String
+statusLine env states = do
+  tests <- readIORef env.testsRef
+  points <- scoveragePoints =<< readIORef env.coverageRef
+  corpus <- readIORef env.corpusRef
+  let totalCalls = sum ((.ncalls) <$> states)
+  pure $ "tests: " <> show (length $ filter didFail tests) <> "/" <> show (length tests)
+    <> ", fuzzing: " <> show totalCalls <> "/" <> show env.cfg.campaignConf.testLimit
+    <> ", values: " <> show (map (.value) $ filter (\t -> isOptimizationTest t.testType) tests)
     <> ", cov: " <> show points
-    <> ", corpus: " <> show (corpusSize camp.corpus)
-  where
-  fuzzRuns = case filter isOpen camp.tests of
-    -- fuzzing progress is the same for all Open tests, grab the first one
-    EchidnaTest { state = Open t }:_ -> t
-    _ -> campaignConf.testLimit
+    <> ", corpus: " <> show (corpusSize corpus)

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -22,7 +22,7 @@ import Control.Monad.Random.Strict (MonadRandom)
 import Control.Monad.Reader
 import Control.Monad.State.Strict hiding (state)
 import Data.ByteString.Lazy qualified as BS
-import Data.List.Extra (chunksOf)
+import Data.List.Split (chunksOf)
 import Data.Map (Map)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Time
@@ -83,7 +83,7 @@ ui vm world dict initialCorpus = do
 
     chunkSize = ceiling
       (fromIntegral (length initialCorpus) / fromIntegral nworkers :: Double)
-    corpusChunks = (if chunkSize > 0 then chunksOf chunkSize initialCorpus else []) ++ repeat []
+    corpusChunks = chunksOf chunkSize initialCorpus ++ repeat []
 
   workers <- forM (zip corpusChunks [0..(nworkers-1)]) $
     uncurry (spawnWorker env perWorkerTestLimit)

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -214,9 +214,11 @@ ui vm world dict initialCorpus = do
 
     pure (threadId, stateRef)
 
+#ifdef INTERACTIVE_UI
   -- | Order the workers to stop immediately
   stopWorkers workers =
     forM_ workers $ \(threadId, _) -> liftIO $ killThread threadId
+#endif
 
   -- | Get a snapshot of all worker states
   workerStates workers =

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -354,6 +354,6 @@ statusLine env states = do
   let totalCalls = sum ((.ncalls) <$> states)
   pure $ "tests: " <> show (length $ filter didFail tests) <> "/" <> show (length tests)
     <> ", fuzzing: " <> show totalCalls <> "/" <> show env.cfg.campaignConf.testLimit
-    <> ", values: " <> show (map (.value) $ filter (\t -> isOptimizationTest t.testType) tests)
+    <> ", values: " <> show ((.value) <$> filter isOptimizationTest tests)
     <> ", cov: " <> show points
     <> ", corpus: " <> show (corpusSize corpus)

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -1,40 +1,51 @@
 module Echidna.UI.Report where
 
-import Control.Monad.Reader (MonadReader, asks, MonadIO (liftIO))
+import Control.Monad.Reader (MonadReader, MonadIO (liftIO), asks)
+import Data.IORef (readIORef)
 import Data.List (intercalate, nub, sortOn)
 import Data.Map (toList)
 import Data.Maybe (catMaybes)
 import Data.Text (Text, unpack)
 import Data.Text qualified as T
+import Data.Time (LocalTime)
 
 import Echidna.ABI (GenDict(..), encodeSig)
 import Echidna.Events (Events)
 import Echidna.Pretty (ppTxCall)
 import Echidna.Types (Gas)
 import Echidna.Types.Campaign
-import Echidna.Types.Corpus (Corpus, corpusSize)
-import Echidna.Types.Coverage (CoverageMap, FrozenCoverageMap, scoveragePoints, scoveragePointsFrozen)
+import Echidna.Types.Coverage (scoveragePoints)
 import Echidna.Types.Test (EchidnaTest(..), TestState(..), TestType(..))
 import Echidna.Types.Tx (Tx(..), TxCall(..), TxConf(..))
 import Echidna.Types.Config
 
 import EVM.Types (W256)
+import Echidna.Types.Corpus (corpusSize)
+import Echidna.Utility (timePrefix)
+import qualified Data.Map as Map
 
-ppCampaign :: (MonadIO m, MonadReader Env m) => Campaign -> m String
-ppCampaign campaign = do
-  testsPrinted <- ppTests campaign
-  gasInfoPrinted <- ppGasInfo campaign
-  coveragePrinted <- liftIO $ ppCoverage campaign.coverage
-  let corpusPrinted = "\n" <> ppCorpus campaign.corpus
-      seedPrinted = "\nSeed: " <> show campaign.genDict.defSeed
-  pure $
-    testsPrinted
-    <> gasInfoPrinted
-    <> coveragePrinted
-    <> corpusPrinted
-    <> seedPrinted
+ppLogLine :: (Int, LocalTime, CampaignEvent) -> String
+ppLogLine (workerId, time, event) =
+  timePrefix time <> "[Worker " <> show workerId <> "] " <> ppCampaignEvent event
 
--- | Given rules for pretty-printing associated address, and whether to print them, pretty-print a 'Transaction'.
+ppCampaign :: (MonadIO m, MonadReader Env m) => [WorkerState] -> m String
+ppCampaign workerStates = do
+  tests <- liftIO . readIORef =<< asks (.testsRef)
+  testsPrinted <- ppTests tests
+  gasInfoPrinted <- ppGasInfo workerStates
+  coveragePrinted <- ppCoverage
+  let seedPrinted = "Seed: " <> show (head workerStates).genDict.defSeed
+  corpusPrinted <- ppCorpus
+  pure $ unlines
+    [ testsPrinted
+    , gasInfoPrinted
+    , coveragePrinted
+    , corpusPrinted
+    , seedPrinted
+    ]
+
+-- | Given rules for pretty-printing associated address, and whether to print
+-- them, pretty-print a 'Transaction'.
 ppTx :: MonadReader Env m => Bool -> Tx -> m String
 ppTx _ Tx { call = NoCall, delay } =
   pure $ "*wait*" <> ppDelay delay
@@ -55,27 +66,23 @@ ppDelay (time, block) =
   <> (if block == 0 then "" else " Block delay: " <> show (toInteger block))
 
 -- | Pretty-print the coverage a 'Campaign' has obtained.
-ppCoverage :: CoverageMap -> IO String
-ppCoverage s = do
-  points <- scoveragePoints s
-  pure $ ppCoverageCommon points (length s)
-
-ppFrozenCoverage :: FrozenCoverageMap -> String
-ppFrozenCoverage s = ppCoverageCommon (scoveragePointsFrozen s) (length s)
-
-ppCoverageCommon :: Int -> Int -> String
-ppCoverageCommon points ncodehashes =
-  "Unique instructions: " <> show points
-    <> "\nUnique codehashes: " <> show ncodehashes
+ppCoverage :: (MonadIO m, MonadReader Env m) => m String
+ppCoverage = do
+  coverage <- liftIO . readIORef =<< asks (.coverageRef)
+  points <- liftIO $ scoveragePoints coverage
+  pure $ "Unique instructions: " <> show points <> "\n" <>
+         "Unique codehashes: " <> show (length coverage)
 
 -- | Pretty-print the corpus a 'Campaign' has obtained.
-ppCorpus :: Corpus -> String
-ppCorpus c = "Corpus size: " <> show (corpusSize c)
+ppCorpus :: (MonadIO m, MonadReader Env m) => m String
+ppCorpus = do
+  corpus <- liftIO . readIORef =<< asks (.corpusRef)
+  pure $ "Corpus size: " <> show (corpusSize corpus)
 
 -- | Pretty-print the gas usage information a 'Campaign' has obtained.
-ppGasInfo :: MonadReader Env m => Campaign -> m String
-ppGasInfo Campaign { gasInfo } | gasInfo == mempty = pure ""
-ppGasInfo Campaign { gasInfo } = do
+ppGasInfo :: MonadReader Env m => [WorkerState] -> m String
+ppGasInfo workerStates = do
+  let gasInfo = Map.unionsWith max ((.gasInfo) <$> workerStates)
   items <- mapM ppGasOne $ sortOn (\(_, (n, _)) -> n) $ toList gasInfo
   pure $ intercalate "" items
 
@@ -109,10 +116,8 @@ ppTS :: MonadReader Env m => TestState -> Events -> [Tx] -> m String
 ppTS (Failed e) _ _  = pure $ "could not evaluate ☣\n  " <> show e
 ppTS Solved     es l = ppFail Nothing es l
 ppTS Passed     _ _  = pure " passed! 🎉"
-ppTS (Open i)   es [] = do
-  t <- asks (.cfg.campaignConf.testLimit)
-  if i >= t then ppTS Passed es [] else pure $ " fuzzing " <> progress i t
-ppTS (Open _)   es r = ppFail Nothing es r
+ppTS Open      _ []  = pure "passing"
+ppTS Open      es r  = ppFail Nothing es r
 ppTS (Large n) es l  = do
   m <- asks (.cfg.campaignConf.shrinkLimit)
   ppFail (if n < m then Just (n, m) else Nothing) es l
@@ -121,7 +126,7 @@ ppOPT :: MonadReader Env m => TestState -> Events -> [Tx] -> m String
 ppOPT (Failed e) _ _  = pure $ "could not evaluate ☣\n  " <> show e
 ppOPT Solved     es l = ppOptimized Nothing es l
 ppOPT Passed     _ _  = pure " passed! 🎉"
-ppOPT (Open _)   es r = ppOptimized Nothing es r
+ppOPT Open      es r  = ppOptimized Nothing es r
 ppOPT (Large n) es l  = do
   m <- asks (.cfg.campaignConf.shrinkLimit)
   ppOptimized (if n < m then Just (n, m) else Nothing) es l
@@ -139,8 +144,9 @@ ppOptimized b es xs = do
          <> ppEvents es
 
 -- | Pretty-print the status of all 'SolTest's in a 'Campaign'.
-ppTests :: MonadReader Env m => Campaign -> m String
-ppTests Campaign { tests } = unlines . catMaybes <$> mapM pp tests
+ppTests :: (MonadReader Env m) => [EchidnaTest] -> m String
+ppTests tests = do
+  unlines . catMaybes <$> mapM pp tests
   where
   pp t =
     case t.testType of
@@ -158,6 +164,7 @@ ppTests Campaign { tests } = unlines . catMaybes <$> mapM pp tests
         pure $ Just (T.unpack n <> ": max value: " <> show t.value <> "\n" <> status)
       Exploration -> pure Nothing
 
--- | Given a number of boxes checked and a number of total boxes, pretty-print progress in box-checking.
+-- | Given a number of boxes checked and a number of total boxes, pretty-print
+-- progress in box-checking.
 progress :: Int -> Int -> String
-progress n m = "(" <> show n <> "/" <> show m <> ")"
+progress n m = show n <> "/" <> show m

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -55,7 +55,7 @@ data UIState = UIState
   , numCodehashes :: Int
   , lastNewCov :: LocalTime
   -- ^ last timestamp of 'NewCoverage' event
-  --
+
   , tests :: [EchidnaTest]
   }
 
@@ -212,10 +212,10 @@ perfWidget :: UIState -> Widget n
 perfWidget uiState =
   str $ "Calls/s: " <>
     if totalTime > 0
-       then show $ div totalCalls totalTime
+       then show $ totalCalls `div` totalTime
        else "-"
   where
-  totalCalls = (sum $ (.ncalls) <$> uiState.campaigns)
+  totalCalls = sum $ (.ncalls) <$> uiState.campaigns
   totalTime = round $
     diffLocalTime (fromMaybe uiState.now uiState.timeStopped)
                   uiState.timeStarted
@@ -323,8 +323,9 @@ optWidget
 optWidget (Failed e) _ = pure (str "could not evaluate", str $ show e)
 optWidget Solved     _ = error "optimization tests cannot be solved"
 optWidget Passed     t = pure (str $ "max value found: " ++ show t.value, emptyWidget)
-optWidget Open       t = do
-  pure (withAttr (attrName "working") $ str $ "optimizing, max value: " ++ show t.value, emptyWidget)
+optWidget Open       t =
+  pure (withAttr (attrName "working") $ str $
+    "optimizing, max value: " ++ show t.value, emptyWidget)
 optWidget (Large n)  t = do
   m <- asks (.cfg.campaignConf.shrinkLimit)
   maxWidget (if n < m then Just (n,m) else Nothing) t.reproducer t.events t.value

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -8,12 +8,16 @@ import Brick
 import Brick.AttrMap qualified as A
 import Brick.Widgets.Border
 import Brick.Widgets.Center
-import Control.Monad.Reader (MonadReader, asks)
+import Brick.Widgets.Dialog qualified as B
+import Control.Monad.Reader (MonadReader, asks, ask)
 import Data.List (nub, intersperse, sortBy)
+import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, isJust)
+import Data.Sequence (Seq)
+import Data.Sequence qualified as Seq
 import Data.Text qualified as T
-import Data.Time (UTCTime, NominalDiffTime, formatTime, defaultTimeLocale, diffUTCTime)
+import Data.Time (LocalTime, NominalDiffTime, formatTime, defaultTimeLocale, diffLocalTime)
 import Data.Version (showVersion)
 import Graphics.Vty qualified as V
 import Paths_echidna qualified (version)
@@ -21,31 +25,41 @@ import Text.Printf (printf)
 import Text.Wrap
 
 import Echidna.ABI
-import Echidna.Campaign (isDone)
 import Echidna.Events (Events)
 import Echidna.Types.Campaign
+import Echidna.Types.Config
 import Echidna.Types.Test
 import Echidna.Types.Tx (Tx(..), TxResult(..))
 import Echidna.UI.Report
-import Echidna.Types.Config
-import Data.Map (Map)
+import Echidna.Utility (timePrefix)
+
 import EVM.Types (Addr, W256)
 import EVM (Contract)
-import Brick.Widgets.Dialog qualified as B
 
 data UIState = UIState
   { status :: UIStateStatus
-  , campaign :: FrozenCampaign
-  , timeStarted :: UTCTime
-  , now :: UTCTime
-
+  , campaigns :: [WorkerState]
+  , timeStarted :: LocalTime
+  , timeStopped :: Maybe LocalTime
+  , now :: LocalTime
   , fetchedContracts :: Map Addr (Maybe Contract)
   , fetchedSlots :: Map Addr (Map W256 (Maybe W256))
   , fetchedDialog :: B.Dialog ()
   , displayFetchedDialog :: Bool
+
+  , workerEvents :: Seq (Int, LocalTime, CampaignEvent)
+  , workersAlive :: Int
+
+  , corpusSize :: Int
+  , coverage :: Int
+  , numCodehashes :: Int
+  , lastNewCov :: LocalTime
+  -- ^ last timestamp of 'NewCoverage' event
+  --
+  , tests :: [EchidnaTest]
   }
 
-data UIStateStatus = Uninitialized | Running | Timedout | Crashed String
+data UIStateStatus = Uninitialized | Running
 
 attrs :: A.AttrMap
 attrs = A.attrMap (V.white `on` V.black)
@@ -57,6 +71,7 @@ attrs = A.attrMap (V.white `on` V.black)
   , (attrName "success", fg V.brightGreen)
   , (attrName "title", fg V.brightYellow `V.withStyle` V.bold)
   , (attrName "subtitle", fg V.brightCyan `V.withStyle` V.bold)
+  , (attrName "time", fg (V.rgbColor (0x70 :: Int) 0x70 0x70))
   ]
 
 bold :: Widget n -> Widget n
@@ -68,41 +83,41 @@ failure = withAttr (attrName "failure")
 success :: Widget n -> Widget n
 success = withAttr (attrName "success")
 
-data Name =
-  TestsViewPort
+data Name
+  = LogViewPort
+  | TestsViewPort
   | SBClick ClickableScrollbarElement Name
   deriving (Ord, Show, Eq)
 
 -- | Render 'Campaign' progress as a 'Widget'.
 campaignStatus :: MonadReader Env m => UIState -> m (Widget Name)
 campaignStatus uiState = do
-  done <- isDone uiState.campaign
-  case (uiState.status, done) of
-    (Uninitialized, _) ->
-      mainbox (padLeft (Pad 1) $ str "Starting up, please wait...") emptyWidget
-    (Crashed e, _) ->
-      mainbox (padLeft (Pad 1) $ failure $ strBreak $ formatCrashReport e) emptyWidget
-    (Timedout, _) -> do
-      tests <- testsWidget uiState.campaign.tests
-      mainbox tests (finalStatus "Timed out, C-c or esc to exit")
-    (_, True) -> do
-      tests <- testsWidget uiState.campaign.tests
-      mainbox tests (finalStatus "Campaign complete, C-c or esc to exit")
-    _ -> do
-      tests <- testsWidget uiState.campaign.tests
-      mainbox tests emptyWidget
+  tests <- testsWidget uiState.tests
+
+  if uiState.workersAlive == 0 then
+    mainbox tests (finalStatus "Campaign complete, C-c or esc to exit")
+  else
+    case uiState.status of
+      Uninitialized ->
+        mainbox (padLeft (Pad 1) $ str "Starting up, please wait...") emptyWidget
+      Running ->
+        mainbox tests emptyWidget
   where
-  mainbox inner underneath =
-    hCenter . hLimit 120 <$> wrapInner inner underneath
-  wrapInner inner underneath = do
-    chainId <- asks (.chainId)
-    pure $ joinBorders $ borderWithLabel echidnaTitle $
-      summaryWidget uiState chainId
+  mainbox inner underneath = do
+    env <- ask
+    pure $ hCenter . hLimit 120 $
+      joinBorders $ borderWithLabel echidnaTitle $
+      summaryWidget env uiState
       <=>
       hBorderWithLabel (withAttr (attrName "subtitle") $ str $
-        (" Tests (" <> show (length uiState.campaign.tests)) <> ") ")
+        (" Tests (" <> show (length uiState.tests)) <> ") ")
       <=>
       inner
+      <=>
+      hBorderWithLabel (withAttr (attrName "subtitle") $ str $
+        " Log (" <> show (length uiState.workerEvents) <> ") ")
+      <=>
+      logPane uiState
       <=>
       underneath
   echidnaTitle =
@@ -112,39 +127,57 @@ campaignStatus uiState = do
     str " ]"
   finalStatus s = hBorder <=> hCenter (bold $ str s)
 
-formatCrashReport :: String -> String
-formatCrashReport e =
-  "Echidna crashed with an error:\n\n" <>
-  e <>
-  "\n\nPlease report it to https://github.com/crytic/echidna/issues"
+logPane :: UIState -> Widget Name
+logPane uiState =
+  vLimitPercent 33 .
+  padLeft (Pad 1) $
+  withClickableVScrollBars SBClick .
+  withVScrollBars OnRight .
+  withVScrollBarHandles .
+  viewport LogViewPort Vertical $
+  foldl (<=>) emptyWidget (showLogLine <$> Seq.reverse uiState.workerEvents)
 
-summaryWidget :: UIState -> Maybe W256 -> Widget Name
-summaryWidget uiState chainId =
-  vLimit 3 $ -- limit to 3 rows
+showLogLine :: (Int, LocalTime, CampaignEvent) -> Widget Name
+showLogLine (workerId, time, event) =
+  (withAttr (attrName "time") $ str $ (timePrefix time) <> "[Worker " <> show workerId <> "] ")
+    <+> strBreak (ppCampaignEvent event)
+
+summaryWidget :: Env -> UIState -> Widget Name
+summaryWidget env uiState =
+  vLimit 5 $ -- limit to 5 rows
     hLimitPercent 33 leftSide <+> vBorder <+>
     hLimitPercent 50 middle <+> vBorder <+>
     rightSide
   where
   leftSide =
-    let c = uiState.campaign in
     padLeft (Pad 1) $
-      timeElapsedWidget uiState
+      (str ("Time elapsed: " <> timeElapsed uiState uiState.timeStarted) <+> fill ' ')
       <=>
-      str ("Seed: " <> show c.genDict.defSeed) <+> fill ' '
+      (str "Workers: " <+> outOf uiState.workersAlive (length uiState.campaigns))
+      <=>
+      str ("Seed: " ++ ppSeed uiState.campaigns)
+      <=>
+      perfWidget uiState
+      <=>
+      str ("Total calls: " <> progress (sum $ (.ncalls) <$> uiState.campaigns)
+                                     env.cfg.campaignConf.testLimit)
   middle =
-    let c = uiState.campaign in
     padLeft (Pad 1) $
-      str (ppFrozenCoverage c.coverage) <+> fill ' '
+      str ("Unique instructions: " <> show uiState.coverage)
       <=>
-      str (ppCorpus c.corpus)
+      str ("Unique codehashes: " <> show uiState.numCodehashes)
+      <=>
+      str ("Corpus size: " <> show uiState.corpusSize <> " seqs")
+      <=>
+      str ("New coverage: " <> timeElapsed uiState uiState.lastNewCov <> " ago") <+> fill ' '
   rightSide =
     padLeft (Pad 1) $
-      (rpcInfoWidget uiState.fetchedContracts uiState.fetchedSlots chainId)
+      (rpcInfoWidget uiState.fetchedContracts uiState.fetchedSlots env.chainId)
 
-timeElapsedWidget :: UIState -> Widget n
-timeElapsedWidget uiState =
-  str "Time elapsed: " <+>
-  str ((formatNominalDiffTime . diffUTCTime uiState.now) uiState.timeStarted)
+timeElapsed :: UIState -> LocalTime -> String
+timeElapsed uiState since =
+  formatNominalDiffTime $
+    diffLocalTime (fromMaybe uiState.now uiState.timeStopped) since
 
 formatNominalDiffTime :: NominalDiffTime -> String
 formatNominalDiffTime diff =
@@ -168,8 +201,27 @@ rpcInfoWidget contracts slots chainId =
   where
   countWidget fetches =
     let successful = filter isJust fetches
-        style = if length successful == length fetches then success else failure
-    in style . str $ show (length successful) <> "/" <> show (length fetches)
+    in outOf (length successful) (length fetches)
+
+outOf :: Int -> Int -> Widget n
+outOf n m =
+  let style = if n == m then success else failure
+  in style . str $ progress n m
+
+perfWidget :: UIState -> Widget n
+perfWidget uiState =
+  str $ "Calls/s: " <>
+    if totalTime > 0
+       then show $ div totalCalls totalTime
+       else "-"
+  where
+  totalCalls = (sum $ (.ncalls) <$> uiState.campaigns)
+  totalTime = round $
+    diffLocalTime (fromMaybe uiState.now uiState.timeStopped)
+                  uiState.timeStarted
+
+ppSeed :: [WorkerState] -> String
+ppSeed campaigns = show (head campaigns).genDict.defSeed
 
 fetchedDialogWidget :: UIState -> Widget n
 fetchedDialogWidget uiState =
@@ -189,7 +241,6 @@ fetchedDialogWidget uiState =
     padLeft (Pad 1) $ strBreak (show slot <> " => " <> show value)
   renderSlot slot Nothing =
     padLeft (Pad 1) $ failure $ str (show slot)
-
 
 failedFirst :: EchidnaTest -> EchidnaTest -> Ordering
 failedFirst t1 _ | didFail t1 = LT
@@ -228,12 +279,7 @@ tsWidget
 tsWidget (Failed e) _ = pure (str "could not evaluate", str $ show e)
 tsWidget Solved     t = failWidget Nothing t.reproducer t.events t.value t.result
 tsWidget Passed     _ = pure (success $ str "PASSED!", emptyWidget)
-tsWidget (Open i)   t = do
-  n <- asks (.cfg.campaignConf.testLimit)
-  if i >= n then
-    tsWidget Passed t
-  else
-    pure (withAttr (attrName "working") $ str $ "fuzzing " ++ progress i n, emptyWidget)
+tsWidget Open       _ = pure (success $ str "passing", emptyWidget)
 tsWidget (Large n)  t = do
   m <- asks (.cfg.campaignConf.shrinkLimit)
   failWidget (if n < m then Just (n,m) else Nothing) t.reproducer t.events t.value t.result
@@ -277,13 +323,8 @@ optWidget
 optWidget (Failed e) _ = pure (str "could not evaluate", str $ show e)
 optWidget Solved     _ = error "optimization tests cannot be solved"
 optWidget Passed     t = pure (str $ "max value found: " ++ show t.value, emptyWidget)
-optWidget (Open i)   t = do
-  n <- asks (.cfg.campaignConf.testLimit)
-  if i >= n then
-    optWidget Passed t
-  else
-    pure (withAttr (attrName "working") $ str $ "optimizing " ++ progress i n
-      ++ ", current max value: " ++ show t.value, emptyWidget)
+optWidget Open       t = do
+  pure (withAttr (attrName "working") $ str $ "optimizing, max value: " ++ show t.value, emptyWidget)
 optWidget (Large n)  t = do
   m <- asks (.cfg.campaignConf.shrinkLimit)
   maxWidget (if n < m then Just (n,m) else Nothing) t.reproducer t.events t.value

--- a/lib/Echidna/Utility.hs
+++ b/lib/Echidna/Utility.hs
@@ -2,27 +2,29 @@ module Echidna.Utility where
 
 import Control.Monad (unless)
 import Control.Monad.Catch (bracket)
-import Data.Time (diffUTCTime, getCurrentTime)
+import Data.Time (diffUTCTime, getCurrentTime, zonedTimeToLocalTime, LocalTime, getZonedTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
-import Data.Time.LocalTime (utcToLocalZonedTime)
 import System.Directory (getDirectoryContents, getCurrentDirectory, setCurrentDirectory)
 import System.IO (hFlush, stdout)
 
 measureIO :: Bool -> String -> IO b -> IO b
 measureIO quiet message action = do
   unless quiet $ do
-    time <- timePrefix
-    putStr (time <> message  <> "... ") >> hFlush stdout
+    prefix <- timePrefix <$> getTimestamp
+    putStr (prefix <> message  <> "... ") >> hFlush stdout
   t0 <- getCurrentTime
   ret <- action
   t1 <- getCurrentTime
   unless quiet $ putStrLn $ "Done! (" <> show (diffUTCTime t1 t0) <> ")"
   pure ret
 
-timePrefix :: IO String
-timePrefix = do
-  time <- utcToLocalZonedTime =<< getCurrentTime
-  pure $ "[" <> formatTime defaultTimeLocale "%F %T.%2q" time <> "] "
+getTimestamp :: IO LocalTime
+getTimestamp =
+  zonedTimeToLocalTime <$> getZonedTime
+
+timePrefix :: LocalTime -> String
+timePrefix time =
+  "[" <> formatTime defaultTimeLocale "%F %T.%2q" time <> "] "
 
 listDirectory :: FilePath -> IO [FilePath]
 listDirectory path = filter f <$> getDirectoryContents path

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -223,7 +223,7 @@ readFileIfExists path = do
 
 data Options = Options
   { cliFilePath         :: NE.NonEmpty FilePath
-  , cliJobs             :: Maybe Word8
+  , cliWorkers          :: Maybe Word8
   , cliSelectedContract :: Maybe Text
   , cliConfigFilepath   :: Maybe FilePath
   , cliOutputFormat     :: Maybe OutputFormat
@@ -251,7 +251,7 @@ options :: Parser Options
 options = Options
   <$> (NE.fromList <$> some (argument str (metavar "FILES"
     <> help "Solidity files to analyze")))
-  <*> optional (option auto $ long "jobs"
+  <*> optional (option auto $ long "workers"
     <> metavar "N"
     <> help "Number of workers to run")
   <*> optional (option str $ long "contract"
@@ -337,7 +337,7 @@ overrideConfig config Options{..} = do
       , shrinkLimit = fromMaybe campaignConf.shrinkLimit cliShrinkLimit
       , seqLen = fromMaybe campaignConf.seqLen cliSeqLen
       , seed = cliSeed <|> campaignConf.seed
-      , jobs = cliJobs <|> campaignConf.jobs
+      , workers = cliWorkers <|> campaignConf.workers
       }
 
     overrideSolConf solConf = solConf

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -17,7 +17,6 @@ module Common
   , getGas
   , gasInRange
   , countCorpus
-  , coverageEmpty
   , overrideQuiet
   ) where
 
@@ -27,7 +26,7 @@ import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCase, assertBool)
 
 import Control.Monad.Reader (runReaderT)
-import Control.Monad.Random (getRandom)
+import Control.Monad.Random (getRandomR)
 import Control.Monad.State.Strict (evalStateT)
 import Data.DoubleWord (Int256)
 import Data.Function ((&))
@@ -42,7 +41,7 @@ import System.Process (readProcess)
 
 import Echidna (prepareContract)
 import Echidna.Config (parseConfig, defaultConfig)
-import Echidna.Campaign (runCampaign)
+import Echidna.Campaign (runWorker)
 import Echidna.Solidity (loadSolTests, compileContracts, selectSourceCache)
 import Echidna.Test (checkETest)
 import Echidna.Types (Gas)
@@ -55,6 +54,8 @@ import Echidna.Types.Tx (Tx(..), TxCall(..), call)
 
 import EVM.Dapp (dappInfo, emptyDapp)
 import EVM.Solidity (SolcContract(..))
+import Control.Concurrent (newChan)
+import Control.Monad (forM_)
 
 testConfig :: EConfig
 testConfig = defaultConfig & overrideQuiet
@@ -89,35 +90,64 @@ withSolcVersion (Just f) t = do
     Right v' -> if f v' then t else assertBool "skip" True
     Left e   -> error $ show e
 
-runContract :: FilePath -> Maybe ContractName -> EConfig -> IO Campaign
+runContract :: FilePath -> Maybe ContractName -> EConfig -> IO (Env, WorkerState)
 runContract f selectedContract cfg = do
-  seed <- getRandom
+  seed <- maybe (getRandomR (0, maxBound)) pure cfg.campaignConf.seed
   (contracts, sourceCaches) <- compileContracts cfg.solConf (f :| [])
   let sourceCache = selectSourceCache selectedContract sourceCaches
   let solcByName = fromList [(c.contractName, c) | c <- contracts]
 
-  cacheMeta <- newIORef mempty
-  cacheContracts <- newIORef mempty
-  cacheSlots <- newIORef mempty
+  metadataCache <- newIORef mempty
+  fetchContractCache <- newIORef mempty
+  fetchSlotCache <- newIORef mempty
+  coverageRef <- newIORef mempty
+  corpusRef <- newIORef mempty
+  eventQueue <- newChan
+  testsRef <- newIORef mempty
   let env = Env { cfg = cfg
                 , dapp = dappInfo "/" solcByName sourceCache
-                , metadataCache = cacheMeta
-                , fetchContractCache = cacheContracts
-                , fetchSlotCache = cacheSlots
+                , metadataCache
+                , fetchContractCache
+                , fetchSlotCache
+                , coverageRef
+                , corpusRef
+                , eventQueue
+                , testsRef
                 , chainId = Nothing }
-  (vm, world, echidnaTests, dict) <- prepareContract env contracts (f :| []) selectedContract seed
-  let corpus = []
-  -- start ui and run tests
-  runReaderT (runCampaign (pure False) vm world echidnaTests dict corpus) env
+  (vm, world, dict) <- prepareContract env contracts (f :| []) selectedContract seed
 
-testContract :: FilePath -> Maybe FilePath -> [(String, Campaign -> Bool)] -> TestTree
+  let corpus = []
+  finalState <- flip runReaderT env $
+    runWorker (pure Nothing) vm world dict 0 corpus cfg.campaignConf.testLimit
+
+  -- TODO: consider snapshotting the state so checking function don't need to
+  -- be IO
+  pure (env, finalState)
+
+testContract
+  :: FilePath
+  -> Maybe FilePath
+  -> [(String, (Env, WorkerState) -> IO Bool)]
+  -> TestTree
 testContract fp cfg = testContract' fp Nothing Nothing cfg True
 
-testContractV :: FilePath -> Maybe SolcVersionComp -> Maybe FilePath -> [(String, Campaign -> Bool)] -> TestTree
+testContractV
+  :: FilePath
+  -> Maybe SolcVersionComp
+  -> Maybe FilePath
+  -> [(String, (Env, WorkerState) -> IO Bool)]
+  -> TestTree
 testContractV fp v cfg = testContract' fp Nothing v cfg True
 
-testContract' :: FilePath -> Maybe ContractName -> Maybe SolcVersionComp -> Maybe FilePath -> Bool -> [(String, Campaign -> Bool)] -> TestTree
-testContract' fp n v configPath s as = testCase fp $ withSolcVersion v $ do
+testContract'
+  :: FilePath
+  -> Maybe ContractName
+  -> Maybe SolcVersionComp
+  -> Maybe FilePath
+  -> Bool
+  -> [(String, (Env, WorkerState) -> IO Bool)]
+  -> TestTree
+testContract' fp n v configPath s expectations = testCase fp $ withSolcVersion v $ do
   c <- case configPath of
     Just path -> do
       parsed <- parseConfig path
@@ -125,19 +155,28 @@ testContract' fp n v configPath s as = testCase fp $ withSolcVersion v $ do
     Nothing -> pure testConfig
   let c' = c & overrideQuiet
              & (if s then overrideLimits else id)
-  res <- runContract fp n c'
-  mapM_ (\(t,f) -> assertBool t $ f res) as
+  result <- runContract fp n c'
+  forM_ expectations $ \(message, assertion) -> do
+    assertion result >>= assertBool message
 
 checkConstructorConditions :: FilePath -> String -> TestTree
 checkConstructorConditions fp as = testCase fp $ do
   cacheMeta <- newIORef mempty
   cacheContracts <- newIORef mempty
   cacheSlots <- newIORef mempty
+  coverageRef <- newIORef mempty
+  corpusRef <- newIORef mempty
+  testsRef <- newIORef mempty
+  eventQueue <- newChan
   let env = Env { cfg = testConfig
                 , dapp = emptyDapp
                 , metadataCache = cacheMeta
                 , fetchContractCache = cacheContracts
                 , fetchSlotCache = cacheSlots
+                , coverageRef
+                , corpusRef
+                , eventQueue
+                , testsRef
                 , chainId = Nothing }
   (v, _, t) <- loadSolTests env (fp :| []) Nothing
   r <- flip runReaderT env $
@@ -147,9 +186,9 @@ checkConstructorConditions fp as = testCase fp $ do
         forceBool _ = error "BoolValue expected"
 
 
-getResult :: Text -> Campaign -> Maybe EchidnaTest
-getResult n c =
-  case filter findTest c.tests of
+getResult :: Text -> [EchidnaTest] -> Maybe EchidnaTest
+getResult n tests =
+  case filter findTest tests of
     []  -> Nothing
     [x] -> Just x
     _   -> error "found more than one tests"
@@ -161,57 +200,68 @@ getResult n c =
                           OptimizationTest t _    -> t == n
                           _                       -> False
 
-optnFor :: Text -> Campaign -> Maybe TestValue
-optnFor n c = case getResult n c of
-  Just t -> Just t.value
-  _      -> Nothing
+optnFor :: Text -> (Env, WorkerState) -> IO (Maybe TestValue)
+optnFor n (env, _) = do
+  tests <- readIORef env.testsRef
+  pure $ case getResult n tests of
+    Just t -> Just t.value
+    _      -> Nothing
 
-optimized :: Text -> Int256 -> Campaign -> Bool
-optimized n v c = case optnFor n c of
-                   Just (IntValue o1) -> o1 >= v
-                   Nothing            -> error "nothing"
-                   _                  -> error "incompatible values"
+optimized :: Text -> Int256 -> (Env, WorkerState) -> IO Bool
+optimized n v final = do
+  x <- optnFor n final
+  pure $ case x of
+    Just (IntValue o1) -> o1 >= v
+    Nothing            -> error "nothing"
+    _                  -> error "incompatible values"
 
-solnFor :: Text -> Campaign -> Maybe [Tx]
-solnFor n c = case getResult n c of
-  Just t -> if null t.reproducer then Nothing else Just t.reproducer
-  _      -> Nothing
+solnFor :: Text -> (Env, WorkerState) -> IO (Maybe [Tx])
+solnFor n (env, _) = do
+  tests <- readIORef env.testsRef
+  pure $ case getResult n tests of
+    Just t -> if null t.reproducer then Nothing else Just t.reproducer
+    _      -> Nothing
 
-solved :: Text -> Campaign -> Bool
-solved t = isJust . solnFor t
+solved :: Text -> (Env, WorkerState) -> IO Bool
+solved t f = isJust <$> solnFor t f
 
-passed :: Text -> Campaign -> Bool
-passed n c = case getResult n c of
-  Just t | isPassed t -> True
-  Just t | isOpen t   -> True
-  Nothing             -> error ("no test was found with name: " ++ show n)
-  _                   -> False
+passed :: Text -> (Env, WorkerState) -> IO Bool
+passed n (env, _) = do
+  tests <- readIORef env.testsRef
+  pure $ case getResult n tests of
+    Just t | isPassed t -> True
+    Just t | isOpen t   -> True
+    Nothing             -> error ("no test was found with name: " ++ show n)
+    _                   -> False
 
-solvedLen :: Int -> Text -> Campaign -> Bool
-solvedLen i t = (== Just i) . fmap length . solnFor t
+solvedLen :: Int -> Text -> (Env, WorkerState) -> IO Bool
+solvedLen i t final = (== Just i) . fmap length <$> solnFor t final
 
-solvedUsing :: Text -> Text -> Campaign -> Bool
-solvedUsing f t = maybe False (any $ matchCall . (.call)) . solnFor t
-                 where matchCall (SolCall (f',_)) = f' == f
-                       matchCall _                = False
+solvedUsing :: Text -> Text -> (Env, WorkerState) -> IO Bool
+solvedUsing f t final =
+  maybe False (any $ matchCall . (.call)) <$> solnFor t final
+  where matchCall (SolCall (f',_)) = f' == f
+        matchCall _                = False
 
 -- NOTE: this just verifies a call was found in the solution. Doesn't care about ordering/seq length
-solvedWith :: TxCall -> Text -> Campaign -> Bool
-solvedWith tx t = maybe False (any $ (== tx) . (.call)) . solnFor t
+solvedWith :: TxCall -> Text -> (Env, WorkerState) -> IO Bool
+solvedWith tx t final =
+  maybe False (any $ (== tx) . (.call)) <$> solnFor t final
 
-solvedWithout :: TxCall -> Text -> Campaign -> Bool
-solvedWithout tx t = maybe False (all $ (/= tx) . (.call)) . solnFor t
+solvedWithout :: TxCall -> Text -> (Env, WorkerState) -> IO Bool
+solvedWithout tx t final =
+  maybe False (all $ (/= tx) . (.call)) <$> solnFor t final
 
-getGas :: Text -> Campaign -> Maybe (Gas, [Tx])
+getGas :: Text -> WorkerState -> Maybe (Gas, [Tx])
 getGas t camp = lookup t camp.gasInfo
 
-gasInRange :: Text -> Gas -> Gas -> Campaign -> Bool
-gasInRange t l h c = case getGas t c of
-  Just (g, _) -> g >= l && g <= h
-  _           -> False
+gasInRange :: Text -> Gas -> Gas -> (Env, WorkerState) -> IO Bool
+gasInRange t l h (_, workerState) = do
+  pure $ case getGas t workerState of
+    Just (g, _) -> g >= l && g <= h
+    _           -> False
 
-countCorpus :: Int -> Campaign -> Bool
-countCorpus n c = length c.corpus == n
-
-coverageEmpty :: Campaign -> Bool
-coverageEmpty c = null c.coverage
+countCorpus :: Int -> (Env, WorkerState) -> IO Bool
+countCorpus n (env, _) = do
+  corpus <- readIORef env.corpusRef
+  pure $ length corpus == n

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -117,8 +117,8 @@ runContract f selectedContract cfg = do
   (vm, world, dict) <- prepareContract env contracts (f :| []) selectedContract seed
 
   let corpus = []
-  finalState <- flip runReaderT env $
-    runWorker (pure Nothing) vm world dict 0 corpus cfg.campaignConf.testLimit
+  (_stopReason, finalState) <- flip runReaderT env $
+    runWorker (pure ()) vm world dict 0 corpus cfg.campaignConf.testLimit
 
   -- TODO: consider snapshotting the state so checking function don't need to
   -- be IO

--- a/src/test/Tests/Assertion.hs
+++ b/src/test/Tests/Assertion.hs
@@ -6,7 +6,7 @@ import Common (testContract, testContract', testContractV, solcV, solved, solved
 
 assertionTests :: TestTree
 assertionTests = testGroup "Assertion-based Integration Testing"
-  [ 
+  [
       testContractV "assert/assert.sol"  (Just (\v -> v < solcV (0,8,0)))  (Just "assert/config.yaml")
       [ ("direct_assert passed",           solved  "direct_assert")
       , ("internal_assert passed",         solved  "internal_assert")
@@ -18,7 +18,7 @@ assertionTests = testGroup "Assertion-based Integration Testing"
       , ("internal_assert failed",         solved "internal_assert")]
 
     , testContractV "assert/assert-0.8.sol" (Just (\v -> v >= solcV (0,8,0))) (Just "assert/config.yaml")
-      [ ("direct_assert passed", solved "direct_assert") ] 
+      [ ("direct_assert passed", solved "direct_assert") ]
 
     , testContract "assert/revert.sol"   (Just "assert/config.yaml")
       [ ("assert_revert passed",       solvedUsing "assert_revert" "AssertionFailed(..)")
@@ -36,7 +36,7 @@ assertionTests = testGroup "Assertion-based Integration Testing"
       ]
     , testContract' "assert/conf.sol" (Just "A") Nothing (Just "assert/multi.yaml") True
       [ ("c failed", passed "c") ]
- 
+
     , testContract' "assert/fullmath.sol" (Just "FullMathEchidnaTest") (Just (\v -> v == solcV (0,7,5))) (Just "assert/config.yaml") False
       [ ("checkMulDivRoundingUp failed", solved "checkMulDivRoundingUp") ]
 

--- a/src/test/Tests/Compile.hs
+++ b/src/test/Tests/Compile.hs
@@ -13,6 +13,7 @@ import Echidna.Solidity (loadSolTests)
 import Echidna.Types.Config (Env(..))
 import EVM.Dapp (emptyDapp)
 import Data.IORef (newIORef)
+import Control.Concurrent (newChan)
 
 compilationTests :: TestTree
 compilationTests = testGroup "Compilation and loading tests"
@@ -42,11 +43,19 @@ loadFails fp c e p = testCase fp . catch tryLoad $ assertBool e . p where
     cacheMeta <- newIORef mempty
     cacheContracts <- newIORef mempty
     cacheSlots <- newIORef mempty
+    eventQueue <- newChan
+    coverageRef <- newIORef mempty
+    corpusRef <- newIORef mempty
+    testsRef <- newIORef mempty
     let env = Env { cfg = testConfig
                   , dapp = emptyDapp
                   , metadataCache = cacheMeta
                   , fetchContractCache = cacheContracts
                   , fetchSlotCache = cacheSlots
                   , chainId = Nothing
+                  , eventQueue
+                  , coverageRef
+                  , corpusRef
+                  , testsRef
                   }
     void $ loadSolTests env (fp :| []) c

--- a/src/test/Tests/Seed.hs
+++ b/src/test/Tests/Seed.hs
@@ -5,8 +5,9 @@ import Test.Tasty.HUnit (testCase, assertBool)
 
 import Common (runContract, overrideQuiet)
 import Data.Function ((&))
+import Data.IORef (readIORef)
 import Echidna.Output.Source (CoverageFileType(..))
-import Echidna.Types.Config (EConfig(..))
+import Echidna.Types.Config (Env(..), EConfig(..))
 import Echidna.Types.Campaign
 import Echidna.Mutator.Corpus (defaultMutationConsts)
 import Echidna.Config (defaultConfig)
@@ -31,10 +32,11 @@ seedTests =
         , corpusDir = Nothing
         , mutConsts = defaultMutationConsts
         , coverageFormats = [Txt,Html,Lcov]
+        , jobs = Nothing
         }
       }
       & overrideQuiet
     gen s = do
-      camp <- runContract "basic/flags.sol" Nothing (cfg s)
-      pure camp.tests
+      (env, _) <- runContract "basic/flags.sol" Nothing (cfg s)
+      readIORef env.testsRef
     same s t = (==) <$> gen s <*> gen t

--- a/src/test/Tests/Seed.hs
+++ b/src/test/Tests/Seed.hs
@@ -32,7 +32,7 @@ seedTests =
         , corpusDir = Nothing
         , mutConsts = defaultMutationConsts
         , coverageFormats = [Txt,Html,Lcov]
-        , jobs = Nothing
+        , workers = Nothing
         }
       }
       & overrideQuiet

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -88,4 +88,4 @@ rpcUrl: null
 # block number to use when fetching over RPC
 rpcBlock: null
 # number of workers
-jobs: 1
+workers: 1

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -87,3 +87,5 @@ maxValue: 100000000000000000000 # 100 eth
 rpcUrl: null
 # block number to use when fetching over RPC
 rpcBlock: null
+# number of workers
+jobs: 1


### PR DESCRIPTION
To test, add `--workers N` to `echidna` command or `workers: N` to config.
This PR also adds `--timeout <seconds>` to CLI which was available only from the yaml config.

Notable code changes:
- `Campaign` type is now `WorkerState` with less data. Tests, coverage and corpus are now `IORef`s that live in `Env` and the data is shared between all workers. The contention on this data is minimal as modifications rarely happen besides the very beginning when coverage grows rapidly.
- There is a shared event queue that uses Chan. Workers push events when something interesting happens. Those events drive the UIs.
- UI module has been reworked to work with multiple workers that can stop at different times.
- Open tests don't count calls, it was the same for all open tests and was moved to WorkerState. The call number is now displayed at the top of TUI.
- The number of functions that use IO has grown because it's easier to grab data straight from Env. This is something that can be improved in the future.

Things to think about:
- ~At the moment, all workers replay the corpus but this is redundant work. Either split corpus across workers to replay or replay it first and then start workers. Consider calls to external contracts that might not be yet deployed. Relevant https://github.com/crytic/echidna/pull/1008~ Corpus is now chunked and distributed across workers to replay.
- There is a lot of contention while shrinking because all workers try to shrink. This can be improved by marking `Large` test with a `workerId` that falsified the test and only this worker shrinks the test.

Closes https://github.com/crytic/echidna/issues/476