### PR TITLE
Optimize coverage collection

### DIFF
--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -8,6 +8,7 @@ import Control.Monad (join)
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
 import Control.Monad.State.Strict (MonadState, gets, modify')
 import Data.Map (Map, toList)
+import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -24,8 +25,7 @@ import Echidna.Types.Buffer (forceBuf, forceLit)
 import Echidna.Types.Signature (SignatureMap, SolCall, ContractA, FunctionHash, MetadataCache, lookupBytecodeMetadata)
 import Echidna.Types.Tx
 import Echidna.Types.World (World(..))
-import Echidna.Types.Campaign (Campaign(..))
-import qualified Data.Map as Map
+import Echidna.Types.Campaign
 
 hasSelfdestructed :: VM -> Addr -> Bool
 hasSelfdestructed vm addr = addr `elem` vm._tx._substate._selfdestructs

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -6,7 +6,7 @@ import Data.Text (Text)
 import Echidna.ABI (GenDict, emptyDict)
 import Echidna.Types
 import Echidna.Types.Corpus
-import Echidna.Types.Coverage (CoverageMap)
+import Echidna.Types.Coverage (CoverageMap, FrozenCoverageMap)
 import Echidna.Types.Test (EchidnaTest)
 import Echidna.Types.Tx (Tx)
 
@@ -38,11 +38,14 @@ data CampaignConf = CampaignConf
     -- ^ Whether or not to generate a coverage report
   }
 
+type FrozenCampaign = GenericCampaign FrozenCoverageMap
+
+type Campaign = GenericCampaign CoverageMap
 -- | The state of a fuzzing campaign.
-data Campaign = Campaign
+data GenericCampaign a = Campaign
   { tests       :: ![EchidnaTest]
     -- ^ Tests being evaluated
-  , coverage    :: !CoverageMap
+  , coverage    :: !a
     -- ^ Coverage captured (NOTE: we don't always record this)
   , gasInfo     :: !(Map Text (Gas, [Tx]))
     -- ^ Worst case gas (NOTE: we don't always record this)
@@ -56,7 +59,7 @@ data Campaign = Campaign
     -- ^ Number of times the callseq is called
   }
 
-defaultCampaign :: Campaign
+defaultCampaign :: Monoid a => GenericCampaign a
 defaultCampaign = Campaign mempty mempty mempty emptyDict False mempty 0
 
 defaultTestLimit :: Int

--- a/lib/Echidna/Types/Coverage.hs
+++ b/lib/Echidna/Types/Coverage.hs
@@ -1,28 +1,53 @@
 module Echidna.Types.Coverage where
 
-import Control.Lens
+import Data.Bits (testBit)
 import Data.ByteString (ByteString)
+import Data.List (foldl')
+import Data.Map qualified as Map
 import Data.Map.Strict (Map)
-import Data.Set (Set, size, map)
+import Data.Vector.Unboxed qualified as VU
+import Data.Vector.Unboxed.Mutable (IOVector)
+import Data.Vector.Unboxed.Mutable qualified as V
+import Data.Word (Word64)
 
 import Echidna.Types.Tx (TxResult)
 
--- Program Counter directly obtained from the EVM
-type PC = Int
--- Index per operation in the source code, obtained from the source mapping
-type OpIx = Int
--- Stack size from the EVM
-type FrameCount = Int
--- Basic coverage information
-type CoverageInfo = (PC, OpIx, FrameCount, TxResult)
--- Map with the coverage information needed for fuzzing and source code printing
-type CoverageMap = Map ByteString (Set CoverageInfo)
+-- | Map with the coverage information needed for fuzzing and source code printing
+type CoverageMap = Map ByteString (IOVector CoverageInfo)
 
--- | Given good point coverage, count unique points.
-coveragePoints :: CoverageMap -> Int
-coveragePoints = sum . fmap size
+-- | Immutable CoverageMap used to pass into pure functions
+type FrozenCoverageMap = Map ByteString (VU.Vector CoverageInfo)
+
+-- | Basic coverage information
+type CoverageInfo = (OpIx, StackDepths, TxResults)
+
+-- | Index per operation in the source code, obtained from the source mapping
+type OpIx = Int
+
+-- | Packed call stack depths from the EVM, corresponding bits are set
+type StackDepths = Word64
+
+-- | Packed TxResults used for coverage, corresponding bits are set
+type TxResults = Word64
+
 -- | Given good point coverage, count the number of unique points but
 -- only considering the different instruction PCs (discarding the TxResult).
 -- This is useful to report a coverage measure to the user
-scoveragePoints :: CoverageMap -> Int
-scoveragePoints = sum . fmap (size . Data.Set.map (view _1))
+scoveragePoints :: CoverageMap -> IO Int
+scoveragePoints cm = do
+  sum <$> mapM (V.foldl' countCovered 0) (Map.elems cm)
+
+scoveragePointsFrozen :: FrozenCoverageMap -> Int
+scoveragePointsFrozen cm =
+  sum $ VU.foldl' countCovered 0 <$> Map.elems cm
+
+countCovered :: Int -> CoverageInfo -> Int
+countCovered acc (opIx,_,_) = if opIx == -1 then acc else acc + 1
+
+unpackTxResults :: TxResults -> [TxResult]
+unpackTxResults txResults =
+  foldl' (\results bit ->
+    if txResults `testBit` bit
+      then toEnum bit : results
+      else results
+  ) [] [0..63]

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -182,7 +182,7 @@ data TxResult
   | ErrorFFI
   | ErrorNonceOverflow
   | ErrorReturnDataOutOfBounds
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Enum)
 $(deriveJSON defaultOptions ''TxResult)
 
 data TxConf = TxConf

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -34,7 +34,7 @@ import Data.Function ((&))
 import Data.IORef
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.List.Split (splitOn)
-import Data.Map (fromList, lookup, empty)
+import Data.Map (fromList, lookup)
 import Data.Maybe (isJust)
 import Data.Text (Text, pack)
 import Data.SemVer (Version, version, fromText)
@@ -47,7 +47,7 @@ import Echidna.Solidity (loadSolTests, compileContracts, selectSourceCache)
 import Echidna.Test (checkETest)
 import Echidna.Types (Gas)
 import Echidna.Types.Config (Env(..), EConfig(..), EConfigWithUsage(..))
-import Echidna.Types.Campaign (Campaign(..), CampaignConf(..))
+import Echidna.Types.Campaign
 import Echidna.Types.Signature (ContractName)
 import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Test
@@ -214,4 +214,4 @@ countCorpus :: Int -> Campaign -> Bool
 countCorpus n c = length c.corpus == n
 
 coverageEmpty :: Campaign -> Bool
-coverageEmpty c = c.coverage == empty
+coverageEmpty c = null c.coverage

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -1,7 +1,7 @@
 module Tests.Config (configTests) where
 
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase, assertBool, (@?=), assertFailure)
+import Test.Tasty.HUnit (testCase, assertBool, assertFailure)
 
 import Control.Lens (sans)
 import Control.Monad (void)
@@ -12,15 +12,16 @@ import Echidna.Types.Config (EConfigWithUsage(..), EConfig(..))
 import Echidna.Types.Campaign (CampaignConf(..))
 import Echidna.Types.Tx (TxConf(..))
 import Echidna.Config (defaultConfig, parseConfig)
+import Data.Maybe (isJust)
 
 configTests :: TestTree
 configTests = testGroup "Configuration tests" $
   [ testCase file . void $ parseConfig file | file <- files ] ++
   [ testCase "parse \"coverage: true\"" $ do
       config <- (.econfig) <$> parseConfig "coverage/test.yaml"
-      assertCoverage config $ Just mempty
+      assertBool "" $ isJust config.campaignConf.knownCoverage
   , testCase "coverage enabled by default" $
-      assertCoverage defaultConfig $ Just mempty
+      assertBool "" $ isJust defaultConfig.campaignConf.knownCoverage
   , testCase "default.yaml" $ do
       EConfigWithUsage _ bad unset <- parseConfig "basic/default.yaml"
       assertBool ("unused options: " ++ show bad) $ null bad
@@ -38,4 +39,3 @@ configTests = testGroup "Configuration tests" $
         Left _ -> pure ()
   ]
   where files = ["basic/config.yaml", "basic/default.yaml"]
-        assertCoverage config value = config.campaignConf.knownCoverage @?= value

--- a/src/test/Tests/Coverage.hs
+++ b/src/test/Tests/Coverage.hs
@@ -6,7 +6,7 @@ import Common (testContract, passed, countCorpus)
 
 coverageTests :: TestTree
 coverageTests = testGroup "Coverage tests"
-  [ 
+  [
       -- single.sol is really slow and kind of unstable. it also messes up travis.
      -- testContract "coverage/single.sol"    (Just "coverage/test.yaml")
      -- [ ("echidna_state failed",                   solved      "echidna_state") ]
@@ -14,6 +14,6 @@ coverageTests = testGroup "Coverage tests"
      -- [ ("echidna_state3 failed",                  solved      "echidna_state3") ]
       testContract "coverage/boolean.sol"       (Just "coverage/boolean.yaml")
       [ ("echidna_true failed",                    passed     "echidna_true")
-      , ("unexpected corpus count ",               countCorpus 4)]
+      , ("unexpected corpus count ",               countCorpus 1)]
 
   ]

--- a/src/test/Tests/Seed.hs
+++ b/src/test/Tests/Seed.hs
@@ -6,7 +6,7 @@ import Test.Tasty.HUnit (testCase, assertBool)
 import Common (runContract, overrideQuiet)
 import Data.Function ((&))
 import Echidna.Types.Config (EConfig(..))
-import Echidna.Types.Campaign (Campaign(..), CampaignConf(..))
+import Echidna.Types.Campaign
 import Echidna.Mutator.Corpus (defaultMutationConsts)
 import Echidna.Config (defaultConfig)
 

--- a/tests/solidity/coverage/boolean.yaml
+++ b/tests/solidity/coverage/boolean.yaml
@@ -1,3 +1,3 @@
 coverage: true
-seqLen: 1
+seqLen: 10
 testLimit: 5000


### PR DESCRIPTION
This changes coverage collection to mutable vectors instead of sets. This change yields a huge performance boost in fuzzing speed (~4x) and cuts the memory usage by half.