### PR TITLE
Save corpus continuously while fuzzing

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -242,7 +242,7 @@ callseq vm txSeq = do
 
     cov <- liftIO . readIORef =<< asks (.coverageRef)
     points <- liftIO $ scoveragePoints cov
-    pushEvent (NewCoverage points (length cov) newSize)
+    pushEvent (NewCoverage points (length cov) newSize (fst <$> res))
 
   -- Update the campaign state
   put campaign'

--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -1,13 +1,18 @@
 module Echidna.Output.Corpus where
 
+import Control.Concurrent (forkFinally, Chan, dupChan, newChan, readChan, writeChan)
+import Control.Monad (unless, void, when)
 import Control.Monad.Extra (unlessM)
 import Data.Aeson (ToJSON(..), decodeStrict, encodeFile)
 import Data.ByteString qualified as BS
 import Data.Hashable (hash)
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, fromMaybe)
 import System.Directory (createDirectoryIfMissing, makeRelativeToCurrentDirectory, doesFileExist)
 import System.FilePath ((</>), (<.>))
 
+import Echidna.Types.Campaign (CampaignEvent(..), CampaignConf(..))
+import Echidna.Types.Config (Env(..), EConfig(..))
+import Echidna.Types.Test (EchidnaTest(..))
 import Echidna.Types.Tx (Tx)
 import Echidna.Utility (listDirectory, withCurrentDirectory)
 
@@ -26,3 +31,33 @@ loadTxs dir = do
   putStrLn ("Loaded " ++ show (length txSeqs) ++ " transaction sequences from " ++ dir)
   pure txSeqs
   where readCall f = decodeStrict <$> BS.readFile f
+
+-- save to corpus in the background while tests are running
+-- returns a channel that gets sent () when the process is done
+runCorpusSaver :: Env -> IO (Chan ())
+runCorpusSaver env = do
+  finishChan <- newChan
+  case env.cfg.campaignConf.corpusDir of
+    Nothing -> writeChan finishChan ()
+    Just dir -> do
+      -- we want to dupChan *before* forking so we don't miss any events
+      chan <- dupChan env.eventQueue
+      void $ forkFinally (loop dir chan nworkers) (const $ writeChan finishChan ())
+  pure finishChan
+  where
+    nworkers :: Int
+    nworkers = fromIntegral $ fromMaybe 1 env.cfg.campaignConf.workers
+
+    loop !dir !chan !workersAlive = when (workersAlive > 0) $ do
+      (_, _, event) <- readChan chan
+      saveEvent dir event
+      case event of
+        WorkerStopped _ -> loop dir chan (workersAlive - 1)
+        _               -> loop dir chan workersAlive
+
+    saveEvent dir (TestFalsified test) = saveFile dir "reproducers" test.reproducer
+    saveEvent dir (TestOptimized test) = saveFile dir "reproducers" test.reproducer
+    saveEvent dir (NewCoverage _ _ _ txs) = saveFile dir "coverage" txs
+    saveEvent _ _ = pure ()
+
+    saveFile dir subdir txs = unless (null txs) $ saveTxs (dir </> subdir) [txs]

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -44,7 +44,7 @@ data CampaignConf = CampaignConf
 data CampaignEvent
   = TestFalsified !EchidnaTest
   | TestOptimized !EchidnaTest
-  | NewCoverage !Int !Int !Int
+  | NewCoverage !Int !Int !Int [Tx]
   | TxSequenceReplayed !Int !Int
   | WorkerStopped WorkerStopReason
   -- ^ This is a terminal event. Worker exits and won't push any events after
@@ -71,7 +71,7 @@ ppCampaignEvent = \case
   TestOptimized test ->
     let name = case test.testType of OptimizationTest n _ -> n; _ -> error "fixme"
     in "New maximum value of " <> T.unpack name <> ": " <> show test.value
-  NewCoverage points codehashes corpus ->
+  NewCoverage points codehashes corpus _ ->
     "New coverage: " <> show points <> " instr, "
       <> show codehashes <> " contracts, "
       <> show corpus <> " seqs in corpus"

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -283,7 +283,7 @@ monitor = do
         modify' $ \state -> state { workerEvents = state.workerEvents |> event }
 
         case campaignEvent of
-          NewCoverage coverage numCodehashes size ->
+          NewCoverage coverage numCodehashes size _ ->
             modify' $ \state ->
               state { coverage = max state.coverage coverage -- max not really needed
                     , corpusSize = size


### PR DESCRIPTION
This PR adds a process which continuously saves corpus as new coverage/reproducers are discovered (#1045). This makes echidna crashes less inconvenient, and shortens the corpus saving time at the end.
It also makes the NewCoverage event include the list of transactions as part of the event, since this is needed when saving corpus info.