### PR TITLE
Fix revert display on coverage reports

### DIFF
--- a/lib/Echidna/Output/Source.hs
+++ b/lib/Echidna/Output/Source.hs
@@ -173,9 +173,14 @@ srcMapCov sc covMap contracts = do
               case srcMapCodePos sc srcMap of
                 Just (file, line) ->
                   Map.alter
-                    (Just . Map.insert line (unpackTxResults txResults) . fromMaybe mempty)
+                    (Just . innerUpdate . fromMaybe mempty)
                     file
                     acc
+                  where
+                  innerUpdate =
+                    Map.alter
+                      (Just . (<> unpackTxResults txResults) . fromMaybe mempty)
+                      line
                 Nothing -> acc
             Nothing -> acc
         ) mempty vec


### PR DESCRIPTION
We were overwriting reverts (or any other markers in general) if there was another op on the same line without a revert after. This PR fixes this issue.