### PR TITLE
Use contract address as keys for coverageMap

### DIFF
--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -11,9 +11,6 @@ import Data.Map qualified as Map
 import Data.Text
 import Data.Text.Encoding (decodeUtf8)
 import Data.Vector.Unboxed qualified as VU
-import Numeric (showHex)
-
-import EVM.Types (keccak')
 
 import Echidna.ABI (ppAbiValue, GenDict(..))
 import Echidna.Events (Events)
@@ -109,7 +106,7 @@ encodeCampaign env workerStates = do
     , _error = Nothing
     , _tests = mapTest <$> tests
     , seed = worker0.genDict.defSeed
-    , coverage = Map.mapKeys (("0x" ++) . (`showHex` "") . keccak') $ VU.toList <$> frozenCov
+    , coverage = Map.mapKeys show $ VU.toList <$> frozenCov
     , gasInfo = Map.toList $ Map.unionsWith max ((.gasInfo) <$> workerStates)
     }
 

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -39,6 +39,7 @@ data CampaignConf = CampaignConf
   , coverageFormats :: [CoverageFileType]
     -- ^ List of file formats to save coverage reports
   , workers         :: Maybe Word8
+    -- ^ Number of workers to use for parallel execution
   }
 
 data CampaignEvent

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -20,6 +20,7 @@ import Echidna.Types.Signature (MetadataCache)
 import Echidna.Types.Solidity (SolConf)
 import Echidna.Types.Test (TestConf, EchidnaTest)
 import Echidna.Types.Tx (TxConf)
+import Data.ByteString (ByteString)
 
 data OperationMode = Interactive | NonInteractive OutputFormat deriving (Show, Eq)
 data OutputFormat = Text | JSON | None deriving (Show, Eq)
@@ -71,6 +72,7 @@ data Env = Env
   , testsRef :: IORef [EchidnaTest]
   , coverageRef :: IORef CoverageMap
   , corpusRef :: IORef Corpus
+  , bytecodesRef :: IORef (Map Addr ByteString)
 
   , metadataCache :: IORef MetadataCache
   , fetchContractCache :: IORef (Map Addr (Maybe Contract))

--- a/lib/Echidna/Types/Coverage.hs
+++ b/lib/Echidna/Types/Coverage.hs
@@ -1,7 +1,6 @@
 module Echidna.Types.Coverage where
 
 import Data.Bits (testBit)
-import Data.ByteString (ByteString)
 import Data.List (foldl')
 import Data.Map qualified as Map
 import Data.Map.Strict (Map)
@@ -10,9 +9,10 @@ import Data.Vector.Unboxed.Mutable qualified as V
 import Data.Word (Word64)
 
 import Echidna.Types.Tx (TxResult)
+import EVM.Types (Addr)
 
 -- | Map with the coverage information needed for fuzzing and source code printing
-type CoverageMap = Map ByteString (IOVector CoverageInfo)
+type CoverageMap = Map Addr (IOVector CoverageInfo)
 
 -- | Basic coverage information
 type CoverageInfo = (OpIx, StackDepths, TxResults)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -96,6 +96,7 @@ main = withUtf8 $ withCP65001 $ do
   coverageRef <- newIORef mempty
   corpusRef <- newIORef mempty
   testsRef <- newIORef mempty
+  bytecodesRef <- newIORef mempty
 
   let
     sourceCache = selectSourceCache cliSelectedContract sourceCaches
@@ -111,6 +112,7 @@ main = withUtf8 $ withCP65001 $ do
               , coverageRef
               , corpusRef
               , testsRef
+              , bytecodesRef
               }
 
   -- take the seed from config, otherwise generate a new one
@@ -158,6 +160,7 @@ main = withUtf8 $ withCP65001 $ do
         runId <- fromIntegral . systemSeconds <$> getSystemTime
 
         coverage <- readIORef coverageRef
+        bytecodes <- readIORef bytecodesRef
 
         -- coverage reports for external contracts, we only support
         -- Ethereum Mainnet for now
@@ -169,12 +172,12 @@ main = withUtf8 $ withCP65001 $ do
                 case r of
                   Just (externalSourceCache, solcContract) -> do
                     let dir' = dir </> show addr
-                    saveCoverages cfg.campaignConf.coverageFormats runId dir' externalSourceCache [solcContract] coverage
+                    saveCoverages cfg.campaignConf.coverageFormats runId dir' externalSourceCache [solcContract] coverage bytecodes
                   Nothing -> pure ()
               Nothing -> pure ()
 
         -- save source coverage reports
-        saveCoverages cfg.campaignConf.coverageFormats runId dir sourceCache contracts coverage
+        saveCoverages cfg.campaignConf.coverageFormats runId dir sourceCache contracts coverage bytecodes
 
   if isSuccessful tests then exitSuccess else exitWith (ExitFailure 1)
 

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -104,6 +104,7 @@ runContract f selectedContract cfg = do
   corpusRef <- newIORef mempty
   eventQueue <- newChan
   testsRef <- newIORef mempty
+  bytecodesRef <- newIORef mempty
   let env = Env { cfg = cfg
                 , dapp = dappInfo "/" solcByName sourceCache
                 , metadataCache
@@ -113,6 +114,7 @@ runContract f selectedContract cfg = do
                 , corpusRef
                 , eventQueue
                 , testsRef
+                , bytecodesRef
                 , chainId = Nothing }
   (vm, world, dict) <- prepareContract env contracts (f :| []) selectedContract seed
 
@@ -167,6 +169,7 @@ checkConstructorConditions fp as = testCase fp $ do
   coverageRef <- newIORef mempty
   corpusRef <- newIORef mempty
   testsRef <- newIORef mempty
+  bytecodesRef <- newIORef mempty
   eventQueue <- newChan
   let env = Env { cfg = testConfig
                 , dapp = emptyDapp
@@ -175,6 +178,7 @@ checkConstructorConditions fp as = testCase fp $ do
                 , fetchSlotCache = cacheSlots
                 , coverageRef
                 , corpusRef
+                , bytecodesRef
                 , eventQueue
                 , testsRef
                 , chainId = Nothing }


### PR DESCRIPTION
Adapts the commit from arcz/no-bememo. N.B. tests do not cover changes to coverage maps