### PR TITLE
Allow to provide a directory with additional json files from slither printer

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -48,12 +48,15 @@ prepareContract
   -> IO (VM, World, GenDict)
 prepareContract env contracts solFiles specifiedContract seed = do
   let solConf = env.cfg.solConf
+  let campaignConf = env.cfg.campaignConf
 
   -- compile and load contracts
   (vm, funs, testNames, signatureMap) <- loadSpecified env specifiedContract contracts
 
   -- run processors
-  slitherInfo <- runSlither (NE.head solFiles) solConf
+  mainSlitherInfo <- runSlither (NE.head solFiles) solConf
+  complementarySlitherInfo <- loadSlitherInfos campaignConf
+  let slitherInfo = appendSlitherInfo mainSlitherInfo complementarySlitherInfo
   case find (< minSupportedSolcVersion) slitherInfo.solcVersions of
     Just version | detectVyperVersion version -> pure ()
     Just version                              -> throwM $ OutdatedSolcVersion version

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -93,6 +93,7 @@ instance FromJSON EConfigWithUsage where
         <*> v ..:? "seed"
         <*> v ..:? "dictFreq" ..!= 0.40
         <*> v ..:? "corpusDir" ..!= Nothing
+        <*> v ..:? "slitherInfoDir" ..!= Nothing
         <*> v ..:? "mutConsts" ..!= defaultMutationConsts
         <*> v ..:? "coverageFormats" ..!= [Txt,Html,Lcov]
         <*> v ..:? "workers"

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -34,6 +34,8 @@ data CampaignConf = CampaignConf
     -- ^ Frequency for the use of dictionary values in the random transactions
   , corpusDir       :: Maybe FilePath
     -- ^ Directory to load and save lists of transactions
+  , slitherInfoDir  :: Maybe FilePath
+    -- ^ Directory to load additional slither info files
   , mutConsts       :: MutationConsts Integer
     -- ^ Directory to load and save lists of transactions
   , coverageFormats :: [CoverageFileType]


### PR DESCRIPTION
This PR allows user to specify a new command line `slitherInfoDir` to load as many external json from `slither --print echidna` as required. This allow users to load their own list of constants or allow external contracts (e.g. from etherscan) to be analyzed before starting a campaign. All the information will be merged.