### PR TITLE
docker: make container multi-platform

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,8 +14,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -63,7 +63,7 @@ jobs:
       - name: Docker Build and Push (Ubuntu & NVM variant)
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           target: final-ubuntu
           file: docker/Dockerfile
           pull: true
@@ -77,7 +77,7 @@ jobs:
         uses: docker/build-push-action@v5
         if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           target: final-distroless
           file: docker/Dockerfile
           pull: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,42 @@
-FROM ubuntu:focal AS builder-echidna
+FROM alpine:3.18 AS builder-echidna
 ENV LD_LIBRARY_PATH=/usr/local/lib PREFIX=/usr/local HOST_OS=Linux
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
+RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk add --no-cache \
+        autoconf \
+        automake \
+        bash \
+        build-base \
+        bzip2-dev \
+        cabal \
         cmake \
         curl \
+        ghc \
         git \
-        libbz2-dev \
-        libgmp-dev \
-        libreadline-dev \
-        libsecp256k1-dev \
-        libssl-dev \
-        software-properties-common \
-        sudo
-RUN curl -sSL https://get.haskellstack.org/ | sh
-COPY . /echidna/
+        gmp-dev \
+        libtool \
+        ncurses-static \
+        openssl-dev \
+        readline-dev \
+        stack@testing \
+        sudo \
+        zlib-dev \
+        zlib-static
+
 WORKDIR /echidna
-RUN .github/scripts/install-libff.sh
-RUN stack upgrade && stack setup && stack install --flag echidna:static --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
+
+COPY .github/scripts /echidna/.github/scripts/
+RUN .github/scripts/install-libsecp256k1.sh && \
+    .github/scripts/install-libff.sh
+
+COPY . /echidna/
+RUN mkdir -p /etc/stack &&\
+    { cat /root/.stack/config.yaml ;\
+      echo "system-ghc: true" ;\
+      echo "install-ghc: false" ;\
+      echo "skip-ghc-check: true" ;\
+    } >> /etc/stack/config.yaml &&\
+    chmod 664 /etc/stack/config.yaml
+RUN stack install --flag echidna:static --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
 
 
 FROM ubuntu:focal AS builder-python3


### PR DESCRIPTION
This enables aarch64 builds for our Docker container image. These can then be used on e.g. M1 Macs to get good performance. It also makes the echidna binary static with musl -- previously it was static with glibc, which might be problematic as shown on #962 if the binary is re-used outside this container (I believe using it inside the container should not cause issues as the glibc version matches between binary and runtime environment)

Caveat: The container is built on an x86 runner using emulation, so the build is somewhat slow (~4h total build time).