### PR TITLE
fix: do not fail if slither fails

### DIFF
--- a/lib/Echidna/Processor.hs
+++ b/lib/Echidna/Processor.hs
@@ -130,7 +130,7 @@ runSlither fp solConf = do
       ProcessorNotFound "slither" "You should install it using 'pip3 install slither-analyzer --user'"
     Just path -> pure path
 
-  let args = ["--ignore-compile", "--print", "echidna", "--json", "-"]
+  let args = ["--ignore-compile", "--print", "echidna", "--json", "--no-fail", "-"]
              ++ solConf.cryticArgs ++ [fp]
   (ec, out, err) <- measureIO solConf.quiet ("Running slither on " <> fp) $
     readCreateProcessWithExitCode (proc path args) {std_err = Inherit} ""

--- a/lib/Echidna/Processor.hs
+++ b/lib/Echidna/Processor.hs
@@ -130,7 +130,7 @@ runSlither fp solConf = do
       ProcessorNotFound "slither" "You should install it using 'pip3 install slither-analyzer --user'"
     Just path -> pure path
 
-  let args = ["--ignore-compile", "--print", "echidna", "--json", "--no-fail", "-"]
+  let args = ["--ignore-compile", "--print", "echidna", "--json", "-", "--no-fail"]
              ++ solConf.cryticArgs ++ [fp]
   (ec, out, err) <- measureIO solConf.quiet ("Running slither on " <> fp) $
     readCreateProcessWithExitCode (proc path args) {std_err = Inherit} ""


### PR DESCRIPTION
Pass `--no-fail` to slither to avoid erroring out. This requires at least Slither 0.9.2 https://github.com/crytic/slither/commit/53238600a1ad3b119b26d752460dcfeea75dd20c

This is probably not the robust approach. I would prefer if we did not make running Slither a requirement to run Echidna. We should **only run it if it's installed** (log a warning "install slither for improved ...") and **not rely on Slither succeeding** i.e. continue fuzzing campaign if it fails