### PR TITLE
Save corpus and reproducers continuously

### DIFF
--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -1,20 +1,28 @@
 module Echidna.Output.Corpus where
 
+import Control.Exception (IOException, handle)
+import Control.Monad (unless)
 import Control.Monad.Extra (unlessM)
 import Data.Aeson (ToJSON(..), decodeStrict, encodeFile)
 import Data.ByteString qualified as BS
 import Data.Hashable (hash)
 import Data.Maybe (catMaybes)
+import Data.Time (LocalTime)
 import System.Directory (createDirectoryIfMissing, makeRelativeToCurrentDirectory, doesFileExist)
 import System.FilePath ((</>), (<.>))
 
+import Echidna.Campaign (pushCampaignEvent)
+import Echidna.Types.Config
+import Echidna.Types.Campaign
+import Echidna.Types.Test (EchidnaTest(..))
 import Echidna.Types.Tx (Tx)
 import Echidna.Utility (listDirectory, withCurrentDirectory)
 
 saveTxs :: FilePath -> [[Tx]] -> IO ()
 saveTxs dir = mapM_ saveTxSeq where
   saveTxSeq txSeq = do
-    let file = dir </> (show . hash . show) txSeq <.> "txt"
+    createDirectoryIfMissing True dir
+    let file = dir </> (show . abs . hash . show) txSeq <.> "txt"
     unlessM (doesFileExist file) $ encodeFile file (toJSON txSeq)
 
 loadTxs :: FilePath -> IO [[Tx]]
@@ -26,3 +34,31 @@ loadTxs dir = do
   putStrLn ("Loaded " ++ show (length txSeqs) ++ " transaction sequences from " ++ dir)
   pure txSeqs
   where readCall f = decodeStrict <$> BS.readFile f
+
+-- Save corpus/reproducers transactions based on an event
+saveCorpusEvent :: Env -> (LocalTime, CampaignEvent) -> IO ()
+saveCorpusEvent env (_time, campaignEvent) = do
+  case env.cfg.campaignConf.corpusDir of
+    Just corpusDir -> saveEvent corpusDir campaignEvent
+    Nothing -> pure ()
+  where
+    saveEvent dir (WorkerEvent _workerId event) =
+      maybe (pure ()) (saveFile dir) $ getEventInfo event
+    saveEvent _ _ = pure ()
+
+    getEventInfo = \case
+      -- TODO: We save intermediate reproducers in separate directories.
+      -- This is to because there can be a lot of them and we want to skip
+      -- loading those on startup. Ideally, we should override the same file
+      -- with a better version of a reproducer, this is smaller or more optimized.
+      TestFalsified test -> Just ("reproducers-unshrunk", test.reproducer)
+      TestOptimized test -> Just ("reproducers-optimizations", test.reproducer)
+      NewCoverage { transactions } -> Just ("coverage", transactions)
+      _ -> Nothing
+
+    saveFile dir (subdir, txs) =
+      unless (null txs) $
+        handle exceptionHandler $ saveTxs (dir </> subdir) [txs]
+
+    exceptionHandler (e :: IOException) =
+      pushCampaignEvent env (Failure $ "Problem while writing to file: " ++ show e)

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -65,7 +65,7 @@ data Env = Env
 
   -- | Shared between all workers. Events are fairly rare so contention is
   -- minimal.
-  , eventQueue :: Chan (Int, LocalTime, CampaignEvent)
+  , eventQueue :: Chan (LocalTime, CampaignEvent)
 
   , testsRef :: IORef [EchidnaTest]
   , coverageRef :: IORef CoverageMap

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -25,9 +25,11 @@ import Echidna.Utility (timePrefix)
 import EVM.Format (showTraceTree)
 import EVM.Types (W256, VM)
 
-ppLogLine :: (Int, LocalTime, CampaignEvent) -> String
-ppLogLine (workerId, time, event) =
+ppLogLine :: (LocalTime, CampaignEvent) -> String
+ppLogLine (time, event@(WorkerEvent workerId _)) =
   timePrefix time <> "[Worker " <> show workerId <> "] " <> ppCampaignEvent event
+ppLogLine (time, event) =
+  timePrefix time <> " " <> ppCampaignEvent event
 
 ppCampaign :: (MonadIO m, MonadReader Env m) => [WorkerState] -> m String
 ppCampaign workerStates = do

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -49,7 +49,7 @@ data UIState = UIState
   , fetchedDialog :: B.Dialog () Name
   , displayFetchedDialog :: Bool
 
-  , workerEvents :: Seq (Int, LocalTime, CampaignEvent)
+  , events :: Seq (LocalTime, CampaignEvent)
   , workersAlive :: Int
 
   , corpusSize :: Int
@@ -117,7 +117,7 @@ campaignStatus uiState = do
       inner
       <=>
       hBorderWithLabel (withAttr (attrName "subtitle") $ str $
-        " Log (" <> show (length uiState.workerEvents) <> ") ")
+        " Log (" <> show (length uiState.events) <> ") ")
       <=>
       logPane uiState
       <=>
@@ -137,12 +137,14 @@ logPane uiState =
   withVScrollBars OnRight .
   withVScrollBarHandles .
   viewport LogViewPort Vertical $
-  foldl (<=>) emptyWidget (showLogLine <$> Seq.reverse uiState.workerEvents)
+  foldl (<=>) emptyWidget (showLogLine <$> Seq.reverse uiState.events)
 
-showLogLine :: (Int, LocalTime, CampaignEvent) -> Widget Name
-showLogLine (workerId, time, event) =
+showLogLine :: (LocalTime, CampaignEvent) -> Widget Name
+showLogLine (time, event@(WorkerEvent workerId _)) =
   (withAttr (attrName "time") $ str $ (timePrefix time) <> "[Worker " <> show workerId <> "] ")
     <+> strBreak (ppCampaignEvent event)
+showLogLine (time, event) =
+  (withAttr (attrName "time") $ str $ (timePrefix time) <> " ") <+> strBreak (ppCampaignEvent event)
 
 summaryWidget :: Env -> UIState -> Widget Name
 summaryWidget env uiState =


### PR DESCRIPTION
Based on https://github.com/crytic/echidna/pull/1048. This one reuses the existing event system to keep fuzzing at the maximum speed.