### PR TITLE
Save traces for every transaction in reproducer

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -16,6 +16,7 @@ import Control.Monad.Trans (lift)
 import Data.Binary.Get (runGetOrFail)
 import Data.ByteString.Lazy qualified as LBS
 import Data.IORef (readIORef, atomicModifyIORef')
+import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Map (Map, (\\))
 import Data.Maybe (isJust, mapMaybe, fromMaybe)
@@ -47,7 +48,6 @@ import Echidna.Types.Test qualified as Test
 import Echidna.Types.Tx (TxCall(..), Tx(..), call)
 import Echidna.Types.World (World)
 import Echidna.Utility (getTimestamp)
-import qualified Data.List as List
 
 instance MonadThrow m => MonadThrow (RandT g m) where
   throwM = lift . throwM

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,15 +2,16 @@
 
 module Main where
 
-import Control.Monad (unless, forM_)
-import Control.Monad.Reader (runReaderT)
+import Control.Monad (unless, forM_, when)
+import Control.Monad.Reader (runReaderT, liftIO)
 import Control.Monad.Random (getRandomR)
 import Data.Aeson.Key qualified as Aeson.Key
 import Data.Function ((&))
+import Data.Hashable (hash)
 import Data.IORef (readIORef)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Time.Clock.System (getSystemTime, systemSeconds)
@@ -19,8 +20,10 @@ import Data.Word (Word8, Word16)
 import Main.Utf8 (withUtf8)
 import Options.Applicative
 import Paths_echidna (version)
+import System.Directory (createDirectoryIfMissing)
+import System.Environment (lookupEnv)
 import System.Exit (exitWith, exitSuccess, ExitCode(..))
-import System.FilePath ((</>))
+import System.FilePath ((</>), (<.>))
 import System.IO (hPutStrLn, stderr)
 import System.IO.CodePage (withCP65001)
 
@@ -35,12 +38,13 @@ import Echidna.Onchain qualified as Onchain
 import Echidna.Output.Corpus
 import Echidna.Output.Source
 import Echidna.Solidity (compileContracts)
-import Echidna.Test (validateTestMode)
+import Echidna.Test (reproduceTest, validateTestMode)
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Solidity
 import Echidna.Types.Test (TestMode, EchidnaTest(..))
 import Echidna.UI
+import Echidna.UI.Report (ppFailWithTraces, ppTestName)
 import Echidna.Utility (measureIO)
 
 main :: IO ()
@@ -76,6 +80,20 @@ main = withUtf8 $ withCP65001 $ do
     Just dir -> do
       measureIO cfg.solConf.quiet "Saving test reproducers" $
         saveTxs (dir </> "reproducers") (filter (not . null) $ (.reproducer) <$> tests)
+
+      saveTracesEnabled <- lookupEnv "ECHIDNA_SAVE_TRACES"
+      when (isJust saveTracesEnabled) $ do
+        measureIO cfg.solConf.quiet "Saving test reproducers-traces" $ do
+          flip runReaderT env $ do
+            forM_ tests $ \test ->
+              unless (null test.reproducer) $ do
+                (results, finalVM) <- reproduceTest vm test
+                let subdir = dir </> "reproducers-traces"
+                liftIO $ createDirectoryIfMissing True subdir
+                let file = subdir </> (show . abs . hash . show) test.reproducer <.> "txt"
+                txsPrinted <- ppFailWithTraces Nothing finalVM results
+                liftIO $ writeFile file (ppTestName test <> ": " <> txsPrinted)
+
       measureIO cfg.solConf.quiet "Saving corpus" $ do
         corpus <- readIORef env.corpusRef
         saveTxs (dir </> "coverage") (snd <$> Set.toList corpus)


### PR DESCRIPTION
Saving traces for every transaction for a falsifying sequence under `reproducers-traces` in corpus dir. A working prototype, set `export ECHIDNA_SAVE_TRACES=true` to use.