### PR TITLE
Fix faulty corpus transaction detection

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -68,7 +68,9 @@ replayCorpus
   -> m ()
 replayCorpus vm txSeqs =
   forM_ (zip [1..] txSeqs) $ \(i, (file, txSeq)) -> do
-    let maybeFaultyTx = List.find (\tx -> LitAddr tx.dst `notElem` Map.keys vm.env.contracts) txSeq
+    let maybeFaultyTx =
+          List.find (\tx -> LitAddr tx.dst `notElem` Map.keys vm.env.contracts) $
+            List.filter (\case Tx { call = NoCall } -> False; _ -> True) txSeq
     case maybeFaultyTx of
       Nothing -> do
         _ <- callseq vm txSeq

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -87,11 +87,14 @@ execTxWith executeTx tx = do
     #traces .= emptyEvents
     vmBeforeTx <- get
     setupTx tx
-    gasLeftBeforeTx <- gets (.state.gas)
-    vmResult <- runFully
-    gasLeftAfterTx <- gets (.state.gas)
-    handleErrorsAndConstruction vmResult vmBeforeTx
-    pure (vmResult, gasLeftBeforeTx - gasLeftAfterTx)
+    case tx.call of
+      NoCall -> pure (VMSuccess (ConcreteBuf ""), 0)
+      _ -> do
+        gasLeftBeforeTx <- gets (.state.gas)
+        vmResult <- runFully
+        gasLeftAfterTx <- gets (.state.gas)
+        handleErrorsAndConstruction vmResult vmBeforeTx
+        pure (vmResult, gasLeftBeforeTx - gasLeftAfterTx)
   where
   runFully = do
     config <- asks (.cfg)

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -161,7 +161,6 @@ setupTx tx@Tx{call = NoCall} = fromEVM $ do
     { state = vm.state
     , block = advanceBlock vm.block tx.delay
     }
-  modify' $ execState $ loadContract (LitAddr tx.dst)
 
 setupTx tx@Tx{call} = fromEVM $ do
   resetState


### PR DESCRIPTION
`NoCall`s form corpus shouldn't be checked for destination. Long term, fix the `Tx` type so `NoCall` doesn't have unnecessary fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the transaction filtering process in the campaign functionality to enhance the selection of potentially faulty transactions by excluding specific non-relevant transactions.
- **Refactor**
	- Altered the execution flow within the `execTxWith` function to handle `NoCall` cases separately, affecting the return value based on the transaction's call type.
- **Refactor**
	- Modified the `setupTx` function in transactions to exclude the `loadContract` call for transactions with `NoCall`, impacting the setup logic for transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->