### PR TITLE
nix: enhance TERMINFO for Linux builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
           mkdir -p $out/bin
           cp ${pkgsStatic.haskell.lib.dontCheck echidna-static}/bin/echidna $out/bin/
           # fix TERMINFO path in ncurses
-          ${perl} -i -pe 's#(${ncurses-static}/share/terminfo)#"/usr/share/terminfo" . "\x0" x (length($1) - 19)#e' $out/bin/echidna
+          ${perl} -i -pe 's#(${ncurses-static}/share/terminfo)#"/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo" . "\x0" x (length($1) - 65)#e' $out/bin/echidna
           chmod 555 $out/bin/echidna
         '' else pkgs.runCommand "echidna-stripNixRefs" {} ''
           mkdir -p $out/bin


### PR DESCRIPTION
Some distros have terminfo on /usr/lib/terminfo, like Ubuntu. Others have them on /usr/share/terminfo, like Fedora. Include all possible paths to be as compatible as possible.

Closes #1185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the TERMINFO variable path in the Nix package build process for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->