### PR TITLE
feat: add CLI commands for RPC URL and block number

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -214,8 +214,8 @@ versionOption = infoOption
 
 overrideConfig :: EConfig -> Options -> IO EConfig
 overrideConfig config Options{..} = do
-  rpcUrl <- maybe (Onchain.rpcUrlEnv) (pure . Just) cliRpcUrl
-  rpcBlock <- maybe (Onchain.rpcBlockEnv) (pure . Just) cliRpcBlock
+  rpcUrl <- (pure cliRpcUrl) <|> Onchain.rpcUrlEnv
+  rpcBlock <- (pure cliRpcBlock) <|> Onchain.rpcBlockEnv
   pure $
     config { solConf = overrideSolConf config.solConf
            , campaignConf = overrideCampaignConf config.campaignConf

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -127,14 +127,14 @@ data Options = Options
   , cliAllContracts     :: Bool
   , cliTimeout          :: Maybe Int
   , cliTestLimit        :: Maybe Int
+  , cliRpcBlock         :: Maybe Word64
+  , cliRpcUrl           :: Maybe Text
   , cliShrinkLimit      :: Maybe Int
   , cliSeqLen           :: Maybe Int
   , cliContractAddr     :: Maybe Addr
   , cliDeployer         :: Maybe Addr
   , cliSender           :: [Addr]
   , cliSeed             :: Maybe Int
-  , cliRpcUrl           :: Maybe Text
-  , cliRpcBlock         :: Maybe Word64
   , cliCryticArgs       :: Maybe String
   , cliSolcArgs         :: Maybe String
   }
@@ -176,6 +176,12 @@ options = Options
   <*> optional (option auto $ long "test-limit"
     <> metavar "INTEGER"
     <> help ("Number of sequences of transactions to generate during testing. Default is " ++ show defaultTestLimit))
+  <*> optional (option auto $ long "rpc-block"
+    <> metavar "BLOCK"
+    <> help "Block number to use when fetching over RPC.")
+  <*> optional (option str $ long "rpc-url"
+    <> metavar "URL"
+    <> help "Fetch contracts over a RPC URL.")
   <*> optional (option auto $ long "shrink-limit"
     <> metavar "INTEGER"
     <> help ("Number of tries to attempt to shrink a failing sequence of transactions. Default is " ++ show defaultShrinkLimit))
@@ -194,12 +200,6 @@ options = Options
   <*> optional (option auto $ long "seed"
     <> metavar "SEED"
     <> help "Run with a specific seed.")
-  <*> optional (option str $ long "rpc-url"
-    <> metavar "URL"
-    <> help "Fetch contracts over a RPC URL.")
-  <*> optional (option auto $ long "rpc-block"
-    <> metavar "BLOCK"
-    <> help "Block number to use when fetching over RPC.")
   <*> optional (option str $ long "crytic-args"
     <> metavar "ARGS"
     <> help "Additional arguments to use in crytic-compile for the compilation of the contract to test.")

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -181,7 +181,7 @@ options = Options
     <> help "Block number to use when fetching over RPC.")
   <*> optional (option str $ long "rpc-url"
     <> metavar "URL"
-    <> help "Fetch contracts over a RPC URL.")
+    <> help "RPC URL to fetch contracts over.")
   <*> optional (option auto $ long "shrink-limit"
     <> metavar "INTEGER"
     <> help ("Number of tries to attempt to shrink a failing sequence of transactions. Default is " ++ show defaultShrinkLimit))
@@ -214,8 +214,8 @@ versionOption = infoOption
 
 overrideConfig :: EConfig -> Options -> IO EConfig
 overrideConfig config Options{..} = do
-  rpcUrl <- (pure cliRpcUrl) <|> Onchain.rpcUrlEnv
-  rpcBlock <- (pure cliRpcBlock) <|> Onchain.rpcBlockEnv
+  rpcUrl <- pure cliRpcUrl <|> Onchain.rpcUrlEnv
+  rpcBlock <- pure cliRpcBlock <|> Onchain.rpcBlockEnv
   pure $
     config { solConf = overrideSolConf config.solConf
            , campaignConf = overrideCampaignConf config.campaignConf

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -214,14 +214,14 @@ versionOption = infoOption
 
 overrideConfig :: EConfig -> Options -> IO EConfig
 overrideConfig config Options{..} = do
-  rpcUrl <- pure cliRpcUrl <|> Onchain.rpcUrlEnv
-  rpcBlock <- pure cliRpcBlock <|> Onchain.rpcBlockEnv
+  envRpcUrl <- Onchain.rpcUrlEnv
+  envRpcBlock <- Onchain.rpcBlockEnv
   pure $
     config { solConf = overrideSolConf config.solConf
            , campaignConf = overrideCampaignConf config.campaignConf
            , uiConf = overrideUiConf config.uiConf
-           , rpcUrl = rpcUrl <|> config.rpcUrl
-           , rpcBlock = rpcBlock <|> config.rpcBlock
+           , rpcUrl = cliRpcUrl <|> envRpcUrl <|> config.rpcUrl
+           , rpcBlock = cliRpcBlock <|> envRpcBlock <|> config.rpcBlock
            }
            & overrideFormat
   where


### PR DESCRIPTION
Implemented CLI arguments `--rpc-url` and `--rpc-block` to allow overriding the corresponding environment variables.

The precedence for settings is now: Command-Line Arguments > Environment Variables > Configuration Defaults.

Closes #1193 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new command-line options for specifying RPC URL and block number, enhancing user control over configuration settings.
- **Enhancements**
	- Improved configuration override mechanism to prioritize command-line inputs over environment variables, offering users more flexibility in setting preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->