### PR TITLE
Update filterFallbacks to be selective rather than all-or-nothing

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -15,7 +15,7 @@ import EVM (cheatCode)
 import EVM.ABI (AbiValue(AbiAddress))
 import EVM.Dapp (DappInfo(..), dappInfo)
 import EVM.Fetch qualified
-import EVM.Solidity (SolcContract(..), BuildOutput)
+import EVM.Solidity (BuildOutput)
 import EVM.Types hiding (Env)
 
 import Echidna.ABI
@@ -72,8 +72,7 @@ prepareContract env solFiles specifiedContract seed = do
                                (forceAddr vm.state.contract)
                                funs
 
-    eventMap = Map.unions $ map (.eventMap) contracts
-    world = mkWorld solConf eventMap signatureMap specifiedContract slitherInfo contracts
+    world = mkWorld solConf signatureMap specifiedContract slitherInfo contracts
 
     deployedAddresses = Set.fromList $ AbiAddress . forceAddr <$> Map.keys vm.env.contracts
     constants = enhanceConstants slitherInfo

--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -73,7 +73,7 @@ prepareContract env solFiles specifiedContract seed = do
                                funs
 
     eventMap = Map.unions $ map (.eventMap) contracts
-    world = mkWorld solConf eventMap signatureMap specifiedContract slitherInfo
+    world = mkWorld solConf eventMap signatureMap specifiedContract slitherInfo contracts
 
     deployedAddresses = Set.fromList $ AbiAddress . forceAddr <$> Map.keys vm.env.contracts
     constants = enhanceConstants slitherInfo

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -326,7 +326,7 @@ filterFallbacks
   -> [SolcContract]
   -> SignatureMap
   -> SignatureMap
-filterFallbacks la lb contracts sm = Map.mapWithKey f sm
+filterFallbacks la lb contracts = Map.mapWithKey f
   where
     f k ss | k `elem` keysToIgnore = ss
     f _ ss = NE.fromList $ case NE.filter (/= fallback) ss of

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -38,7 +38,7 @@ import Echidna.ABI
   , commonTypeSizes, mkValidAbiInt, mkValidAbiUInt )
 import Echidna.Deploy (deployContracts, deployBytecodes)
 import Echidna.Etheno (loadEthenoBatch)
-import Echidna.Events (EventMap, extractEvents)
+import Echidna.Events (extractEvents)
 import Echidna.Exec (execTx, initialVM)
 import Echidna.SourceAnalysis.Slither
 import Echidna.Symbolic (forceAddr)
@@ -291,14 +291,14 @@ loadSpecified env name cs = do
 -- for running a 'Campaign' against the tests found.
 mkWorld
   :: SolConf
-  -> EventMap
   -> SignatureMap
   -> Maybe ContractName
   -> SlitherInfo
   -> [SolcContract]
   -> World
-mkWorld SolConf{sender, testMode} eventMap sigMap maybeContract slitherInfo contracts =
+mkWorld SolConf{sender, testMode} sigMap maybeContract slitherInfo contracts =
   let
+    eventMap = Map.unions $ map (.eventMap) contracts
     payableSigs = filterResults maybeContract slitherInfo.payableFunctions
     as = if isAssertionMode testMode then filterResults maybeContract slitherInfo.asserts else []
     cs = if isDapptestMode testMode then [] else filterResults maybeContract slitherInfo.constantFunctions \\ as

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -333,7 +333,7 @@ filterFallbacks la lb contracts = Map.mapWithKey f
                 []  -> [fallback] -- No other alternative
                 ss' -> ss'
     keysToIgnore = concatMap contractNameToCodehashes (la ++ lb)
-    contractNameToCodehashes name = map (.runtimeCodehash) $ filter (\c -> c.contractName == name) contracts
+    contractNameToCodehashes name = map (.runtimeCodehash) $ filter (\c -> last (T.splitOn ":" c.contractName) == name) contracts
 
 prepareHashMaps
   :: [FunctionSelector]


### PR DESCRIPTION
This PR changes the `filterFallbacks` function so that it filters out fallbacks selectively, rather than either removing fallbacks from all contracts or none. It also removes the first argument of the function, which was unused.

Fixes issue 1 of #1134 (now it's 1000 calls/s in both cases, rather than 1000 in one and 10000 in the other; the performance only improved before because it was trying a bunch of fallback calls, which executed quickly because they didn't do anything)