### PR TITLE
Fix mac builds with stack build in nix develop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,9 @@
             packages = _: [ (echidna pkgs) ];
             shellHook = "hpack";
             buildInputs = [
+              pkgs.secp256k1
+              pkgs.libff
+              pkgs.gmp
               solc
               slither-analyzer
               haskellPackages.hlint


### PR DESCRIPTION
This fixes `stack build` via `nix develop` on my mac, which was previously failing due to "ld: library not found for -lsecp256k1". I'm mostly opening this PR to provide the diff in case somebody has the same issue as me