### PR TITLE
Add symbolic execution

### DIFF
--- a/.github/scripts/install-z3.sh
+++ b/.github/scripts/install-z3.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eux -o pipefail
+
+if [ "$HOST_OS" = "Linux" ]; then
+  sudo apt-get update
+  sudo apt-get install -y z3
+fi
+# symbolic tests are currently disabled on windows because they fail
+# if [ "$HOST_OS" = "Windows" ]; then
+#   choco install z3
+# fi

--- a/.github/scripts/install-z3.sh
+++ b/.github/scripts/install-z3.sh
@@ -5,7 +5,6 @@ if [ "$HOST_OS" = "Linux" ]; then
   sudo apt-get update
   sudo apt-get install -y z3
 fi
-# symbolic tests are currently disabled on windows because they fail
-# if [ "$HOST_OS" = "Windows" ]; then
-#   choco install z3
-# fi
+if [ "$HOST_OS" = "Windows" ]; then
+  choco install z3
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
         run: |
           .github/scripts/install-solc.sh
           .github/scripts/install-crytic-compile.sh
+          .github/scripts/install-z3.sh
         env:
           HOST_OS: ${{ runner.os }}
           SOLC_VER: ${{ matrix.solc }}

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -97,6 +97,11 @@ instance FromJSON EConfigWithUsage where
         <*> v ..:? "coverageFormats" ..!= [Txt,Html,Lcov]
         <*> v ..:? "workers"
         <*> v ..:? "server"
+        <*> v ..:? "symExec"            ..!= False
+        <*> v ..:? "symExecTimeout"     ..!= defaultSymExecTimeout
+        <*> v ..:? "symExecNSolvers"    ..!= defaultSymExecNWorkers
+        <*> v ..:? "symExecMaxIters"    ..!= defaultSymExecMaxIters
+        <*> v ..:? "symExecAskSMTIters" ..!= defaultSymExecAskSMTIters
 
       solConfParser = SolConf
         <$> v ..:? "contractAddr"    ..!= defaultContractAddr

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -98,6 +98,7 @@ instance FromJSON EConfigWithUsage where
         <*> v ..:? "workers"
         <*> v ..:? "server"
         <*> v ..:? "symExec"            ..!= False
+        <*> v ..:? "symExecConcolic"    ..!= True
         <*> v ..:? "symExecTimeout"     ..!= defaultSymExecTimeout
         <*> v ..:? "symExecNSolvers"    ..!= defaultSymExecNWorkers
         <*> v ..:? "symExecMaxIters"    ..!= defaultSymExecMaxIters

--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -42,7 +42,7 @@ saveCorpusEvent env (_time, campaignEvent) = do
     Just corpusDir -> saveEvent corpusDir campaignEvent
     Nothing -> pure ()
   where
-    saveEvent dir (WorkerEvent _workerId event) =
+    saveEvent dir (WorkerEvent _workerId _workerType event) =
       maybe (pure ()) (saveFile dir) $ getEventInfo event
     saveEvent _ _ = pure ()
 

--- a/lib/Echidna/SymExec.hs
+++ b/lib/Echidna/SymExec.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE DataKinds #-}
+
+module Echidna.SymExec (createSymTx) where
+
+import Control.Concurrent (ThreadId, forkIO)
+import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
+import Control.Monad (forM)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (runReaderT)
+import Data.ByteString.Lazy qualified as BS
+import Data.Function ((&))
+import Data.Functor ((<&>))
+import Data.Map qualified as Map
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Optics.Core ((.~), (%))
+import Echidna.Solidity (chooseContract)
+import Echidna.Types (fromEVM)
+import Echidna.Types.Campaign (CampaignConf(..))
+import Echidna.Types.Config (EConfig(..))
+import Echidna.Types.Solidity (SolConf(..))
+import EVM.ABI (Sig(..), decodeAbiValue)
+import EVM.Expr (simplify)
+import EVM.Fetch qualified as Fetch
+import EVM.SMT (SMTCex(..))
+import EVM (loadContract, resetState)
+import EVM.Effects (defaultEnv)
+import EVM.Solidity (SolcContract(..), Method(..))
+import EVM.Solvers (withSolvers, Solver(Z3), CheckSatResult(Sat))
+import EVM.SymExec (interpret, runExpr, abstractVM, mkCalldata, produceModels, LoopHeuristic (Naive))
+import EVM.Types (Addr, VM(..), Frame(..), FrameState(..), VMType(..), Env(..), Expr(..), EType(..), BaseState(..), word256Bytes)
+import Control.Monad.ST (stToIO, RealWorld)
+import Control.Monad.State.Strict (execState, runStateT)
+import Echidna.Types.Tx (Tx(..), TxCall(..), maxGasPerBlock)
+
+
+-- | Uses symbolic execution to find transactions which would increase coverage.
+-- Spawns a new thread; returns its thread ID as the first return value.
+-- The second return value is an MVar which is populated with transactions
+--   once the symbolic execution is finished.
+createSymTx :: EConfig -> Maybe Text -> [SolcContract] -> VM Concrete RealWorld -> IO (ThreadId, MVar [Tx])
+createSymTx cfg name cs vm = do
+    mainContract <- chooseContract cs name
+    exploreContract cfg mainContract vm
+
+exploreContract :: EConfig -> SolcContract -> VM Concrete RealWorld -> IO (ThreadId, MVar [Tx])
+exploreContract conf contract vm = do
+  let methods = Map.elems contract.abiMap
+      timeout = Just (fromIntegral conf.campaignConf.symExecTimeout)
+
+  threadIdChan <- newEmptyMVar
+  doneChan <- newEmptyMVar
+  resultChan <- newEmptyMVar
+
+  flip runReaderT defaultEnv $ withSolvers Z3 (fromIntegral conf.campaignConf.symExecNSolvers) timeout $ \solvers -> do
+    threadId <- liftIO $ forkIO $ flip runReaderT defaultEnv $ do
+      res <- forM methods $ \method -> do
+        let
+          dst = conf.solConf.contractAddr
+          calldata@(cd, constraints) = mkCalldata (Just (Sig method.methodSignature (snd <$> method.inputs))) []
+          vmSym = abstractVM calldata contract.runtimeCode Nothing False
+          maxIters = Just conf.campaignConf.symExecMaxIters
+          askSmtIters = conf.campaignConf.symExecAskSMTIters
+          rpcInfo = Nothing
+        vmSym' <- liftIO $ stToIO vmSym
+        vmReset <- liftIO $ snd <$> runStateT (fromEVM resetState) vm
+        let vm' = vmReset & execState (loadContract (LitAddr dst))
+                          & vmMakeSymbolic
+                          & #frames .~ []
+                          & #constraints .~ constraints
+                          & #state % #callvalue .~ TxValue
+                          & #state % #caller .~ SymAddr "caller"
+                          & #state % #calldata .~ cd
+                          & #state % #pc .~ 0
+                          & #state % #stack .~ []
+                          & #config % #baseState .~ AbstractBase
+                          & #env % #contracts .~ (Map.union vmSym'.env.contracts vm.env.contracts)
+        exprInter <- interpret (Fetch.oracle solvers rpcInfo) maxIters askSmtIters Naive vm' runExpr
+        models <- produceModels solvers (simplify exprInter)
+        pure $ mapMaybe (modelToTx dst method) models
+      liftIO $ putMVar resultChan (mconcat res)
+      liftIO $ putMVar doneChan ()
+    liftIO $ putMVar threadIdChan threadId
+    liftIO $ takeMVar doneChan
+
+  threadId <- takeMVar threadIdChan
+  pure (threadId, resultChan)
+
+-- | Sets result to Nothing, and sets gas to ()
+vmMakeSymbolic :: VM Concrete s -> VM Symbolic s
+vmMakeSymbolic vm
+  = VM
+  { result         = Nothing
+  , state          = frameStateMakeSymbolic vm.state
+  , frames         = map frameMakeSymbolic vm.frames
+  , env            = vm.env
+  , block          = vm.block
+  , tx             = vm.tx
+  , logs           = vm.logs
+  , traces         = vm.traces
+  , cache          = vm.cache
+  , burned         = ()
+  , iterations     = vm.iterations
+  , constraints    = vm.constraints
+  , config         = vm.config
+  , forks          = vm.forks
+  , currentFork    = vm.currentFork
+  }
+
+frameStateMakeSymbolic :: FrameState Concrete s -> FrameState Symbolic s
+frameStateMakeSymbolic fs
+  = FrameState
+  { contract     = fs.contract
+  , codeContract = fs.codeContract
+  , code         = fs.code
+  , pc           = fs.pc
+  , stack        = fs.stack
+  , memory       = fs.memory
+  , memorySize   = fs.memorySize
+  , calldata     = fs.calldata
+  , callvalue    = fs.callvalue
+  , caller       = fs.caller
+  , gas          = ()
+  , returndata   = fs.returndata
+  , static       = fs.static
+  }
+
+frameMakeSymbolic :: Frame Concrete s -> Frame Symbolic s
+frameMakeSymbolic fr = Frame { context = fr.context, state = frameStateMakeSymbolic fr.state }
+
+modelToTx :: Addr -> Method -> (Expr 'End, CheckSatResult) -> Maybe Tx
+modelToTx dst method (_end, result) =
+  case result of
+    Sat cex ->
+      let
+        args = (zip [1..] method.inputs) <&> \(i::Int, (_argName, argType)) ->
+          case Map.lookup (Var ("arg" <> T.pack (show i))) cex.vars of
+            Just w ->
+              decodeAbiValue argType (BS.fromStrict (word256Bytes w))
+            Nothing -> -- put a placeholder
+              decodeAbiValue argType (BS.repeat 0)
+
+        value = fromMaybe 0 $ Map.lookup TxValue cex.txContext
+
+      in Just Tx
+        { call = SolCall (method.name, args)
+        , src = 0
+        , dst = dst
+        , gasprice = 0
+        , gas = maxGasPerBlock
+        , value = value
+        , delay = (0, 0)
+        }
+
+    _ -> Nothing

--- a/lib/Echidna/SymExec.hs
+++ b/lib/Echidna/SymExec.hs
@@ -1,35 +1,42 @@
-{-# LANGUAGE DataKinds #-}
+{-# OPTIONS_GHC -Wno-gadt-mono-local-binds #-}
 
 module Echidna.SymExec (createSymTx) where
 
+import Control.Applicative ((<|>))
+import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent (ThreadId, forkIO)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
 import Control.Monad (forM)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (runReaderT)
 import Data.ByteString.Lazy qualified as BS
+import Data.Foldable (fold)
 import Data.Function ((&))
-import Data.Functor ((<&>))
+import Data.List (singleton)
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe, isJust, fromJust)
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Vector (toList, fromList)
 import Optics.Core ((.~), (%))
 import Echidna.Solidity (chooseContract)
 import Echidna.Types (fromEVM)
 import Echidna.Types.Campaign (CampaignConf(..))
 import Echidna.Types.Config (EConfig(..))
 import Echidna.Types.Solidity (SolConf(..))
-import EVM.ABI (Sig(..), decodeAbiValue)
+import EVM.ABI (AbiValue(..), AbiType(..), Sig(..), decodeAbiValue)
 import EVM.Expr (simplify)
 import EVM.Fetch qualified as Fetch
-import EVM.SMT (SMTCex(..))
+import EVM.SMT (SMTCex(..), SMT2, assertProps)
 import EVM (loadContract, resetState)
-import EVM.Effects (defaultEnv)
+import EVM.Effects (defaultEnv, defaultConfig)
 import EVM.Solidity (SolcContract(..), Method(..))
-import EVM.Solvers (withSolvers, Solver(Z3), CheckSatResult(Sat))
-import EVM.SymExec (interpret, runExpr, abstractVM, mkCalldata, produceModels, LoopHeuristic (Naive))
-import EVM.Types (Addr, VM(..), Frame(..), FrameState(..), VMType(..), Env(..), Expr(..), EType(..), BaseState(..), word256Bytes)
+import EVM.Solvers (withSolvers, Solver(Z3), CheckSatResult(Sat), SolverGroup, checkSat)
+import EVM.SymExec (interpret, runExpr, abstractVM, mkCalldata, LoopHeuristic (Naive), flattenExpr, extractProps)
+import EVM.Types (Addr, VM(..), Frame(..), FrameState(..), VMType(..), Env(..), Expr(..), EType(..), Query(..), Prop(..), BranchCondition(..), W256, word256Bytes, word)
+import EVM.Traversals (mapExpr)
 import Control.Monad.ST (stToIO, RealWorld)
 import Control.Monad.State.Strict (execState, runStateT)
 import Echidna.Types.Tx (Tx(..), TxCall(..), maxGasPerBlock)
@@ -39,15 +46,28 @@ import Echidna.Types.Tx (Tx(..), TxCall(..), maxGasPerBlock)
 -- Spawns a new thread; returns its thread ID as the first return value.
 -- The second return value is an MVar which is populated with transactions
 --   once the symbolic execution is finished.
-createSymTx :: EConfig -> Maybe Text -> [SolcContract] -> VM Concrete RealWorld -> IO (ThreadId, MVar [Tx])
-createSymTx cfg name cs vm = do
-    mainContract <- chooseContract cs name
-    exploreContract cfg mainContract vm
+-- Also takes an optional Tx argument; this is used as the transaction
+--   to follow during concolic execution. If none is provided, we do full
+--   symbolic execution.
+--   The Tx argument, if present, must have a .call value of type SolCall.
+createSymTx :: EConfig -> Maybe Text -> [SolcContract] -> Maybe Tx -> VM Concrete RealWorld -> IO (ThreadId, MVar [Tx])
+createSymTx cfg name cs tx vm = do
+  mainContract <- chooseContract cs name
+  exploreContract cfg mainContract tx vm
 
-exploreContract :: EConfig -> SolcContract -> VM Concrete RealWorld -> IO (ThreadId, MVar [Tx])
-exploreContract conf contract vm = do
-  let methods = Map.elems contract.abiMap
-      timeout = Just (fromIntegral conf.campaignConf.symExecTimeout)
+exploreContract :: EConfig -> SolcContract -> Maybe Tx -> VM Concrete RealWorld -> IO (ThreadId, MVar [Tx])
+exploreContract conf contract tx vm = do
+  let
+    isConc = isJust tx
+    allMethods = Map.elems contract.abiMap
+    concMethods (Tx { call = SolCall (methodName, _) }) = filter (\method -> method.name == methodName) allMethods
+    concMethods _ = error "`exploreContract` should only be called with Nothing or Just Tx{call=SolCall _} for its tx argument"
+    methods = maybe allMethods concMethods tx
+    timeout = Just (fromIntegral conf.campaignConf.symExecTimeout)
+    maxIters = if isConc then Nothing else Just conf.campaignConf.symExecMaxIters
+    askSmtIters = if isConc then 0 else conf.campaignConf.symExecAskSMTIters
+    rpcInfo = Nothing
+    defaultSender = fromJust $ fmap (.dst) tx <|> Set.lookupMin conf.solConf.sender <|> Just 0
 
   threadIdChan <- newEmptyMVar
   doneChan <- newEmptyMVar
@@ -57,35 +77,40 @@ exploreContract conf contract vm = do
     threadId <- liftIO $ forkIO $ flip runReaderT defaultEnv $ do
       res <- forM methods $ \method -> do
         let
+          fetcher = concOrSymFetcher tx solvers rpcInfo
           dst = conf.solConf.contractAddr
           calldata@(cd, constraints) = mkCalldata (Just (Sig method.methodSignature (snd <$> method.inputs))) []
           vmSym = abstractVM calldata contract.runtimeCode Nothing False
-          maxIters = Just conf.campaignConf.symExecMaxIters
-          askSmtIters = conf.campaignConf.symExecAskSMTIters
-          rpcInfo = Nothing
         vmSym' <- liftIO $ stToIO vmSym
         vmReset <- liftIO $ snd <$> runStateT (fromEVM resetState) vm
         let vm' = vmReset & execState (loadContract (LitAddr dst))
                           & vmMakeSymbolic
-                          & #frames .~ []
                           & #constraints .~ constraints
                           & #state % #callvalue .~ TxValue
                           & #state % #caller .~ SymAddr "caller"
                           & #state % #calldata .~ cd
-                          & #state % #pc .~ 0
-                          & #state % #stack .~ []
-                          & #config % #baseState .~ AbstractBase
                           & #env % #contracts .~ (Map.union vmSym'.env.contracts vm.env.contracts)
-        exprInter <- interpret (Fetch.oracle solvers rpcInfo) maxIters askSmtIters Naive vm' runExpr
-        models <- produceModels solvers (simplify exprInter)
-        pure $ mapMaybe (modelToTx dst method) models
-      liftIO $ putMVar resultChan (mconcat res)
+        -- TODO we might want to switch vm's state.baseState value to to AbstractBase eventually.
+        -- Doing so might mess up concolic execution.
+        exprInter <- interpret fetcher maxIters askSmtIters Naive vm' runExpr
+        models <- liftIO $ mapConcurrently (checkSat solvers) $ manipulateExprInter isConc exprInter
+        pure $ mapMaybe (modelToTx dst method conf.solConf.sender defaultSender) models
+      liftIO $ putMVar resultChan $ concat res
       liftIO $ putMVar doneChan ()
     liftIO $ putMVar threadIdChan threadId
     liftIO $ takeMVar doneChan
 
   threadId <- takeMVar threadIdChan
   pure (threadId, resultChan)
+
+-- | Turn the expression returned by `interpret` into into SMT2 values to feed into the solver
+manipulateExprInter :: Bool -> Expr End -> [SMT2]
+manipulateExprInter isConc = map (assertProps defaultConfig) . middleStep . map (extractProps . simplify) . flattenExpr . simplify where
+  middleStep = if isConc then middleStepConc else id
+  middleStepConc = map singleton . concatMap (go (PBool True))
+  go :: Prop -> [Prop] -> [Prop]
+  go _ [] = []
+  go acc (h:t) = (PNeg h `PAnd` acc) : go (h `PAnd` acc) t
 
 -- | Sets result to Nothing, and sets gas to ()
 vmMakeSymbolic :: VM Concrete s -> VM Symbolic s
@@ -129,23 +154,42 @@ frameStateMakeSymbolic fs
 frameMakeSymbolic :: Frame Concrete s -> Frame Symbolic s
 frameMakeSymbolic fr = Frame { context = fr.context, state = frameStateMakeSymbolic fr.state }
 
-modelToTx :: Addr -> Method -> (Expr 'End, CheckSatResult) -> Maybe Tx
-modelToTx dst method (_end, result) =
+modelToTx :: Addr -> Method -> Set Addr -> Addr -> CheckSatResult -> Maybe Tx
+modelToTx dst method senders fallbackSender result =
   case result of
     Sat cex ->
       let
-        args = (zip [1..] method.inputs) <&> \(i::Int, (_argName, argType)) ->
-          case Map.lookup (Var ("arg" <> T.pack (show i))) cex.vars of
-            Just w ->
-              decodeAbiValue argType (BS.fromStrict (word256Bytes w))
-            Nothing -> -- put a placeholder
-              decodeAbiValue argType (BS.repeat 0)
+        args = zipWith grabArg (snd <$> method.inputs) ["arg" <> T.pack (show n) | n <- [1..] :: [Int]]
+
+        grabArg t
+          = case t of
+              AbiUIntType _ -> grabNormalArg t
+              AbiIntType _ -> grabNormalArg t
+              AbiBoolType -> grabNormalArg t
+              AbiBytesType _ -> grabNormalArg t
+              AbiAddressType -> grabAddressArg
+              AbiArrayType n mt -> grabArrayArg n mt
+              _ -> error "Unexpected ABI type in `modelToTx`"
+
+        grabNormalArg argType name
+          = case Map.lookup (Var name) cex.vars of
+              Just w ->
+                decodeAbiValue argType (BS.fromStrict (word256Bytes w))
+              Nothing -> -- put a placeholder
+                decodeAbiValue argType (BS.repeat 0)
+
+        grabAddressArg name = AbiAddress $ fromMaybe 0 $ Map.lookup (SymAddr name) cex.addrs
+
+        grabArrayArg nElem memberType name = AbiArray nElem memberType $ fromList [grabArg memberType $ name <> T.pack (show n) | n <- [0..nElem] :: [Int]]
+
+        src_ = fromMaybe 0 $ Map.lookup (SymAddr "sender") cex.addrs
+        src = if Set.member src_ senders then src_ else fallbackSender
 
         value = fromMaybe 0 $ Map.lookup TxValue cex.txContext
 
       in Just Tx
         { call = SolCall (method.name, args)
-        , src = 0
+        , src = src
         , dst = dst
         , gasprice = 0
         , gas = maxGasPerBlock
@@ -154,3 +198,48 @@ modelToTx dst method (_end, result) =
         }
 
     _ -> Nothing
+
+-- | Symbolic variable -> concrete value mapping used during concolic execution.
+-- The third member in the tuple is the transaction value.
+type Substs = ([(Text, W256)], [(Text, Addr)], W256)
+
+-- | Mirrors hevm's `symAbiArg` function; whenever that changes, we need to change this too
+genSubsts :: Tx -> Substs
+genSubsts (Tx { call = SolCall (_, abiVals), src, value }) = addOnFinalValues $ fold $ zipWith genVal abiVals (T.pack . ("arg" <>) . show <$> ([1..] :: [Int])) where
+  addOnFinalValues (a, b) = (a, ("sender", src):b, value)
+  genVal (AbiUInt _ i) name = ([(name, fromIntegral i)], [])
+  genVal (AbiInt _ i) name = ([(name, fromIntegral i)], [])
+  genVal (AbiBool b) name = ([(name, if b then 1 else 0)], [])
+  genVal (AbiAddress addr) name = ([], [(name, addr)])
+  genVal (AbiBytes n b) name | n > 0 && n <= 32 = ([(name, word b)], [])
+  genVal (AbiArray _ _ vals) name = fold $ zipWith genVal (toList vals) [name <> T.pack (show n) | n <- [0..] :: [Int]]
+  genVal _ _ = error "`genSubsts` is not implemented for all API types, mirroring hevm's `symAbiArg` function"
+genSubsts _ = error "`genSubsts` should only be called with a `SolCall` transaction argument"
+
+-- | Apply substitutions into an expression
+substExpr :: Substs -> Expr a -> Expr a
+substExpr (sw, sa, val) = mapExpr go where
+  go v@(Var t) = maybe v Lit (lookup t sw)
+  go v@(SymAddr t) = maybe v LitAddr (lookup t sa)
+  go TxValue = Lit val
+  go e = e
+
+-- | Fetcher used during concolic exeuction.
+-- This is the most important function for concolic execution;
+-- it determines what branch `interpret` should take.
+-- We ensure that this fetcher is always used by setting askSMTIter to 0.
+-- We determine what branch to take by substituting concrete values into
+-- the provided `Prop`, and then simplifying.
+-- We fall back on `Fetch.oracle`.
+concFetcher :: Substs -> SolverGroup -> Fetch.RpcInfo -> Fetch.Fetcher t m s
+concFetcher substs s r (PleaseAskSMT branchcondition pathconditions continue) =
+  case simplify (substExpr substs branchcondition) of
+    Lit n -> pure (continue (Case (n/=0)))
+    simplifiedExpr -> Fetch.oracle s r (PleaseAskSMT simplifiedExpr pathconditions continue)
+concFetcher _ s r q = Fetch.oracle s r q
+
+-- | Depending on whether we're doing concolic or full symbolic execution,
+-- choose a fetcher to be used in `interpret` (either `concFetcher` or `Fetch.oracle`).
+concOrSymFetcher :: Maybe Tx -> SolverGroup -> Fetch.RpcInfo -> Fetch.Fetcher t m s
+concOrSymFetcher (Just c) = concFetcher $ genSubsts c
+concOrSymFetcher Nothing = Fetch.oracle

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -46,6 +46,9 @@ data CampaignConf = CampaignConf
     -- ^ Server-Sent Events HTTP port number, if missing server is not ran
   , symExec            :: Bool
     -- ^ Whether to add an additional symbolic execution worker
+  , symExecConcolic    :: Bool
+    -- ^ Whether symbolic execution will be concolic (vs full symbolic execution)
+    -- Only relevant if symExec is True
   , symExecTimeout     :: Int
     -- ^ Timeout for symbolic execution SMT solver.
     -- Only relevant if symExec is True
@@ -54,11 +57,11 @@ data CampaignConf = CampaignConf
     -- Only relevant if symExec is True
   , symExecMaxIters    :: Integer
     -- ^ Number of times we may revisit a particular branching point.
-    -- Only relevant if symExec is True
+    -- Only relevant if symExec is True and symExecConcolic is False
   , symExecAskSMTIters :: Integer
     -- ^ Number of times we may revisit a particular branching point
-    -- before we consult the smt solver to check reachability.
-    -- Only relevant if symExec is True
+    -- before we consult the SMT solver to check reachability.
+    -- Only relevant if symExec is True and symExecConcolic is False
   }
 
 data WorkerType = FuzzWorker | SymbolicWorker deriving (Eq)

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -1,7 +1,9 @@
 module Echidna.Types.Campaign where
 
+import Control.Concurrent (ThreadId)
 import Data.Aeson
 import Data.Map (Map)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Word (Word8, Word16)
@@ -14,46 +16,64 @@ import Echidna.Types.Tx (Tx)
 
 -- | Configuration for running an Echidna 'Campaign'.
 data CampaignConf = CampaignConf
-  { testLimit       :: Int
+  { testLimit          :: Int
     -- ^ Maximum number of function calls to execute while fuzzing
-  , stopOnFail      :: Bool
+  , stopOnFail         :: Bool
     -- ^ Whether to stop the campaign immediately if any property fails
-  , estimateGas     :: Bool
+  , estimateGas        :: Bool
     -- ^ Whether to collect gas usage statistics
-  , seqLen          :: Int
+  , seqLen             :: Int
     -- ^ Number of calls between state resets (e.g. \"every 10 calls,
     -- reset the state to avoid unrecoverable states/save memory\"
-  , shrinkLimit     :: Int
+  , shrinkLimit        :: Int
     -- ^ Maximum number of candidate sequences to evaluate while shrinking
-  , knownCoverage   :: Maybe CoverageMap
+  , knownCoverage      :: Maybe CoverageMap
     -- ^ If applicable, initially known coverage. If this is 'Nothing',
     -- Echidna won't collect coverage information (and will go faster)
-  , seed            :: Maybe Int
+  , seed               :: Maybe Int
     -- ^ Seed used for the generation of random transactions
-  , dictFreq        :: Float
+  , dictFreq           :: Float
     -- ^ Frequency for the use of dictionary values in the random transactions
-  , corpusDir       :: Maybe FilePath
+  , corpusDir          :: Maybe FilePath
     -- ^ Directory to load and save lists of transactions
-  , mutConsts       :: MutationConsts Integer
+  , mutConsts          :: MutationConsts Integer
     -- ^ Directory to load and save lists of transactions
-  , coverageFormats :: [CoverageFileType]
+  , coverageFormats    :: [CoverageFileType]
     -- ^ List of file formats to save coverage reports
-  , workers         :: Maybe Word8
+  , workers            :: Maybe Word8
     -- ^ Number of fuzzing workers
-  , serverPort      :: Maybe Word16
+  , serverPort         :: Maybe Word16
     -- ^ Server-Sent Events HTTP port number, if missing server is not ran
+  , symExec            :: Bool
+    -- ^ Whether to add an additional symbolic execution worker
+  , symExecTimeout     :: Int
+    -- ^ Timeout for symbolic execution SMT solver.
+    -- Only relevant if symExec is True
+  , symExecNSolvers    :: Int
+    -- ^ Number of SMT solvers used in symbolic execution.
+    -- Only relevant if symExec is True
+  , symExecMaxIters    :: Integer
+    -- ^ Number of times we may revisit a particular branching point.
+    -- Only relevant if symExec is True
+  , symExecAskSMTIters :: Integer
+    -- ^ Number of times we may revisit a particular branching point
+    -- before we consult the smt solver to check reachability.
+    -- Only relevant if symExec is True
   }
+
+data WorkerType = FuzzWorker | SymbolicWorker deriving (Eq)
 
 type WorkerId = Int
 
 data CampaignEvent
-  = WorkerEvent WorkerId WorkerEvent
+  = WorkerEvent WorkerId WorkerType WorkerEvent
   | Failure String
 
 data WorkerEvent
   = TestFalsified !EchidnaTest
   | TestOptimized !EchidnaTest
   | NewCoverage { points :: !Int, numCodehashes :: !Int, corpusSize :: !Int, transactions :: [Tx] }
+  | SymNoNewCoverage
   | TxSequenceReplayed FilePath !Int !Int
   | TxSequenceReplayFailed FilePath Tx
   | WorkerStopped WorkerStopReason
@@ -67,6 +87,7 @@ instance ToJSON WorkerEvent where
     TestOptimized test -> toJSON test
     NewCoverage { points, numCodehashes, corpusSize } ->
       object [ "coverage" .= points, "contracts" .= numCodehashes, "corpus_size" .= corpusSize]
+    SymNoNewCoverage -> object []
     TxSequenceReplayed file current total ->
       object [ "file" .= file, "current" .= current, "total" .= total ]
     TxSequenceReplayFailed file tx ->
@@ -75,6 +96,7 @@ instance ToJSON WorkerEvent where
 
 data WorkerStopReason
   = TestLimitReached
+  | SymbolicDone
   | TimeLimitReached
   | FastFailed
   | Killed !String
@@ -83,7 +105,7 @@ data WorkerStopReason
 
 ppCampaignEvent :: CampaignEvent -> String
 ppCampaignEvent = \case
-  WorkerEvent _ e -> ppWorkerEvent e
+  WorkerEvent _ _ e -> ppWorkerEvent e
   Failure err -> err
 
 ppWorkerEvent :: WorkerEvent -> String
@@ -97,6 +119,8 @@ ppWorkerEvent = \case
     "New coverage: " <> show points <> " instr, "
       <> show numCodehashes <> " contracts, "
       <> show corpusSize <> " seqs in corpus"
+  SymNoNewCoverage ->
+    "Symbolic execution finished with no new coverage."
   TxSequenceReplayed file current total ->
     "Sequence replayed from corpus file " <> file <> " (" <> show current <> "/" <> show total <> ")"
   TxSequenceReplayFailed file tx ->
@@ -105,6 +129,8 @@ ppWorkerEvent = \case
     "Remove the file or the transaction to fix the issue."
   WorkerStopped TestLimitReached ->
     "Test limit reached. Stopping."
+  WorkerStopped SymbolicDone ->
+    "Symbolic worker ran out of transactions to work on. Stopping."
   WorkerStopped TimeLimitReached ->
     "Time limit reached. Stopping."
   WorkerStopped FastFailed ->
@@ -136,6 +162,9 @@ data WorkerState = WorkerState
     -- ^ Number of times the callseq is called
   , ncalls      :: !Int
     -- ^ Number of calls executed while fuzzing
+  , runningThreads :: [ThreadId]
+    -- ^ Extra threads currently being run,
+    --   aside from the main worker thread
   }
 
 initialWorkerState :: WorkerState
@@ -146,6 +175,7 @@ initialWorkerState =
               , newCoverage = False
               , ncallseqs = 0
               , ncalls = 0
+              , runningThreads = []
               }
 
 defaultTestLimit :: Int
@@ -156,3 +186,29 @@ defaultSequenceLength = 100
 
 defaultShrinkLimit :: Int
 defaultShrinkLimit = 5000
+
+defaultSymExecTimeout :: Int
+defaultSymExecTimeout = 30
+
+defaultSymExecNWorkers :: Int
+defaultSymExecNWorkers = 1
+
+defaultSymExecMaxIters :: Integer
+defaultSymExecMaxIters = 10
+
+-- | Same default as in hevm, "everything else is unsound"
+-- (https://github.com/ethereum/hevm/pull/252)
+defaultSymExecAskSMTIters :: Integer
+defaultSymExecAskSMTIters = 1
+
+-- | Get number of fuzzing workers (doesn't include sym exec worker)
+-- Defaults to 1 if set to Nothing
+getNFuzzWorkers :: CampaignConf -> Int
+getNFuzzWorkers conf = fromIntegral (fromMaybe 1 (conf.workers))
+
+-- | Number of workers, including SymExec worker if there is one
+getNWorkers :: CampaignConf -> Int
+getNWorkers conf = getNFuzzWorkers conf + (if conf.symExec then 1 else 0)
+
+workerIDToType :: CampaignConf -> WorkerId -> WorkerType
+workerIDToType conf wid = if conf.symExec && wid == (getNWorkers conf - 1) then SymbolicWorker else FuzzWorker

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -25,11 +25,13 @@ import Data.ByteString.Lazy qualified as BS
 import Data.List.Split (chunksOf)
 import Data.Map (Map)
 import Data.Maybe (fromMaybe, isJust)
+import Data.Text (Text)
 import Data.Time
 import UnliftIO
-  ( MonadUnliftIO, newIORef, readIORef, hFlush, stdout , writeIORef, timeout)
+  ( MonadUnliftIO, IORef, newIORef, readIORef, hFlush, stdout , writeIORef, timeout)
 import UnliftIO.Concurrent hiding (killThread, threadDelay)
 
+import EVM.Solidity (SolcContract)
 import EVM.Types (Addr, Contract, VM, VMType(Concrete), W256)
 
 import Echidna.ABI
@@ -41,6 +43,7 @@ import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Corpus qualified as Corpus
 import Echidna.Types.Coverage (scoveragePoints)
+import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Test (EchidnaTest(..), didFail, isOptimizationTest)
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.World (World)
@@ -61,15 +64,17 @@ ui
   -> World   -- ^ Initial world state
   -> GenDict
   -> [(FilePath, [Tx])]
+  -> Maybe Text
+  -> [SolcContract]
   -> m [WorkerState]
-ui vm world dict initialCorpus = do
+ui vm world dict initialCorpus cliSelectedContract cs = do
   env <- ask
   conf <- asks (.cfg)
   terminalPresent <- liftIO isTerminal
 
   let
-    -- default to one worker if not configured
-    nworkers = fromIntegral $ fromMaybe 1 conf.campaignConf.workers
+    nFuzzWorkers = getNFuzzWorkers conf.campaignConf
+    nworkers = getNWorkers conf.campaignConf
 
     effectiveMode = case conf.uiConf.operationMode of
       Interactive | not terminalPresent -> NonInteractive Text
@@ -78,10 +83,10 @@ ui vm world dict initialCorpus = do
     -- Distribute over all workers, could be slightly bigger overall due to
     -- ceiling but this doesn't matter
     perWorkerTestLimit = ceiling
-      (fromIntegral conf.campaignConf.testLimit / fromIntegral nworkers :: Double)
+      (fromIntegral conf.campaignConf.testLimit / fromIntegral nFuzzWorkers :: Double)
 
     chunkSize = ceiling
-      (fromIntegral (length initialCorpus) / fromIntegral nworkers :: Double)
+      (fromIntegral (length initialCorpus) / fromIntegral nFuzzWorkers :: Double)
     corpusChunks = chunksOf chunkSize initialCorpus ++ repeat []
 
   corpusSaverStopVar <- spawnListener (saveCorpusEvent env)
@@ -217,11 +222,14 @@ ui vm world dict initialCorpus = do
 
     threadId <- forkIO $ do
       -- TODO: maybe figure this out with forkFinally?
+      let workerType = workerIDToType env.cfg.campaignConf workerId
       stopReason <- catches (do
-          let timeoutUsecs = maybe (-1) (*1_000_000) env.cfg.uiConf.maxTime
+          let
+            timeoutUsecs = maybe (-1) (*1_000_000) env.cfg.uiConf.maxTime
+            corpus = if workerType == SymbolicWorker then initialCorpus else corpusChunk
           maybeResult <- timeout timeoutUsecs $
-            runWorker (get >>= writeIORef stateRef)
-                      vm world dict workerId corpusChunk testLimit
+            runWorker workerType (get >>= writeIORef stateRef)
+                      vm world dict workerId corpus testLimit cliSelectedContract cs
           pure $ case maybeResult of
             Just (stopReason, _finalState) -> stopReason
             Nothing -> TimeLimitReached
@@ -231,7 +239,7 @@ ui vm world dict initialCorpus = do
         ]
 
       time <- liftIO getTimestamp
-      writeChan env.eventQueue (time, WorkerEvent workerId (WorkerStopped stopReason))
+      writeChan env.eventQueue (time, WorkerEvent workerId workerType (WorkerStopped stopReason))
 
     pure (threadId, stateRef)
 
@@ -241,9 +249,11 @@ ui vm world dict initialCorpus = do
 
 #ifdef INTERACTIVE_UI
  -- | Order the workers to stop immediately
-stopWorkers :: MonadIO m => [(ThreadId, a)] -> m ()
+stopWorkers :: MonadIO m => [(ThreadId, IORef WorkerState)] -> m ()
 stopWorkers workers =
-  forM_ workers $ \(threadId, _) -> liftIO $ killThread threadId
+  forM_ workers $ \(threadId, workerStateRef) -> do
+    workerState <- readIORef workerStateRef
+    liftIO $ mapM_ killThread (threadId : workerState.runningThreads)
 
 vtyConfig :: IO Config
 vtyConfig = do
@@ -274,14 +284,14 @@ monitor = do
         modify' $ \state -> state { events = state.events |> event }
 
         case campaignEvent of
-          WorkerEvent _ (NewCoverage { points, numCodehashes, corpusSize }) ->
+          WorkerEvent _ _ (NewCoverage { points, numCodehashes, corpusSize }) ->
             modify' $ \state ->
               state { coverage = max state.coverage points -- max not really needed
                     , corpusSize
                     , numCodehashes
                     , lastNewCov = time
                     }
-          WorkerEvent _ (WorkerStopped _) ->
+          WorkerEvent _ _ (WorkerStopped _) ->
             modify' $ \state ->
               state { workersAlive = state.workersAlive - 1
                     , timeStopped = if state.workersAlive == 1

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -30,8 +30,10 @@ import EVM.Solidity (SolcContract(..))
 import EVM.Types (W256, VM, VMType(Concrete), Addr, Expr (LitAddr))
 
 ppLogLine :: (LocalTime, CampaignEvent) -> String
-ppLogLine (time, event@(WorkerEvent workerId _)) =
+ppLogLine (time, event@(WorkerEvent workerId FuzzWorker _)) =
   timePrefix time <> "[Worker " <> show workerId <> "] " <> ppCampaignEvent event
+ppLogLine (time, event@(WorkerEvent workerId SymbolicWorker _)) =
+  timePrefix time <> "[Worker " <> show workerId <> ", symbolic] " <> ppCampaignEvent event
 ppLogLine (time, event) =
   timePrefix time <> " " <> ppCampaignEvent event
 

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -146,9 +146,13 @@ logPane uiState =
   foldl (<=>) emptyWidget (showLogLine <$> Seq.reverse uiState.events)
 
 showLogLine :: (LocalTime, CampaignEvent) -> Widget Name
-showLogLine (time, event@(WorkerEvent workerId _)) =
-  (withAttr (attrName "time") $ str $ (timePrefix time) <> "[Worker " <> show workerId <> "] ")
+showLogLine (time, event@(WorkerEvent workerId workerType _)) =
+  (withAttr (attrName "time") $ str $ (timePrefix time) <> "[Worker " <> show workerId <> symSuffix <> "] ")
     <+> strBreak (ppCampaignEvent event)
+  where
+  symSuffix = case workerType of
+    SymbolicWorker -> ", symbolic"
+    _ -> ""
 showLogLine (time, event) =
   (withAttr (attrName "time") $ str $ (timePrefix time) <> " ") <+> strBreak (ppCampaignEvent event)
 

--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,7 @@ ghc-options:
 dependencies:
   - base
   - aeson
+  - async
   - base16-bytestring
   - binary
   - bytestring

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -14,6 +14,7 @@ import Tests.Values (valuesTests)
 import Tests.Seed (seedTests)
 import Tests.Dapptest (dapptestTests)
 import Tests.Cheat (cheatTests)
+import Tests.Symbolic (symbolicTests)
 
 main :: IO ()
 main = withCurrentDirectory "./tests/solidity" . defaultMain $
@@ -32,4 +33,5 @@ main = withCurrentDirectory "./tests/solidity" . defaultMain $
            , dapptestTests
            , encodingJSONTests
            , cheatTests
+           , symbolicTests
            ]

--- a/src/test/Tests/Assertion.hs
+++ b/src/test/Tests/Assertion.hs
@@ -4,6 +4,8 @@ import Test.Tasty (TestTree, testGroup)
 
 import Common (testContract, testContract', testContractV, solcV, solved, solvedUsing, passed)
 
+import Echidna.Types.Campaign (WorkerType(..))
+
 assertionTests :: TestTree
 assertionTests = testGroup "Assertion-based Integration Testing"
   [
@@ -34,10 +36,10 @@ assertionTests = testGroup "Assertion-based Integration Testing"
       [ ("fail passed",     solvedUsing "fail" "AssertionFailed(..)")
       , ("f failed",         passed     "f")
       ]
-    , testContract' "assert/conf.sol" (Just "A") Nothing (Just "assert/multi.yaml") True
+    , testContract' "assert/conf.sol" (Just "A") Nothing (Just "assert/multi.yaml") True FuzzWorker
       [ ("c failed", passed "c") ]
 
-    , testContract' "assert/fullmath.sol" (Just "FullMathEchidnaTest") (Just (\v -> v == solcV (0,7,5))) (Just "assert/config.yaml") False
+    , testContract' "assert/fullmath.sol" (Just "FullMathEchidnaTest") (Just (\v -> v == solcV (0,7,5))) (Just "assert/config.yaml") False FuzzWorker
       [ ("checkMulDivRoundingUp failed", solved "checkMulDivRoundingUp") ]
 
   ]

--- a/src/test/Tests/Cheat.hs
+++ b/src/test/Tests/Cheat.hs
@@ -4,9 +4,11 @@ import Test.Tasty (TestTree, testGroup)
 
 import Common (testContract', solcV, solved)
 
+import Echidna.Types.Campaign (WorkerType(..))
+
 cheatTests :: TestTree
 cheatTests =
   testGroup "Cheatcodes Tests"
-    [ testContract' "cheat/ffi.sol" (Just "TestFFI") (Just (> solcV (0,6,0))) (Just "cheat/ffi.yaml") False
+    [ testContract' "cheat/ffi.sol" (Just "TestFFI") (Just (> solcV (0,6,0))) (Just "cheat/ffi.yaml") False FuzzWorker
         [ ("echidna_ffi passed", solved "echidna_ffi") ]
     ]

--- a/src/test/Tests/Coverage.hs
+++ b/src/test/Tests/Coverage.hs
@@ -10,7 +10,7 @@ coverageTests = testGroup "Coverage tests"
       -- single.sol is really slow and kind of unstable. it also messes up travis.
      -- testContract "coverage/single.sol"    (Just "coverage/test.yaml")
      -- [ ("echidna_state failed",                   solved      "echidna_state") ]
-     -- testContract' "coverage/multi.sol" Nothing Nothing (Just "coverage/test.yaml") False
+     -- testContract' "coverage/multi.sol" Nothing Nothing (Just "coverage/test.yaml") False False
      -- [ ("echidna_state3 failed",                  solved      "echidna_state3") ]
       testContract "coverage/boolean.sol"       (Just "coverage/boolean.yaml")
       [ ("echidna_true failed",                    passed     "echidna_true")

--- a/src/test/Tests/Dapptest.hs
+++ b/src/test/Tests/Dapptest.hs
@@ -4,9 +4,11 @@ import Test.Tasty (TestTree, testGroup)
 
 import Common (testContract', solcV, solved, passed)
 
+import Echidna.Types.Campaign (WorkerType(..))
+
 dapptestTests :: TestTree
 dapptestTests = testGroup "Dapptest Integration Testing"
-  [ testContract' "dapptest/basic.sol" (Just "GreeterTest") (Just (\v -> v >= solcV (0,7,5))) (Just "dapptest/config.yaml") False
+  [ testContract' "dapptest/basic.sol" (Just "GreeterTest") (Just (\v -> v >= solcV (0,7,5))) (Just "dapptest/config.yaml") False FuzzWorker
      [ 
         ("testShrinking passed", solved "testShrinking"),
         ("testFuzzFixedArray passed", solved "testFuzzFixedArray"),

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -5,6 +5,7 @@ import Test.Tasty (TestTree, testGroup)
 import Common (testContract, testContractV, solcV, testContract', checkConstructorConditions, passed, solved, solvedLen, solvedWith, solvedWithout, gasInRange)
 import Data.Functor ((<&>))
 import Data.Text (unpack)
+import Echidna.Types.Campaign (WorkerType(..))
 import Echidna.Types.Tx (TxCall(..))
 import EVM.ABI (AbiValue(..))
 
@@ -76,7 +77,7 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_construct passed",               solved      "echidna_construct") ]
   , testContract "basic/gasprice.sol"     (Just "basic/gasprice.yaml")
       [ ("echidna_state passed",                   solved      "echidna_state") ]
-  , testContract' "basic/allContracts.sol" (Just "B") Nothing (Just "basic/allContracts.yaml") True
+  , testContract' "basic/allContracts.sol" (Just "B") Nothing (Just "basic/allContracts.yaml") True FuzzWorker
       [ ("echidna_test passed",                    solved      "echidna_test") ]
   , testContract "basic/array-mutation.sol"   Nothing
       [ ("echidna_mutated passed",                 solved      "echidna_mutated") ]
@@ -97,9 +98,9 @@ integrationTests = testGroup "Solidity Integration Testing"
       "invalid codesize"
   , testContractV "basic/eip-170.sol" (Just (>= solcV (0,5,0))) (Just "basic/eip-170.yaml")
       [ ("echidna_test passed",                    passed      "echidna_test") ]
-  , testContract' "basic/deploy.sol" (Just "Test") Nothing (Just "basic/deployContract.yaml") True
+  , testContract' "basic/deploy.sol" (Just "Test") Nothing (Just "basic/deployContract.yaml") True FuzzWorker
       [ ("test passed",                    solved     "test") ]
-  , testContract' "basic/deploy.sol" (Just "Test") Nothing (Just "basic/deployBytecode.yaml") True
+  , testContract' "basic/deploy.sol" (Just "Test") Nothing (Just "basic/deployBytecode.yaml") True FuzzWorker
       [ ("test passed",                    solved     "test") ]
   , testContract "basic/flags.sol" (Just "basic/etheno-query-error.yaml")
       [] -- Just check if the etheno config does not crash Echidna

--- a/src/test/Tests/Research.hs
+++ b/src/test/Tests/Research.hs
@@ -4,15 +4,17 @@ import Test.Tasty (TestTree, testGroup)
 
 import Common (testContract, testContract', solcV, solved)
 
+import Echidna.Types.Campaign (WorkerType(..))
+
 researchTests :: TestTree
 researchTests = testGroup "Research-based Integration Testing"
   [ testContract "research/harvey_foo.sol" Nothing
       [ ("echidna_assert failed",     solved "echidna_assert") ]
-  , testContract' "research/harvey_baz.sol" Nothing Nothing Nothing False
+  , testContract' "research/harvey_baz.sol" Nothing Nothing Nothing False FuzzWorker
       [ ("echidna_all_states failed", solved "echidna_all_states") ]
-  , testContract' "research/ilf_crowdsale.sol" Nothing (Just (\v -> v >= solcV (0,5,0) && v < solcV (0,6,0))) (Just "research/ilf_crowdsale.yaml") False
+  , testContract' "research/ilf_crowdsale.sol" Nothing (Just (\v -> v >= solcV (0,5,0) && v < solcV (0,6,0))) (Just "research/ilf_crowdsale.yaml") False FuzzWorker
       [ ("echidna_assert failed", solved "withdraw") ]
-  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just (< solcV (0,6,0))) (Just "research/solcfuzz_funwithnumbers.yaml") True
+  , testContract' "research/solcfuzz_funwithnumbers.sol" (Just "VerifyFunWithNumbers") (Just (< solcV (0,6,0))) (Just "research/solcfuzz_funwithnumbers.yaml") True FuzzWorker
       [ ("echidna_assert failed", solved "sellTokens"),
         ("echidna_assert failed", solved "buyTokens")
       ]

--- a/src/test/Tests/Seed.hs
+++ b/src/test/Tests/Seed.hs
@@ -21,7 +21,7 @@ seedTests =
     ]
     where
     cfg s = defaultConfig
-      { campaignConf = CampaignConf
+      { campaignConf = defaultConfig.campaignConf
         { testLimit = 600
         , stopOnFail = False
         , estimateGas = False
@@ -39,6 +39,6 @@ seedTests =
       }
       & overrideQuiet
     gen s = do
-      (env, _) <- runContract "basic/flags.sol" Nothing (cfg s)
+      (env, _) <- runContract "basic/flags.sol" Nothing (cfg s) FuzzWorker
       readIORef env.testsRef
     same s t = (\x y -> ((.reproducer) <$> x) == ((.reproducer) <$> y)) <$> gen s <*> gen t

--- a/src/test/Tests/Symbolic.hs
+++ b/src/test/Tests/Symbolic.hs
@@ -1,0 +1,16 @@
+module Tests.Symbolic (symbolicTests) where
+
+import System.Info (os)
+import Test.Tasty (TestTree, testGroup)
+import Common (testContract', solved, passed)
+import Echidna.Types.Campaign (WorkerType(..))
+
+symbolicTests :: TestTree
+symbolicTests = testGroup "Symbolic tests" $ if os /= "linux" then [] else
+  [ testContract' "symbolic/sym.sol" Nothing Nothing (Just "symbolic/sym.yaml") True SymbolicWorker
+      [ ("echidna_sym passed", passed "echidna_sym") ]
+
+  , testContract' "symbolic/sym-assert.sol" Nothing Nothing (Just "symbolic/sym-assert.yaml") True SymbolicWorker
+      [ ("func_one passed", solved "func_one")
+      , ("func_two passed", solved "func_two") ]
+  ]

--- a/src/test/Tests/Symbolic.hs
+++ b/src/test/Tests/Symbolic.hs
@@ -1,12 +1,11 @@
 module Tests.Symbolic (symbolicTests) where
 
-import System.Info (os)
 import Test.Tasty (TestTree, testGroup)
 import Common (testContract', solved, passed)
 import Echidna.Types.Campaign (WorkerType(..))
 
 symbolicTests :: TestTree
-symbolicTests = testGroup "Symbolic tests" $ if os /= "linux" then [] else
+symbolicTests = testGroup "Symbolic tests"
   [ testContract' "symbolic/sym.sol" Nothing Nothing (Just "symbolic/sym.yaml") True SymbolicWorker
       [ ("echidna_sym passed", passed "echidna_sym") ]
 

--- a/src/test/Tests/Values.hs
+++ b/src/test/Tests/Values.hs
@@ -4,12 +4,14 @@ import Test.Tasty (TestTree, testGroup)
 
 import Common (testContract, testContract', solved, solvedLen)
 
+import Echidna.Types.Campaign (WorkerType(..))
+
 valuesTests :: TestTree
 valuesTests = testGroup "Value extraction tests"
   [ 
     testContract "values/nearbyMining.sol" Nothing
       [ ("echidna_findNearby passed", solved "echidna_findNearby") ]
-    , testContract' "values/smallValues.sol" Nothing Nothing (Just "coverage/test.yaml") False
+    , testContract' "values/smallValues.sol" Nothing Nothing (Just "coverage/test.yaml") False FuzzWorker
       [ ("echidna_findSmall passed", solved "echidna_findSmall") ]
     , testContract "values/constants.sol"    Nothing
       [ ("echidna_found failed",                   solved      "echidna_found")
@@ -20,15 +22,15 @@ valuesTests = testGroup "Value extraction tests"
       [ ("echidna_found_sender failed",            solved      "echidna_found_sender") ]
     , testContract "values/rconstants.sol"   Nothing
       [ ("echidna_found failed",                   solved      "echidna_found") ]
-    , testContract' "values/extreme.sol"   Nothing Nothing (Just "values/extreme.yaml") False
+    , testContract' "values/extreme.sol"   Nothing Nothing (Just "values/extreme.yaml") False FuzzWorker
       [ ("testMinInt8 passed",                   solved      "testMinInt8"),
         ("testMinInt16 passed",                  solved      "testMinInt16"),
         ("testMinInt64 passed",                  solved      "testMinInt32"),
         ("testMinInt128 passed",                 solved      "testMinInt128")
       ]
-    , testContract' "values/utf8.sol"   Nothing Nothing (Just "values/extreme.yaml") False
+    , testContract' "values/utf8.sol"   Nothing Nothing (Just "values/extreme.yaml") False FuzzWorker
       [ ("testNonUtf8 passed",                   solved      "testNonUTF8")]
-    , testContract' "values/create.sol" (Just "C") Nothing Nothing True
+    , testContract' "values/create.sol" (Just "C") Nothing Nothing True FuzzWorker
       [ ("echidna_state failed",                   solved      "echidna_state") ]
     , testContract "values/time.sol"         (Just "values/time.yaml")
       [ ("echidna_timepassed passed",              solved      "echidna_timepassed") ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,8 @@ packages:
 - '.'
 
 extra-deps:
-- git: https://github.com/ethereum/hevm.git
-  commit: a39b1c07a3f643330f920042eb94a43d7e6454b5
+- git: https://github.com/samalws-tob/hevm.git
+  commit: 0a2a7f24303a727b0e65ad2bb3a33ffe4d780a7d
 
 - restless-git-0.7@sha256:346a5775a586f07ecb291036a8d3016c3484ccdc188b574bcdec0a82c12db293,968
 - s-cargot-0.1.4.0@sha256:61ea1833fbb4c80d93577144870e449d2007d311c34d74252850bb48aa8c31fb,3525

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -93,15 +93,18 @@ workers: 1
 server: null
 # whether to add an additional symbolic execution worker
 symExec: false
-# timeout for symbolic execution SMT solver
+# whether symbolic execution will be concolic (vs full symbolic execution)
+# only relevant if symExec is true
+symExecConcolic: true
+# number of SMT solvers used in symbolic execution
 # only relevant if symExec is true
 symExecNSolvers: 1
-# number of SMT solvers used in symbolic execution
+# timeout for symbolic execution SMT solver
 # only relevant if symExec is true
 symExecTimeout: 30
 # Number of times we may revisit a particular branching point
-# only relevant if symExec is true
+# only relevant if symExec is true and symExecConcolic is false
 symExecMaxIters: 10
 # Number of times we may revisit a particular branching point before we consult the smt solver to check reachability
-# only relevant if symExec is true
+# only relevant if symExec is true and symExecConcolic is false
 symExecAskSMTIters: 1

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -91,3 +91,17 @@ rpcBlock: null
 workers: 1
 # events server port
 server: null
+# whether to add an additional symbolic execution worker
+symExec: false
+# timeout for symbolic execution SMT solver
+# only relevant if symExec is true
+symExecNSolvers: 1
+# number of SMT solvers used in symbolic execution
+# only relevant if symExec is true
+symExecTimeout: 30
+# Number of times we may revisit a particular branching point
+# only relevant if symExec is true
+symExecMaxIters: 10
+# Number of times we may revisit a particular branching point before we consult the smt solver to check reachability
+# only relevant if symExec is true
+symExecAskSMTIters: 1

--- a/tests/solidity/symbolic/sym-assert.sol
+++ b/tests/solidity/symbolic/sym-assert.sol
@@ -1,0 +1,15 @@
+contract VulnerableContract {
+    mapping (uint256 => uint256) a;
+    function func_one(uint256 x) public payable {
+        a[12323] = ((x >> 5) / 7777);
+        if (a[12323] == 2222) {
+            assert(false); // BUG
+        }
+    }
+
+    function func_two(uint256 x) public payable {
+        if ((x >> 5) / 7777 == 2222) {
+            assert(false); // BUG
+        }
+    }
+}

--- a/tests/solidity/symbolic/sym-assert.yaml
+++ b/tests/solidity/symbolic/sym-assert.yaml
@@ -1,0 +1,3 @@
+testMode: assertion
+symExec: true
+workers: 0

--- a/tests/solidity/symbolic/sym-assert.yaml
+++ b/tests/solidity/symbolic/sym-assert.yaml
@@ -1,3 +1,4 @@
 testMode: assertion
 symExec: true
+symExecConcolic: false
 workers: 0

--- a/tests/solidity/symbolic/sym.sol
+++ b/tests/solidity/symbolic/sym.sol
@@ -1,0 +1,21 @@
+contract VulnerableContract {
+    mapping (uint256 => uint256) a;
+    bool y;
+    bool z;
+    function func_one(uint256 x) public payable {
+        a[12323] = ((x >> 5) / 7777);
+        if (a[12323] == 2222) {
+            y = true;
+        }
+    }
+
+    function func_two(uint256 x) public payable {
+        if ((x >> 5) / 7777 == 2222) {
+            z = true;
+        }
+    }
+
+    function echidna_sym() public returns (bool) {
+        return !(y && z);
+    }
+}

--- a/tests/solidity/symbolic/sym.yaml
+++ b/tests/solidity/symbolic/sym.yaml
@@ -1,0 +1,2 @@
+symExec: true
+workers: 0

--- a/tests/solidity/symbolic/sym.yaml
+++ b/tests/solidity/symbolic/sym.yaml
@@ -1,2 +1,3 @@
 symExec: true
 workers: 0
+symExecConcolic: false


### PR DESCRIPTION
This PR is a continuation of #1030 and #1175. It adds a `symExec` configuration option which enables an extra symbolic execution worker, which runs alongside the existing fuzzing workers. This should allow for bugs which require very specific inputs to be caught more easily (see `tests/solidity/symbolic/sym.sol` for a fairly contrived example). Symbolic execution is mostly implemented by hevm; the bulk of this PR has to do with calling hevm's symbolic executor in the right way, and spawning a new worker to do this.
The sym exec worker runs at startup using the initial corpus, and also runs whenever a fuzz worker finds new coverage. It uses a queue to keep track of this. When the queue is empty, the worker is in a sleep mode waiting for more events to come in.
This PR also adds `symExecTimeout` and `symExecNSolvers` configuration options which allow for choosing the timeout and number of sym exec solvers (i.e. Z3 instances, I think). It's unclear what a good default value for these would be, so I just picked something that looks right (30 and 1, respectively).

This is meant to be an experimental feature, and this PR shouldn't affect users unless they explicitly enable `symExec`. It is turned off by default.