### PR TITLE
Adjust default GC allocation area

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -87,7 +87,9 @@ executables:
     main: Main.hs
     source-dirs: src/
     dependencies: echidna
-    ghc-options: -threaded -with-rtsopts=-N
+    ghc-options:
+      - -threaded
+      - '"-with-rtsopts=-A64m -N"'
     when:
       - condition: (os(linux) || os(windows)) && flag(static)
         ghc-options:


### PR DESCRIPTION
Experimentally, a value of between 32~64M appears to perform the best

https://downloads.haskell.org/ghc/latest/docs/users_guide/runtime_control.html#rts-flag--A%20%E2%9F%A8size%E2%9F%A9