### PR TITLE
ci, release: pin macOS runners to the correct architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-20.04
             shell: bash
             container: "{\"image\": \"elopeztob/alpine-haskell-stack-echidna:ghc-9.4.7\", \"options\": \"--user 1001\"}"
-          - os: macos-latest
+          - os: macos-13 # x86_64 macOS
             shell: bash
           - os: windows-latest
             shell: msys2 {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
             name: Linux (x86_64)
             tuple: x86_64-linux
             timeout: 180
-          - os: macos-latest
+          - os: macos-13
             name: macOS (x86_64)
             tuple: x86_64-macos
-          - os: macos-latest-xlarge
+          - os: macos-14
             name: macOS (aarch64)
             tuple: aarch64-macos
     steps:


### PR DESCRIPTION
`macos-latest` and `macos-14` are now `aarch64`: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources