### PR TITLE
Emit log message when saving reproducers

### DIFF
--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -23,6 +23,7 @@ saveTxs dir = mapM_ saveTxSeq where
   saveTxSeq txSeq = do
     createDirectoryIfMissing True dir
     let file = dir </> (show . abs . hash . show) txSeq <.> "txt"
+    putStrLn ("Saving reproducer to " ++ file)
     unlessM (doesFileExist file) $ encodeFile file (toJSON txSeq)
 
 loadTxs :: FilePath -> IO [(FilePath, [Tx])]


### PR DESCRIPTION
Fixes #1179
One problem with this: sometimes this message should be prefaced with a \n and sometimes it shouldn't. Example:
```
[2024-06-12 14:08:43.07] Saving corpus... Saving reproducer to asdf/coverage/9205690443874393131.txt
Done! (0.042806s)
```
Should be:
```
[2024-06-12 14:08:43.07] Saving corpus...
Saving reproducer to asdf/coverage/9205690443874393131.txt
Done! (0.042806s)
```
Any suggestions for how to do this in a consistent way are appreciated