### PR TITLE
Docs improvement

### DIFF
--- a/.github/container-linux-static/README.md
+++ b/.github/container-linux-static/README.md
@@ -4,5 +4,5 @@ This container is used as part of `.github/workflows/ci.yml` to produce
 statically-linked amd64 linux builds of Echidna. It is based on the following
 container produced by FP Complete and maintained in the
 [`fpco/alpine-haskell-stack`](https://github.com/fpco/alpine-haskell-stack/tree/ghc927)
-repository, and contains a few extra dependencies and configuration to make it
+repository, and contains a few extra dependencies and configurations to make it
 suitable for the GitHub Actions environment.

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -211,7 +211,7 @@ addChars c b = foldM withR b . enumFromTo 0 =<< rand where
 addNulls :: MonadRandom m => ByteString -> m ByteString
 addNulls = addChars $ pure 0
 
--- | Given a \"list-y\" structure with analogues of 'take', 'drop', and 'length',
+-- | Given a \"list-y\" structure with analogs of 'take', 'drop', and 'length',
 -- remove some elements at random.
 shrinkWith
   :: MonadRandom m

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -371,7 +371,7 @@ callseq vm txSeq = do
 
   where
   -- Given a list of transactions and a return typing rule, checks whether we
-  -- know the return type for each function called. If yes, tries to parse the
+  -- know the return type for each function called. If yes, try to parse the
   -- return value as a value of that type. Returns a 'GenDict' style Map.
   returnValues
     :: [(Tx, VMResult Concrete RealWorld)]

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -127,7 +127,7 @@ execTxWith executeTx tx = do
                     fromEVM (continuation contract)
                     liftIO $ atomicWriteIORef cacheRef $ Map.insert addr (Just contract) cache
                   _ -> do
-                    -- TODO: better error reporting in HEVM, when intermmittent
+                    -- TODO: better error reporting in HEVM, when intermittent
                     -- network error then retry
                     liftIO $ atomicWriteIORef cacheRef $ Map.insert addr Nothing cache
                     logMsg $ "ERROR: Failed to fetch contract: " <> show q

--- a/lib/Echidna/Mutator/Array.hs
+++ b/lib/Echidna/Mutator/Array.hs
@@ -15,7 +15,7 @@ listMutators = fromList
 -- | Mutate a list-like data structure using a list of mutators
 mutateLL
   :: (LL.ListLike f i, MonadRandom m)
-  -- | Required size for the mutated list-like value (or Nothing if there are no constrains)
+  -- | Required size for the mutated list-like value (or Nothing if there are no constraints)
   => Maybe Int
   -- | Randomly generated list-like value to complement the mutated list, if it is
   -- shorter than the requested size

--- a/lib/Echidna/Onchain.hs
+++ b/lib/Echidna/Onchain.hs
@@ -99,7 +99,7 @@ toFetchedContractData contract =
     }
 
 -- | Try to load the persisted RPC cache.
--- TODO: we use the corpus dir for now, think where to place it
+-- TODO: we use the corpus dir for now, think about where to place it
 loadRpcCache :: Env -> IO ()
 loadRpcCache Env { cfg, fetchContractCache, fetchSlotCache } =
   case cfg.campaignConf.corpusDir of

--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -49,7 +49,7 @@ saveCorpusEvent env (_time, campaignEvent) = do
 
     getEventInfo = \case
       -- TODO: We save intermediate reproducers in separate directories.
-      -- This is to because there can be a lot of them and we want to skip
+      -- This is because there can be a lot of them and we want to skip
       -- loading those on startup. Ideally, we should override the same file
       -- with a better version of a reproducer, this is smaller or more optimized.
       TestFalsified test -> Just ("reproducers-unshrunk", test.reproducer)

--- a/lib/Echidna/Types/Coverage.hs
+++ b/lib/Echidna/Types/Coverage.hs
@@ -31,7 +31,7 @@ type TxResults = Word64
 
 -- | Given good point coverage, count the number of unique points but
 -- only considering the different instruction PCs (discarding the TxResult).
--- This is useful to report a coverage measure to the user
+-- This is useful for reporting a coverage measure to the user
 scoveragePoints :: CoverageMap -> IO Int
 scoveragePoints cm = do
   sum <$> mapM (V.foldl' countCovered 0) (Map.elems cm)

--- a/lib/Echidna/Types/Solidity.hs
+++ b/lib/Echidna/Types/Solidity.hs
@@ -50,7 +50,7 @@ instance Show SolException where
     ConstructorArgs s      -> "Constructor arguments are required: " ++ s
     NoCryticCompile        -> "crytic-compile not installed or not found in PATH. To install it, run:\n   pip install crytic-compile"
     InvalidMethodFilters f -> "Applying the filter " ++ show f ++ " to the methods produces an empty list. Are you filtering the correct functions using `filterFunctions` or fuzzing the correct contract?"
-    SetUpCallFailed        -> "Calling the setUp() function failed (revert, out-of-gas, sending ether to an non-payable constructor, etc.)"
+    SetUpCallFailed        -> "Calling the setUp() function failed (revert, out-of-gas, sending ether to a non-payable constructor, etc.)"
     DeploymentFailed a t   -> "Deploying the contract " ++ show a ++ " failed (revert, out-of-gas, sending ether to an non-payable constructor, etc.):\n" ++ unpack t
     OutdatedSolcVersion v  -> "Solc version " ++ toString v ++ " detected. Echidna doesn't support versions of solc before " ++ toString minSupportedSolcVersion ++ ". Please use a newer version."
 

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -218,7 +218,7 @@ catNoCalls (tx1:tx2:xs) =
       _                -> tx1 : catNoCalls (tx2:xs)
   where nc = tx1 { delay = (fst tx1.delay + fst tx2.delay, snd tx1.delay + snd tx2.delay) }  
 
--- | Transform a VMResult into a more hash friendly sum type
+-- | Transform a VMResult into a more hash-friendly sum type
 getResult :: VMResult Concrete s -> TxResult
 getResult = \case
   VMSuccess b | forceBuf b == encodeAbiValue (AbiBool True)  -> ReturnTrue

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -59,7 +59,7 @@ ppCampaign vm workerStates = do
     , seedPrinted
     ]
 
--- | Given rules for pretty-printing associated address, and whether to print
+-- | Given rules for pretty-printing associated addresses, and whether to print
 -- them, pretty-print a 'Transaction'.
 ppTx :: MonadReader Env m => VM Concrete RealWorld -> Bool -> Tx -> m String
 ppTx _ _ Tx { call = NoCall, delay } =


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.