### PR TITLE
Show gas per second in the UI

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -137,6 +137,7 @@ runSymWorker callback vm dict workerId initialCorpus name cs = do
                 , newCoverage = False
                 , ncallseqs = 0
                 , ncalls = 0
+                , totalGas = 0
                 , runningThreads = []
                 }
 
@@ -213,6 +214,7 @@ runFuzzWorker callback vm world dict workerId initialCorpus testLimit = do
                   , newCoverage = False
                   , ncallseqs = 0
                   , ncalls = 0
+                  , totalGas = 0
                   , runningThreads = []
                   }
 
@@ -453,6 +455,7 @@ evalSeq vm0 execFunc = go vm0 [] where
       [] -> pure ([], vm)
       (tx:remainingTxs) -> do
         (result, vm') <- execFunc vm tx
+        modify' $ \workerState -> workerState { totalGas = workerState.totalGas + fromIntegral (vm'.burned - vm.burned) }
         -- NOTE: we don't use the intermediate VMs, just the last one. If any of
         -- the intermediate VMs are needed, they can be put next to the result
         -- of each transaction - `m ([(Tx, result, VM)])`

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -168,6 +168,8 @@ data WorkerState = WorkerState
     -- ^ Number of times the callseq is called
   , ncalls      :: !Int
     -- ^ Number of calls executed while fuzzing
+  , totalGas    :: !Int
+    -- ^ Total gas consumed while fuzzing
   , runningThreads :: [ThreadId]
     -- ^ Extra threads currently being run,
     --   aside from the main worker thread
@@ -181,6 +183,7 @@ initialWorkerState =
               , newCoverage = False
               , ncallseqs = 0
               , ncalls = 0
+              , totalGas = 0
               , runningThreads = []
               }
 

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -173,6 +173,8 @@ summaryWidget env uiState =
       <=>
       perfWidget uiState
       <=>
+      gasPerfWidget uiState
+      <=>
       str ("Total calls: " <> progress (sum $ (.ncalls) <$> uiState.campaigns)
                                      env.cfg.campaignConf.testLimit)
   middle =
@@ -230,6 +232,18 @@ perfWidget uiState =
        else "-"
   where
   totalCalls = sum $ (.ncalls) <$> uiState.campaigns
+  totalTime = round $
+    diffLocalTime (fromMaybe uiState.now uiState.timeStopped)
+                  uiState.timeStarted
+
+gasPerfWidget :: UIState -> Widget n
+gasPerfWidget uiState =
+  str $ "Gas/s: " <>
+    if totalTime > 0
+       then show $ totalGas `div` totalTime
+       else "-"
+  where
+  totalGas = sum $ (.totalGas) <$> uiState.campaigns
   totalTime = round $
     diffLocalTime (fromMaybe uiState.now uiState.timeStopped)
                   uiState.timeStarted


### PR DESCRIPTION
This will help for determining performance. We keep track of gas consumption after each transaction call, rather than after each instruction: hevm handles the bookkeeping at the instruction level. Should have a very minimal effect on performance, since hevm already keeps track of gas consumption strictly: `burned :: !(Gas t)` (hevm/src/EVM/Types.hs:620).

I'm unsure whether we should be keeping track of totalGas as an Int or as hevm's native Gas type. One way or another we need to cast to a different type to display it onscreen. In any case this choice is only a minor issue