### PR TITLE
Fix MVar issue

### DIFF
--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -99,7 +99,7 @@ ui vm world dict initialCorpus cliSelectedContract cs = do
     Interactive -> do
       -- Channel to push events to update UI
       uiChannel <- liftIO $ newBChan 1000
-      let forwardEvent = writeBChan uiChannel . EventReceived
+      let forwardEvent = void . writeBChanNonBlocking uiChannel . EventReceived
       uiEventsForwarderStopVar <- spawnListener forwardEvent
 
       ticker <- liftIO . forkIO . forever $ do


### PR DESCRIPTION
This `writeBChan` was getting stuck when echidna was ctrl-c'd in some circumstances, causing an MVar error. This PR replaces it with `writeBChanNonBlocking`. This may affect UI behavior in theory, but the queue size is 1000 so it should be fine.

May fix #1266, #1219, #1209