### PR TITLE
Minor change for symExecTimeout comments

### DIFF
--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -51,7 +51,7 @@ data CampaignConf = CampaignConf
     -- Only relevant if symExec is True
   , symExecTargets     :: Maybe [Text]
   , symExecTimeout     :: Int
-    -- ^ Timeout for symbolic execution SMT solver.
+    -- ^ Timeout for symbolic execution SMT solver queries.
     -- Only relevant if symExec is True
   , symExecNSolvers    :: Int
     -- ^ Number of SMT solvers used in symbolic execution.

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -101,7 +101,7 @@ symExecConcolic: true
 # number of SMT solvers used in symbolic execution
 # only relevant if symExec is true
 symExecNSolvers: 1
-# timeout for symbolic execution SMT solver
+# timeout for symbolic execution SMT solver queries
 # only relevant if symExec is true
 symExecTimeout: 30
 # Number of times we may revisit a particular branching point


### PR DESCRIPTION
As pointed out in #1216 :
> `symExecTimeout` is actually per query in Z3 (but global in other solvers, afaik), I think it is better to clarify that.
