### PR TITLE
Add support for unlimited tests

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -261,7 +261,7 @@ runFuzzWorker callback vm dict workerId initialCorpus testLimit = do
          shrink >> lift callback >> run
 
        -- no shrinking work, fuzz
-       | (null tests || any isOpen tests) && ncalls < testLimit ->
+       | (null tests || any isOpen tests) && (ncalls < testLimit || testLimit <= 0) ->
          fuzz >> lift callback >> run
 
        -- NOTE: this is a hack which forces shrinking of optimization tests


### PR DESCRIPTION
This makes `--test-limit 0` run indefinitely, in line with medusa's behavior.