### PR TITLE
docker: build multi-platform container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,10 +12,21 @@ env:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            os: ubuntu-24.04-arm
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Prepare
+        run: |
+          echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+        env:
+          PLATFORM: "${{ matrix.platform }}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -35,6 +46,14 @@ jobs:
             type=ref,event=branch,prefix=testing-
             type=edge
 
+      - name: Extract image names (Ubuntu & NVM variant)
+        id: name-ubuntu
+        run: |
+          {
+            echo -n "name="
+            jq -cr '.tags | map(split(":")[0]) | unique | join(",")' <<< "$DOCKER_METADATA_OUTPUT_JSON"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Set Docker metadata (Distroless variant)
         id: meta-distroless
         uses: docker/metadata-action@v5
@@ -45,6 +64,15 @@ jobs:
             type=ref,event=tag
             type=ref,event=branch,prefix=testing-
             type=edge
+
+      - name: Extract image names (Distroless variant)
+        id: name-distroless
+        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
+        run: |
+          {
+            echo -n "name="
+            jq -cr '.tags | map(split(":")[0]) | unique | join(",")' <<< "$DOCKER_METADATA_OUTPUT_JSON"
+          } >> "$GITHUB_OUTPUT"
 
       - name: GitHub Container Registry Login
         uses: docker/login-action@v3
@@ -62,13 +90,13 @@ jobs:
 
       - name: Docker Build and Push (Ubuntu & NVM variant)
         uses: docker/build-push-action@v6
+        id: build-ubuntu
         with:
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           target: final-ubuntu
           file: docker/Dockerfile
           pull: true
-          push: true
-          tags: ${{ steps.meta-ubuntu.outputs.tags }}
+          outputs: type=image,"name=${{ steps.name-ubuntu.outputs.name }}",push-by-digest=true,push=true
           labels: ${{ steps.meta-ubuntu.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -76,13 +104,114 @@ jobs:
       - name: Docker Build and Push (Distroless variant)
         uses: docker/build-push-action@v6
         if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
+        id: build-distroless
         with:
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           target: final-distroless
           file: docker/Dockerfile
           pull: true
-          push: true
-          tags: ${{ steps.meta-distroless.outputs.tags }}
+          outputs: type=image,"name=${{ steps.name-distroless.outputs.name }}",push-by-digest=true,push=true
           labels: ${{ steps.meta-distroless.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests/ubuntu" "$RUNNER_TEMP/digests/distroless"
+          touch "$RUNNER_TEMP/digests/ubuntu/${DIGEST_UBUNTU#sha256:}"
+          touch "$RUNNER_TEMP/digests/distroless/${DIGEST_DISTROLESS#sha256:}"
+        env:
+          DIGEST_UBUNTU: "${{ steps.build-ubuntu.outputs.digest }}"
+          DIGEST_DISTROLESS: "${{ steps.build-distroless.outputs.digest }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - docker
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: GitHub Container Registry Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Hub Login
+        uses: docker/login-action@v3
+        if: github.repository == 'crytic/echidna'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set Docker metadata (Ubuntu & NVM variant)
+        id: meta-ubuntu
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/echidna
+            name=trailofbits/echidna,enable=${{ github.repository == 'crytic/echidna' }}
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch,prefix=testing-
+            type=edge
+
+      - name: Create manifest list and push (Ubuntu & NVM variant)
+        working-directory: ${{ runner.temp }}/digests/ubuntu
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "$IMAGE_NAME@sha256:%s " *)
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}/echidna
+
+      - name: Inspect image (Ubuntu & NVM variant)
+        run: |
+          docker buildx imagetools inspect "$IMAGE_NAME:$VERSION"
+        env:
+          IMAGE_NAME: "ghcr.io/${{ github.repository }}/echidna"
+          VERSION: "${{ steps.meta-ubuntu.outputs.version }}"
+
+      - name: Set Docker metadata (Distroless variant)
+        id: meta-distroless
+        uses: docker/metadata-action@v5
+        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
+        with:
+          images: ghcr.io/${{ github.repository }}/distroless
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch,prefix=testing-
+            type=edge
+
+      - name: Create manifest list and push (Distroless variant)
+        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
+        working-directory: ${{ runner.temp }}/digests/distroless
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "$IMAGE_NAME@sha256:%s " *)
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}/distroless
+
+      - name: Inspect image
+        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
+        run: |
+          docker buildx imagetools inspect "$IMAGE_NAME:$VERSION"
+        env:
+          IMAGE_NAME: "ghcr.io/${{ github.repository }}/distroless"
+          VERSION: "${{ steps.meta-distroless.outputs.version }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,9 +7,6 @@ on:
     tags:
       - '*'
 
-env:
-  WORKFLOW_BUILD_DISTROLESS: false
-
 jobs:
   build:
     name: build ${{ matrix.platform }} container
@@ -55,26 +52,6 @@ jobs:
             jq -cr '.tags | map(split(":")[0]) | unique | join(",")' <<< "$DOCKER_METADATA_OUTPUT_JSON"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Set Docker metadata (Distroless variant)
-        id: meta-distroless
-        uses: docker/metadata-action@v5
-        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
-        with:
-          images: ghcr.io/${{ github.repository }}/distroless
-          tags: |
-            type=ref,event=tag
-            type=ref,event=branch,prefix=testing-
-            type=edge
-
-      - name: Extract image names (Distroless variant)
-        id: name-distroless
-        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
-        run: |
-          {
-            echo -n "name="
-            jq -cr '.tags | map(split(":")[0]) | unique | join(",")' <<< "$DOCKER_METADATA_OUTPUT_JSON"
-          } >> "$GITHUB_OUTPUT"
-
       - name: GitHub Container Registry Login
         uses: docker/login-action@v3
         with:
@@ -102,28 +79,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Docker Build and Push (Distroless variant)
-        uses: docker/build-push-action@v6
-        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
-        id: build-distroless
-        with:
-          platforms: ${{ matrix.platform }}
-          target: final-distroless
-          file: docker/Dockerfile
-          pull: true
-          outputs: type=image,"name=${{ steps.name-distroless.outputs.name }}",push-by-digest=true,push=true
-          labels: ${{ steps.meta-distroless.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       - name: Export digest
         run: |
-          mkdir -p "$RUNNER_TEMP/digests/ubuntu" "$RUNNER_TEMP/digests/distroless"
+          mkdir -p "$RUNNER_TEMP/digests/ubuntu"
           touch "$RUNNER_TEMP/digests/ubuntu/${DIGEST_UBUNTU#sha256:}"
-          touch "$RUNNER_TEMP/digests/distroless/${DIGEST_DISTROLESS#sha256:}"
         env:
           DIGEST_UBUNTU: "${{ steps.build-ubuntu.outputs.digest }}"
-          DIGEST_DISTROLESS: "${{ steps.build-distroless.outputs.digest }}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
@@ -189,31 +150,3 @@ jobs:
         env:
           IMAGE_NAME: "ghcr.io/${{ github.repository }}/echidna"
           VERSION: "${{ steps.meta-ubuntu.outputs.version }}"
-
-      - name: Set Docker metadata (Distroless variant)
-        id: meta-distroless
-        uses: docker/metadata-action@v5
-        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
-        with:
-          images: ghcr.io/${{ github.repository }}/distroless
-          tags: |
-            type=ref,event=tag
-            type=ref,event=branch,prefix=testing-
-            type=edge
-
-      - name: Create manifest list and push (Distroless variant)
-        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
-        working-directory: ${{ runner.temp }}/digests/distroless
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf "$IMAGE_NAME@sha256:%s " *)
-        env:
-          IMAGE_NAME: ghcr.io/${{ github.repository }}/distroless
-
-      - name: Inspect image
-        if: ${{ env.WORKFLOW_BUILD_DISTROLESS == true }}
-        run: |
-          docker buildx imagetools inspect "$IMAGE_NAME:$VERSION"
-        env:
-          IMAGE_NAME: "ghcr.io/${{ github.repository }}/distroless"
-          VERSION: "${{ steps.meta-distroless.outputs.version }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,8 @@ env:
   WORKFLOW_BUILD_DISTROLESS: false
 
 jobs:
-  docker:
+  build:
+    name: build ${{ matrix.platform }} container
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -133,9 +134,10 @@ jobs:
           retention-days: 1
 
   merge:
+    name: merge containers
     runs-on: ubuntu-latest
     needs:
-      - docker
+      - build
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This enables aarch64 builds for our Docker container image. These can then be used on e.g. M1 Macs or ARM runners to get good performance.