### PR TITLE
Quote paths on logging output

### DIFF
--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -88,7 +88,7 @@ compileContracts solConf fp = do
       stderr <- if solConf.quiet
                    then UseHandle <$> openFile nullFilePath WriteMode
                    else pure Inherit
-      (ec, out, err) <- measureIO solConf.quiet ("Compiling " <> x) $ do
+      (ec, out, err) <- measureIO solConf.quiet ("Compiling `" <> x <> "`") $ do
         readCreateProcessWithExitCode
           (proc path $ (solConf.cryticArgs ++ solargs) |> x) {std_err = stderr} ""
       case ec of

--- a/lib/Echidna/SourceAnalysis/Slither.hs
+++ b/lib/Echidna/SourceAnalysis/Slither.hs
@@ -161,7 +161,7 @@ runSlither fp solConf = if solConf.disableSlither
     Just path -> do
       let args = ["--ignore-compile", "--print", "echidna", "--json", "-"]
                  ++ solConf.cryticArgs ++ [fp]
-      (exitCode, out, err) <- measureIO solConf.quiet ("Running slither on " <> fp) $
+      (exitCode, out, err) <- measureIO solConf.quiet ("Running slither on `" <> fp <> "`") $
         readCreateProcessWithExitCode (proc path args) {std_err = Inherit} ""
       case exitCode of
         ExitSuccess ->


### PR DESCRIPTION
When paths are wrapped in quotes, it makes them easier to distinguish.

  > Compiling `.`... Done! (4.216295s)
  > Running slither on `.`... Done! (4.548446s)

Fixes: #1225