### PR TITLE
Show which project is currently being fuzzed

### DIFF
--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -57,6 +57,7 @@ instance FromJSON EConfigWithUsage where
               <*> v ..:? "rpcUrl"
               <*> v ..:? "rpcBlock"
               <*> v ..:? "etherscanApiKey"
+              <*> v ..:? "projectName"
       where
       useKey k = modify' $ Set.insert k
       x ..:? k = useKey k >> lift (x .:? k)

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -46,6 +46,7 @@ data EConfig = EConfig
   , rpcUrl :: Maybe Text
   , rpcBlock :: Maybe Word64
   , etherscanApiKey :: Maybe Text
+  , projectName :: Maybe Text
   }
 
 instance Read OutputFormat where

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -113,7 +113,7 @@ campaignStatus uiState = do
   mainbox inner underneath = do
     env <- ask
     pure $ hCenter . hLimit 160 $
-      joinBorders $ borderWithLabel echidnaTitle $
+      joinBorders $ borderWithLabel (echidnaTitle env.cfg.projectName) $
       summaryWidget env uiState
       <=>
       (if uiState.displayTestsPane then
@@ -131,11 +131,14 @@ campaignStatus uiState = do
       else emptyWidget)
       <=>
       underneath
-  echidnaTitle =
-    str "[ " <+>
-    withAttr (attrName "title")
-      (str $ "Echidna " <> showVersion Paths_echidna.version) <+>
-    str " ]"
+  echidnaTitle projectName =
+    let projectTitle = case projectName of
+          Just name -> " (" <> T.unpack name <> ")"
+          Nothing -> ""
+    in str "[ " <+>
+       withAttr (attrName "title")
+         (str $ "Echidna " <> showVersion Paths_echidna.version <> projectTitle) <+>
+       str " ]"
   finalStatus s = hBorder <=> hCenter (bold $ str s)
 
 logPane :: UIState -> Widget Name

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -15,6 +15,7 @@ import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Time.Clock.System (getSystemTime, systemSeconds)
 import Data.Version (showVersion)
 import Data.Word (Word8, Word16, Word64)
@@ -54,6 +55,8 @@ main = withUtf8 $ withCP65001 $ do
   EConfigWithUsage loadedCfg ks _ <-
     maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig cliConfigFilepath
   cfg <- overrideConfig loadedCfg opts
+
+  printProjectName cfg.projectName
 
   unless cfg.solConf.quiet $
     forM_ ks $ hPutStrLn stderr . ("Warning: unused option: " ++) . Aeson.Key.toString
@@ -288,3 +291,8 @@ overrideConfig config Options{..} = do
       , testMode = maybe solConf.testMode validateTestMode cliTestMode
       , allContracts = cliAllContracts || solConf.allContracts
       }
+
+printProjectName :: Maybe Text -> IO ()
+printProjectName (Just name) = putStrLn $
+    "This is Echidna " <> showVersion version <> " running on project `" <> T.unpack name <> "`"
+printProjectName Nothing = pure ()

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -1,4 +1,6 @@
 # TODO
+#a friendly name to identify what is being fuzzed. Shown next to the echidna version in the UI
+projectName: null
 #select the mode to test, which can be property, assertion, overflow, exploration, optimization
 testMode: "property"
 #check if some contract was destructed or not


### PR DESCRIPTION
This adds a new configuration option, `projectName`, to allow people to distinguish different Echidna runs from each other.

Closes: #833