### PR TITLE
Speed up coverage filename calculation

### DIFF
--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -24,8 +24,9 @@ saveTxs env dir = mapM_ saveTxSeq where
   saveTxSeq txSeq = do
     createDirectoryIfMissing True dir
     let file = dir </> (show . abs . hash) txSeq <.> "txt"
-    unlessM (doesFileExist file) $ encodeFile file (toJSON txSeq)
-    pushCampaignEvent env (ReproducerSaved file)
+    unlessM (doesFileExist file) $ do
+      encodeFile file (toJSON txSeq)
+      pushCampaignEvent env (ReproducerSaved file)
 
 loadTxs :: FilePath -> IO [(FilePath, [Tx])]
 loadTxs dir = do

--- a/lib/Echidna/Output/Corpus.hs
+++ b/lib/Echidna/Output/Corpus.hs
@@ -23,7 +23,7 @@ saveTxs :: Env -> FilePath -> [[Tx]] -> IO ()
 saveTxs env dir = mapM_ saveTxSeq where
   saveTxSeq txSeq = do
     createDirectoryIfMissing True dir
-    let file = dir </> (show . abs . hash . show) txSeq <.> "txt"
+    let file = dir </> (show . abs . hash) txSeq <.> "txt"
     unlessM (doesFileExist file) $ encodeFile file (toJSON txSeq)
     pushCampaignEvent env (ReproducerSaved file)
 

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -14,7 +14,9 @@ import Data.Aeson (FromJSON, ToJSON, parseJSON, toJSON, object, withObject, (.=)
 import Data.Aeson.TH (deriveJSON, defaultOptions)
 import Data.Aeson.Types (Parser)
 import Data.ByteString (ByteString)
+import Data.Hashable (Hashable(..))
 import Data.Text (Text)
+import Data.Vector (Vector, toList)
 import Data.Word (Word64)
 
 import EVM.ABI (encodeAbiValue, AbiValue(..), AbiType)
@@ -66,6 +68,16 @@ data Tx = Tx
   , value :: !W256         -- ^ Value
   , delay :: !(W256, W256) -- ^ (Time, # of blocks since last call)
   } deriving (Eq, Ord, Show, Generic)
+
+instance Hashable a => Hashable (Vector a) where
+  hashWithSalt s v = s `hashWithSalt` toList v
+
+deriving instance Hashable Tx
+deriving instance Hashable TxCall
+deriving instance Hashable AbiValue
+deriving instance Hashable AbiType
+deriving anyclass instance Hashable Addr
+deriving anyclass instance Hashable W256
 
 deriving instance NFData Tx
 deriving instance NFData TxCall

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -93,7 +93,7 @@ main = withUtf8 $ withCP65001 $ do
                 (results, finalVM) <- reproduceTest vm test
                 let subdir = dir </> "reproducers-traces"
                 liftIO $ createDirectoryIfMissing True subdir
-                let file = subdir </> (show . abs . hash . show) test.reproducer <.> "txt"
+                let file = subdir </> (show . abs . hash) test.reproducer <.> "txt"
                 txsPrinted <- ppFailWithTraces Nothing finalVM results
                 liftIO $ writeFile file (ppTestName test <> ": " <> txsPrinted)
 


### PR DESCRIPTION
Don't show and then hash; instead, compute hash directly.