### PR TITLE
Enable onlyDeployed and updated hevm

### DIFF
--- a/lib/Echidna/SymExec/Exploration.hs
+++ b/lib/Echidna/SymExec/Exploration.hs
@@ -105,7 +105,7 @@ exploreContract contract method vm = do
   let iterConfig = IterConfig { maxIter = maxIters, askSmtIters = askSmtIters, loopHeuristic = Naive}
   let veriOpts = defaultVeriOpts {iterConf = iterConfig, rpcInfo = rpcInfo}
   let isNonInteractive = conf.uiConf.operationMode == NonInteractive Text
-  let runtimeEnv = defaultEnv { config = defaultConfig { maxWidth = 5, maxDepth = maxExplore, maxBufSize = 12, promiseNoReent = True, debug = isNonInteractive, dumpQueries = False, numCexFuzz = 100 } }
+  let runtimeEnv = defaultEnv { config = defaultConfig { maxWidth = 5, maxDepth = maxExplore, maxBufSize = 12, promiseNoReent = True, onlyDeployed = True, debug = isNonInteractive, dumpQueries = False, numCexFuzz = 100 } }
   pushWorkerEvent $ SymExecLog ("Exploring " <> (show method.name))
   liftIO $ flip runReaderT runtimeEnv $ withSolvers conf.campaignConf.symExecSMTSolver (fromIntegral conf.campaignConf.symExecNSolvers) 1 timeoutSMT $ \solvers -> do
     threadId <- liftIO $ forkIO $ flip runReaderT runtimeEnv $ do

--- a/lib/Echidna/SymExec/Verification.hs
+++ b/lib/Echidna/SymExec/Verification.hs
@@ -43,7 +43,7 @@ verifyMethod method contract vm = do
   let iterConfig = IterConfig { maxIter = maxIters, askSmtIters = askSmtIters, loopHeuristic = Naive}
   let veriOpts = defaultVeriOpts {iterConf = iterConfig, rpcInfo = rpcInfo}
   let isNonInteractive = conf.uiConf.operationMode == NonInteractive Text
-  let runtimeEnv = defaultEnv { config = defaultConfig { maxWidth = 5, maxDepth = maxExplore, maxBufSize = 12, promiseNoReent = False, debug = isNonInteractive, numCexFuzz = 100 } }
+  let runtimeEnv = defaultEnv { config = defaultConfig { maxWidth = 5, maxDepth = maxExplore, maxBufSize = 12, promiseNoReent = False, onlyDeployed = True, debug = isNonInteractive, numCexFuzz = 100 } }
   pushWorkerEvent $ SymExecLog ("Verifying " <> (show method.name))
   
   liftIO $ flip runReaderT runtimeEnv $ withSolvers conf.campaignConf.symExecSMTSolver (fromIntegral conf.campaignConf.symExecNSolvers) 1 timeoutSMT $ \solvers -> do

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/ethereum/hevm.git
-  commit: 9982c580ed19b88ebab9744d29d940fd2f0bd8c6
+  commit: 1aa4c5dfdd32281063aa86e9ee610397301b42d3
 
 - smt2-parser-0.1.0.1@sha256:1e1a4565915ed851c13d1e6b8bb5185cf5d454da3b43170825d53e221f753d77,1421
 - spawn-0.3@sha256:b91e01d8f2b076841410ae284b32046f91471943dc799c1af77d666c72101f02,1162


### PR DESCRIPTION
Echidna needs to enabled the new `onlyDeployed` option in order to get correct results when an address is symbolic (and it has some constraints). However, there is some issue compared to hevm, and we currently don´t know why it works in a different way: https://github.com/ethereum/hevm/issues/828. Once that's solved, a unit case should be added here and this is ready to go.