### PR TITLE
docker: update base image; build with musl; include z3, bitwuzla

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ You can get further information in the [`echidna` Homebrew Formula](https://form
 If you prefer to use a pre-built Docker container, check out our [docker
 package](https://github.com/orgs/crytic/packages?repo_name=echidna), which is
 auto-built via GitHub Actions. The `echidna` container is based on
-`ubuntu:focal` and it is meant to be a small yet flexible enough image to use
+`ubuntu:noble` and it is meant to be a small yet flexible enough image to use
 Echidna on. It provides a pre-built version of `echidna`, as well as
 `slither`, `crytic-compile`, `solc-select` and `nvm` under 200 MB.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal AS builder-echidna
+FROM ubuntu:noble AS builder-echidna
 ENV LD_LIBRARY_PATH=/usr/local/lib PREFIX=/usr/local HOST_OS=Linux
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
@@ -19,16 +19,42 @@ RUN .github/scripts/install-libff.sh
 RUN stack upgrade && stack setup && stack install --flag echidna:static --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
 
 
-FROM ubuntu:focal AS builder-python3
+FROM ubuntu:noble AS builder-python3
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
         gcc \
-        python3.8-dev \
-        python3.8-venv
+        python3 \
+        python3.12-dev \
+        python3.12-venv
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PIP_NO_CACHE_DIR=1
 RUN python3 -m venv /venv && /venv/bin/pip3 install --no-cache --upgrade setuptools pip
 RUN /venv/bin/pip3 install --no-cache slither-analyzer solc-select
+
+
+FROM ubuntu:noble AS builder-solvers
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
+        unzip \
+        ca-certificates \
+        curl
+RUN mkdir /solvers/
+RUN if [ $(uname -m) = "aarch64" ]; then \
+        curl -fsSL -o z3.zip https://github.com/Z3Prover/z3/releases/download/z3-4.15.2/z3-4.15.2-arm64-glibc-2.34.zip; \
+    elif [ $(uname -m) = "x86_64" ]; then \
+        curl -fsSL -o z3.zip https://github.com/Z3Prover/z3/releases/download/z3-4.15.2/z3-4.15.2-x64-glibc-2.39.zip; \
+    fi && \
+    unzip z3.zip && \
+    cp -a z3-*/* /solvers/ && \
+    rm -rf z3-*/ z3.zip
+RUN if [ $(uname -m) = "aarch64" ]; then \
+        curl -fsSL -o bitwuzla.zip https://github.com/bitwuzla/bitwuzla/releases/download/0.8.2/Bitwuzla-Linux-arm64-static.zip; \
+    elif [ $(uname -m) = "x86_64" ]; then \
+        curl -fsSL -o bitwuzla.zip https://github.com/bitwuzla/bitwuzla/releases/download/0.8.2/Bitwuzla-Linux-x86_64-static.zip; \
+    fi && \
+    unzip bitwuzla.zip && \
+    cp -a Bitwuzla-*/* /solvers/ && \
+    rm -rf Bitwuzla-*/ bitwuzla.zip
 
 
 FROM gcr.io/distroless/python3-debian11:nonroot AS final-distroless
@@ -39,16 +65,16 @@ ENV PATH="$PATH:/venv/bin"
 ENTRYPOINT [ "/usr/local/bin/solc-install", "/usr/local/bin/echidna" ]
 
 
-FROM ubuntu:focal AS final-ubuntu
+FROM ubuntu:noble AS final-ubuntu
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
         ca-certificates \
         curl \
         python3 \
-        python3-distutils \
         && \
     rm -rf /var/lib/apt/lists/*
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+COPY --from=builder-solvers /solvers/bin/z3 /solvers/bin/bitwuzla /usr/local/bin/
 COPY --from=builder-echidna /root/.local/bin/echidna /usr/local/bin/echidna
 RUN ln -s /usr/local/bin/echidna /usr/local/bin/echidna-test
 COPY --from=builder-python3 /venv /venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,24 @@
-FROM ubuntu:noble AS builder-echidna
-ENV LD_LIBRARY_PATH=/usr/local/lib PREFIX=/usr/local HOST_OS=Linux
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-suggests --no-install-recommends \
+FROM docker.io/benz0li/ghc-musl:9.8.4 AS builder-echidna
+# https://gitlab.com/benz0li/ghc-musl
+
+RUN apk upgrade --no-cache &&\
+    apk add --no-cache \
+        autoconf \
+        automake \
+        binutils-gold \
         cmake \
-        curl \
-        git \
-        libbz2-dev \
-        libgmp-dev \
-        libreadline-dev \
-        libsecp256k1-dev \
-        libssl-dev \
-        software-properties-common \
-        sudo
-RUN curl -sSL https://get.haskellstack.org/ | sh
+        libtool
+
+RUN mkdir -p /etc/stack &&\
+    { echo "system-ghc: true" ;\
+      echo "install-ghc: false" ;\
+      echo "skip-ghc-check: true" ;\
+    } >> /etc/stack/config.yaml
+
+ENV LD_LIBRARY_PATH=/usr/local/lib PREFIX=/usr/local HOST_OS=Linux
 COPY . /echidna/
 WORKDIR /echidna
+RUN .github/scripts/install-libsecp256k1.sh
 RUN .github/scripts/install-libff.sh
 RUN stack upgrade && stack setup && stack install --flag echidna:static --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
 


### PR DESCRIPTION
This PR does the following:
* Updates the base image to Ubuntu noble (from focal)
* Starts shipping static musl binaries in the container instead of glibc ones
* Includes z3 and bitwuzla in the container