### PR TITLE
Add independent coverage directory configuration option

### DIFF
--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -95,6 +95,7 @@ instance FromJSON EConfigWithUsage where
         <*> v ..:? "seed"
         <*> v ..:? "dictFreq" ..!= 0.40
         <*> v ..:? "corpusDir" ..!= Nothing
+        <*> v ..:? "coverageDir" ..!= Nothing
         <*> v ..:? "mutConsts" ..!= defaultMutationConsts
         <*> v ..:? "coverageFormats" ..!= [Txt,Html,Lcov]
         <*> v ..:? "workers"

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -31,6 +31,8 @@ data CampaignConf = CampaignConf
     -- ^ Frequency for the use of dictionary values in the random transactions
   , corpusDir          :: Maybe FilePath
     -- ^ Directory to load and save lists of transactions
+  , coverageDir        :: Maybe FilePath
+    -- ^ Directory to save coverage reports
   , mutConsts          :: MutationConsts Integer
     -- ^ Mutation constants for fuzzing
   , coverageFormats    :: [CoverageFileType]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -101,7 +101,7 @@ main = withUtf8 $ withCP65001 $ do
         corpus <- readIORef env.corpusRef
         saveTxs env (dir </> "coverage") (snd <$> Set.toList corpus)
 
-  -- save coverage reports (now using separate directory)
+  -- save coverage reports
   let coverageDir = cfg.campaignConf.coverageDir <|> cfg.campaignConf.corpusDir
   case coverageDir of
     Nothing -> pure ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -101,20 +101,21 @@ main = withUtf8 $ withCP65001 $ do
         corpus <- readIORef env.corpusRef
         saveTxs env (dir </> "coverage") (snd <$> Set.toList corpus)
 
-      -- TODO: We use the corpus dir to save coverage reports which is confusing.
-      -- Add config option to pass dir for saving coverage report and decouple it
-      -- from corpusDir.
-      unless (null cfg.campaignConf.coverageFormats) $ measureIO cfg.solConf.quiet "Saving coverage" $ do
-        -- We need runId to have a unique directory to save files under so they
-        -- don't collide with the next runs. We use the current time for this
-        -- as it orders the runs chronologically.
-        runId <- fromIntegral . systemSeconds <$> getSystemTime
+  -- save coverage reports (now using separate directory)
+  let coverageDir = cfg.campaignConf.coverageDir <|> cfg.campaignConf.corpusDir
+  case coverageDir of
+    Nothing -> pure ()
+    Just dir -> unless (null cfg.campaignConf.coverageFormats) $ measureIO cfg.solConf.quiet "Saving coverage" $ do
+      -- We need runId to have a unique directory to save files under so they
+      -- don't collide with the next runs. We use the current time for this
+      -- as it orders the runs chronologically.
+      runId <- fromIntegral . systemSeconds <$> getSystemTime
 
-        Onchain.saveCoverageReport env runId
+      Onchain.saveCoverageReport env runId
 
-        -- save source coverage reports
-        let contracts = Map.elems env.dapp.solcByName
-        saveCoverages env runId dir buildOutput.sources contracts
+      -- save source coverage reports
+      let contracts = Map.elems env.dapp.solcByName
+      saveCoverages env runId dir buildOutput.sources contracts
 
   if isSuccessful tests then exitSuccess else exitWith (ExitFailure 1)
 
@@ -126,6 +127,7 @@ data Options = Options
   , cliConfigFilepath   :: Maybe FilePath
   , cliOutputFormat     :: Maybe OutputFormat
   , cliCorpusDir        :: Maybe FilePath
+  , cliCoverageDir      :: Maybe FilePath
   , cliTestMode         :: Maybe TestMode
   , cliAllContracts     :: Bool
   , cliTimeout          :: Maybe Int
@@ -179,7 +181,10 @@ options = Options . NE.fromList
     <> help "Output format. Either 'json', 'text', 'none'. All these disable interactive UI")
   <*> optional (option str $ long "corpus-dir"
     <> metavar "PATH"
-    <> help "Directory to save and load corpus and coverage data.")
+    <> help "Directory to save and load corpus data.")
+  <*> optional (option str $ long "coverage-dir"
+    <> metavar "PATH"
+    <> help "Directory to save coverage reports. Defaults to corpus-dir if not specified.")
   <*> optional (option str $ long "test-mode"
     <> help "Test mode to use. Either 'property', 'assertion', 'dapptest', 'optimization', 'overflow' or 'exploration'" )
   <*> switch (long "all-contracts"
@@ -269,6 +274,7 @@ overrideConfig config Options{..} = do
 
     overrideCampaignConf campaignConf = campaignConf
       { corpusDir = cliCorpusDir <|> campaignConf.corpusDir
+      , coverageDir = cliCoverageDir <|> campaignConf.coverageDir
       , testLimit = fromMaybe campaignConf.testLimit cliTestLimit
       , shrinkLimit = fromMaybe campaignConf.shrinkLimit cliShrinkLimit
       , seqLen = fromMaybe campaignConf.seqLen cliSeqLen

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -19,7 +19,6 @@ module Common
   , overrideQuiet
   , loadSolTests
   , checkCoverageUsesCorpusDir
-  , checkEffectiveCoverageDir
   ) where
 
 import Test.Tasty (TestTree)
@@ -39,7 +38,6 @@ import Data.Maybe (isJust)
 import Data.SemVer (Version, version, fromText)
 import Data.Text (Text, pack)
 import System.Process (readProcess)
-import Control.Applicative ((<|>))
 
 import EVM.Solidity (Contracts(..), BuildOutput(..), SolcContract(..))
 import EVM.Types hiding (Env, Gas)
@@ -260,10 +258,3 @@ checkCoverageUsesCorpusDir expectedCorpusDir (env, _) = do
   case (env.cfg.campaignConf.corpusDir, env.cfg.campaignConf.coverageDir) of
     (Just corpusDir, Nothing) -> pure $ corpusDir == expectedCorpusDir
     _ -> pure False
-
--- | Check that the effective coverage directory matches the expected path.
--- This tests the actual fallback logic: coverageDir <|> corpusDir.
-checkEffectiveCoverageDir :: FilePath -> (Env, WorkerState) -> IO Bool
-checkEffectiveCoverageDir expectedDir (env, _) = do
-  let effectiveDir = env.cfg.campaignConf.coverageDir <|> env.cfg.campaignConf.corpusDir
-  pure $ effectiveDir == Just expectedDir

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -12,7 +12,7 @@ import Echidna.Types.Config (EConfigWithUsage(..), EConfig(..))
 import Echidna.Types.Campaign (CampaignConf(..))
 import Echidna.Types.Tx (TxConf(..))
 import Echidna.Config (defaultConfig, parseConfig)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, isNothing)
 
 configTests :: TestTree
 configTests = testGroup "Configuration tests" $
@@ -35,11 +35,11 @@ configTests = testGroup "Configuration tests" $
   , testCase "coverageDir fallback to corpusDir" $ do
       config <- (.econfig) <$> parseConfig "basic/corpus-fallback-test.yaml"
       assertBool "corpusDir should be set" $ config.campaignConf.corpusDir == Just "test-corpus"
-      assertBool "coverageDir should not be set" $ config.campaignConf.coverageDir == Nothing
+      assertBool "coverageDir should not be set" $ isNothing (config.campaignConf.coverageDir)
   , testCase "corpusDir defaults to Nothing" $
-      assertBool "" $ defaultConfig.campaignConf.corpusDir == Nothing
+      assertBool "" $ isNothing (defaultConfig.campaignConf.corpusDir)
   , testCase "coverageDir defaults to Nothing" $
-      assertBool "" $ defaultConfig.campaignConf.coverageDir == Nothing
+      assertBool "" $ isNothing (defaultConfig.campaignConf.coverageDir)
   , testCase "default.yaml" $ do
       EConfigWithUsage _ bad unset <- parseConfig "basic/default.yaml"
       assertBool ("unused options: " ++ show bad) $ null bad

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -22,6 +22,24 @@ configTests = testGroup "Configuration tests" $
       assertBool "" $ isJust config.campaignConf.knownCoverage
   , testCase "coverage enabled by default" $
       assertBool "" $ isJust defaultConfig.campaignConf.knownCoverage
+  , testCase "parse corpusDir" $ do
+      config <- (.econfig) <$> parseConfig "research/bran_bar.yaml"
+      assertBool "" $ config.campaignConf.corpusDir == Just "corpus"
+  , testCase "parse coverageDir" $ do
+      config <- (.econfig) <$> parseConfig "basic/coverage-test.yaml"
+      assertBool "" $ config.campaignConf.coverageDir == Just "coverage-reports"
+  , testCase "corpusDir and coverageDir independent" $ do
+      config <- (.econfig) <$> parseConfig "basic/coverage-test.yaml"
+      assertBool "corpusDir should be set" $ config.campaignConf.corpusDir == Just "corpus-data"
+      assertBool "coverageDir should be set" $ config.campaignConf.coverageDir == Just "coverage-reports"
+  , testCase "coverageDir fallback to corpusDir" $ do
+      config <- (.econfig) <$> parseConfig "basic/corpus-fallback-test.yaml"
+      assertBool "corpusDir should be set" $ config.campaignConf.corpusDir == Just "test-corpus"
+      assertBool "coverageDir should not be set" $ config.campaignConf.coverageDir == Nothing
+  , testCase "corpusDir defaults to Nothing" $
+      assertBool "" $ defaultConfig.campaignConf.corpusDir == Nothing
+  , testCase "coverageDir defaults to Nothing" $
+      assertBool "" $ defaultConfig.campaignConf.coverageDir == Nothing
   , testCase "default.yaml" $ do
       EConfigWithUsage _ bad unset <- parseConfig "basic/default.yaml"
       assertBool ("unused options: " ++ show bad) $ null bad
@@ -38,4 +56,4 @@ configTests = testGroup "Configuration tests" $
         Right (_ :: EConfigWithUsage) -> assertFailure "should not decode"
         Left _ -> pure ()
   ]
-  where files = ["basic/config.yaml", "basic/default.yaml"]
+  where files = ["basic/config.yaml", "basic/default.yaml", "basic/coverage-test.yaml", "basic/corpus-fallback-test.yaml"]

--- a/src/test/Tests/Coverage.hs
+++ b/src/test/Tests/Coverage.hs
@@ -2,7 +2,7 @@ module Tests.Coverage (coverageTests) where
 
 import Test.Tasty (TestTree, testGroup)
 
-import Common (testContract, passed, countCorpus)
+import Common (testContract, passed, countCorpus, checkCoverageUsesCorpusDir, checkEffectiveCoverageDir)
 
 coverageTests :: TestTree
 coverageTests = testGroup "Coverage tests"
@@ -15,5 +15,15 @@ coverageTests = testGroup "Coverage tests"
       testContract "coverage/boolean.sol"       (Just "coverage/boolean.yaml")
       [ ("echidna_true failed",                    passed     "echidna_true")
       , ("unexpected corpus count ",               countCorpus 1)]
+
+  -- Test corpus and coverage directory functionality
+  , testContract "basic/revert.sol"              (Just "basic/coverage-test.yaml")
+      [ ("corpus count",                           countCorpus 1)
+      , ("uses coverageDir when set",              checkEffectiveCoverageDir "coverage-reports")]
+
+  -- Test coverage fallback to corpus directory
+  , testContract "basic/revert.sol"              (Just "basic/corpus-fallback-test.yaml")
+      [ ("uses corpusDir for coverage",           checkCoverageUsesCorpusDir "test-corpus")
+      , ("fallback to corpusDir",                 checkEffectiveCoverageDir "test-corpus")]
 
   ]

--- a/src/test/Tests/Coverage.hs
+++ b/src/test/Tests/Coverage.hs
@@ -2,7 +2,7 @@ module Tests.Coverage (coverageTests) where
 
 import Test.Tasty (TestTree, testGroup)
 
-import Common (testContract, passed, countCorpus, checkCoverageUsesCorpusDir, checkEffectiveCoverageDir)
+import Common (testContract, passed, countCorpus, checkCoverageUsesCorpusDir)
 
 coverageTests :: TestTree
 coverageTests = testGroup "Coverage tests"
@@ -18,12 +18,10 @@ coverageTests = testGroup "Coverage tests"
 
   -- Test corpus and coverage directory functionality
   , testContract "basic/revert.sol"              (Just "basic/coverage-test.yaml")
-      [ ("corpus count",                           countCorpus 1)
-      , ("uses coverageDir when set",              checkEffectiveCoverageDir "coverage-reports")]
+      [ ("corpus count",                           countCorpus 1)]
 
   -- Test coverage fallback to corpus directory
   , testContract "basic/revert.sol"              (Just "basic/corpus-fallback-test.yaml")
-      [ ("uses corpusDir for coverage",           checkCoverageUsesCorpusDir "test-corpus")
-      , ("fallback to corpusDir",                 checkEffectiveCoverageDir "test-corpus")]
+      [ ("uses corpusDir for coverage",           checkCoverageUsesCorpusDir "test-corpus")]
 
   ]

--- a/tests/solidity/basic/corpus-fallback-test.yaml
+++ b/tests/solidity/basic/corpus-fallback-test.yaml
@@ -1,0 +1,7 @@
+# Test configuration for coverage fallback to corpus directory
+testMode: "property"
+testLimit: 100
+corpusDir: "test-corpus"
+# coverageDir is intentionally not set to test fallback behavior
+coverageFormats: ["txt", "html"]
+quiet: true

--- a/tests/solidity/basic/coverage-test.yaml
+++ b/tests/solidity/basic/coverage-test.yaml
@@ -1,0 +1,7 @@
+# Test configuration for coverage directory functionality
+testMode: "property"
+testLimit: 100
+corpusDir: "corpus-data"
+coverageDir: "coverage-reports"
+coverageFormats: ["txt", "html"]
+quiet: true

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -77,6 +77,8 @@ filterBlacklist: true
 allowFFI: false
 #directory to save the corpus; by default is disabled
 corpusDir: null
+#directory to save coverage reports; by default is disabled
+coverageDir: null
 # list of file formats to save coverage reports in; default is all possible formats
 coverageFormats: ["txt","html","lcov"]
 # constants for corpus mutations (for experimentation only)


### PR DESCRIPTION
This PR adds a new `coverageDir` configuration option that allows users to specify a separate directory for saving coverage reports, independent from the corpus directory.

Previously, coverage reports were saved to the corpus directory, which mixed different types of output files. This PR introduces a dedicated configuration option with automatic fallback to maintain backward compatibility.

**Usage Example**
```yaml
corpusDir: "corpus-xyz"
coverageDir: "coverage-xyz"
```