### PR TITLE
docs: fix incorrect Docker volume mount command

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ something like the following command. It will map the current directory as
 `echidna`:
 
 ```sh
-$ docker run --rm -it -v `pwd`:/src ghcr.io/crytic/echidna/echidna
+$ docker run --rm -it -v "$(pwd)":/src ghcr.io/crytic/echidna/echidna
 ```
 
 Otherwise, if you want to locally build the latest version of Echidna, we
@@ -241,7 +241,7 @@ Then, you can run the `echidna` image locally. For example, to install solc
 0.5.7 and check `tests/solidity/basic/flags.sol`, you can run:
 
 ```sh
-$ docker run -it -v `pwd`:/src echidna bash -c "solc-select install 0.5.7 && solc-select use 0.5.7 && echidna /src/tests/solidity/basic/flags.sol"
+$ docker run -it -v "$(pwd)":/src echidna bash -c "solc-select install 0.5.7 && solc-select use 0.5.7 && echidna /src/tests/solidity/basic/flags.sol"
 ```
 
 ### Building using Stack


### PR DESCRIPTION
noticed that the provided Docker commands don’t work as written because `pwd` is treated as a literal directory name instead of being evaluated. this makes the examples unusable out of the box.

changed `-v pwd:/src` → `-v "$(pwd)":/src` so that the current path is correctly mounted.

both affected commands are updated - now they run as expected without errors.