### PR TITLE
Added initial support for generation of foundry reproducers

### DIFF
--- a/lib/Echidna/Output/Foundry.hs
+++ b/lib/Echidna/Output/Foundry.hs
@@ -21,12 +21,12 @@ foundryTestHeader = unlines
   , ""
   ]
 
-foundryTestBody :: Maybe Text -> String -> EchidnaTest -> String
-foundryTestBody mContractName reproducerHash test =
+foundryTestBody :: Maybe Text -> EchidnaTest -> String
+foundryTestBody mContractName test =
   case test.testType of
     AssertionTest{} ->
       let
-        contractName = "Test." ++ reproducerHash
+        contractName = "Test"
         senders = nub $ map (.src) test.reproducer
         actors = foundryActors senders
         repro = foundryReproducer test
@@ -35,7 +35,7 @@ foundryTestBody mContractName reproducerHash test =
         [ "contract " ++ contractName ++ " is Test {"
         , actors
         , "    // TODO: Replace with your actual contract instance"
-        , "    " ++ cName ++ " Tester;"
+        , "    " ++ cName ++ " Target;"
         , ""
         , "  function setUp() public {"
         , "      // TODO: Initialize your contract here"
@@ -67,8 +67,8 @@ foundryActor sender i = "    address constant USER" ++ show i ++ " = " ++ format
 formatAddr :: Addr -> String
 formatAddr addr = "address(0x" ++ showHex (fromIntegral addr :: W256) "" ++ ")"
 
-foundryTest :: Maybe Text -> String -> EchidnaTest -> String
-foundryTest mContractName reproducerHash test = foundryTestHeader ++ foundryTestBody mContractName reproducerHash test
+foundryTest :: Maybe Text -> EchidnaTest -> String
+foundryTest mContractName test = foundryTestHeader ++ foundryTestBody mContractName test
 
 foundryReproducer :: EchidnaTest -> String
 foundryReproducer test = unlines $ map foundryTx test.reproducer
@@ -79,7 +79,7 @@ foundryTx tx =
     SolCall (name, args) ->
       let
         sender = "_setUpActor(address(0x" ++ showHex (fromIntegral tx.src :: W256) "" ++ "));"
-        call = "Tester." ++ unpack name ++ "(" ++ foundryArgs (map abiValueToString args) ++ ");"
+        call = "Target." ++ unpack name ++ "(" ++ foundryArgs (map abiValueToString args) ++ ");"
       in "    " ++ sender ++ "\n" ++ "    " ++ call
     _ -> ""
 

--- a/lib/Echidna/Output/Foundry.hs
+++ b/lib/Echidna/Output/Foundry.hs
@@ -1,0 +1,100 @@
+module Echidna.Output.Foundry where
+
+import Data.List (nub)
+import Data.Text (Text, unpack)
+import Data.Text.Encoding (decodeUtf8)
+import Data.Vector as V hiding ((++), map, zipWith)
+import EVM.ABI (AbiValue(..))
+import Echidna.ABI ()
+import EVM.Types (W256, Addr)
+import Numeric (showHex)
+
+import Echidna.Types.Test (EchidnaTest(..), TestType(..), getAssertionFunctionName)
+import Echidna.Types.Tx (Tx(..), TxCall(..))
+
+foundryTestHeader :: String
+foundryTestHeader = unlines
+  [ "// SPDX-License-Identifier: Unlicense"
+  , "pragma solidity ^0.8.0;"
+  , ""
+  , "import \"forge-std/Test.sol\";"
+  , ""
+  ]
+
+foundryTestBody :: Maybe Text -> EchidnaTest -> String
+foundryTestBody mContractName test =
+  case test.testType of
+    AssertionTest{} ->
+      let
+        testName = getAssertionFunctionName test
+        contractName = "Test" ++ testName
+        senders = nub $ map (.src) test.reproducer
+        actors = foundryActors senders
+        repro = foundryReproducer test
+        cName = maybe "YourContract" unpack mContractName
+      in unlines
+        [ "contract " ++ contractName ++ " is Test {"
+        , actors
+        , "    // TODO: Replace with your actual contract instance"
+        , "    " ++ cName ++ " Tester;"
+        , ""
+        , "  function setUp() public {"
+        , "      // TODO: Initialize your contract here"
+        , "      Tester = new " ++ cName ++ "();"
+        , "  }"
+        , ""
+        , "  function test" ++ testName ++ "() public {"
+        , repro
+        , "  }"
+        , ""
+        , "  function _setUpActor(address actor) internal {"
+        , "      vm.startPrank(actor);"
+        , "      // Add any additional actor setup here if needed"
+        , "  }"
+        , ""
+        , "  function _delay(uint256 timeInSeconds) internal {"
+        , "      vm.warp(block.timestamp + timeInSeconds);"
+        , "  }"
+        , "}"
+        ]
+    _ -> ""
+
+foundryActors :: [Addr] -> String
+foundryActors senders = unlines $ zipWith foundryActor senders [1..]
+
+foundryActor :: Addr -> Int -> String
+foundryActor sender i = "    address constant USER" ++ show i ++ " = " ++ formatAddr sender ++ ";"
+
+formatAddr :: Addr -> String
+formatAddr addr = "address(0x" ++ showHex (fromIntegral addr :: W256) "" ++ ")"
+
+foundryTest :: Maybe Text -> EchidnaTest -> String
+foundryTest mContractName test = foundryTestHeader ++ foundryTestBody mContractName test
+
+foundryReproducer :: EchidnaTest -> String
+foundryReproducer test = unlines $ map foundryTx test.reproducer
+
+foundryTx :: Tx -> String
+foundryTx tx =
+  case tx.call of
+    SolCall (name, args) ->
+      let
+        sender = "_setUpActor(address(0x" ++ showHex (fromIntegral tx.src :: W256) "" ++ "));"
+        call = "Tester." ++ unpack name ++ "(" ++ foundryArgs (map abiValueToString args) ++ ");"
+      in "    " ++ sender ++ "\n" ++ "    " ++ call
+    _ -> ""
+
+foundryArgs :: [String] -> String
+foundryArgs [] = ""
+foundryArgs [x] = x
+foundryArgs (x:xs) = x ++ ", " ++ foundryArgs xs
+
+abiValueToString :: AbiValue -> String
+abiValueToString (AbiUInt _ w) = show w
+abiValueToString (AbiInt _ w) = show w
+abiValueToString (AbiAddress a) = "address(0x" ++ showHex (fromIntegral a :: W256) "" ++ ")"
+abiValueToString (AbiBool b) = if b then "true" else "false"
+abiValueToString (AbiBytes _ bs) = "hex\"" ++ unpack (decodeUtf8 bs) ++ "\""
+abiValueToString (AbiString s) = show s
+abiValueToString (AbiTuple vs) = "(" ++ foundryArgs (map abiValueToString (V.toList vs)) ++ ")"
+abiValueToString _ = ""

--- a/lib/Echidna/Output/Foundry.hs
+++ b/lib/Echidna/Output/Foundry.hs
@@ -33,7 +33,7 @@ foundryTest mContractName test =
       in fromStrict $ substituteValue template (toMustache testData)
     _ -> ""
 
--- | Create an Aeson Value from test data for the Moustache template.
+-- | Create an Aeson Value from test data for the Mustache template.
 createTestData :: Maybe Text -> EchidnaTest -> Value
 createTestData mContractName test =
   let

--- a/lib/Echidna/Output/assets/foundry.mustache
+++ b/lib/Echidna/Output/assets/foundry.mustache
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+contract {{testName}} is Test {
+{{#actors}}
+    address constant {{name}} = {{address}};
+{{/actors}}
+
+    // TODO: Replace with your actual contract instance
+    {{contractName}} Target;
+
+  function setUp() public {
+      // TODO: Initialize your contract here
+      Target = new {{contractName}}();
+  }
+
+  function test_replay() public {
+{{#reproducer}}
+    {{{ . }}}
+{{/reproducer}}
+  }
+
+  function _setUpActor(address actor) internal {
+      vm.startPrank(actor);
+      // Add any additional actor setup here if needed
+  }
+
+  function _delay(uint256 timeInSeconds) internal {
+      vm.warp(block.timestamp + timeInSeconds);
+  }
+}

--- a/lib/Echidna/Output/assets/foundry.mustache
+++ b/lib/Echidna/Output/assets/foundry.mustache
@@ -18,7 +18,8 @@ contract {{testName}} is Test {
 
   function test_replay() public {
 {{#reproducer}}
-    {{{ . }}}
+    {{{prelude}}}
+    {{{call}}}
 {{/reproducer}}
   }
 
@@ -27,7 +28,8 @@ contract {{testName}} is Test {
       // Add any additional actor setup here if needed
   }
 
-  function _delay(uint256 timeInSeconds) internal {
+  function _delay(uint256 timeInSeconds, uint256 numBlocks) internal {
       vm.warp(block.timestamp + timeInSeconds);
+      vm.roll(block.number + numBlocks);
   }
 }

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -16,6 +16,7 @@ import Data.Maybe (fromMaybe, isJust)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Time.Clock.System (getSystemTime, systemSeconds)
 import Data.Version (showVersion)
 import Data.Word (Word8, Word16, Word64)
@@ -116,7 +117,7 @@ main = withUtf8 $ withCP65001 $ do
                 reproducerHash = (show . abs . hash) test.reproducer
                 fileName = foundryDir </> "Test." ++ reproducerHash <.> "sol"
                 content = foundryTest cliSelectedContract test
-              liftIO $ writeFile fileName content
+              liftIO $ writeFile fileName (TL.unpack content)
             _ -> pure ()
 
       -- TODO: We use the corpus dir to save coverage reports which is confusing.

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -45,7 +45,7 @@ import Echidna.Test (reproduceTest, validateTestMode)
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Solidity
-import Echidna.Types.Test (TestMode, EchidnaTest(..), TestType(..), TestState(..), getAssertionFunctionName)
+import Echidna.Types.Test (TestMode, EchidnaTest(..), TestType(..), TestState(..))
 import Echidna.UI
 import Echidna.UI.Report (ppFailWithTraces, ppTestName)
 import Echidna.Utility (measureIO)
@@ -109,15 +109,15 @@ main = withUtf8 $ withCP65001 $ do
           case (test.testType, test.state) of
             (AssertionTest{}, Solved) -> do
               let
-                testName = getAssertionFunctionName test
-                fileName = foundryDir </> "Test" ++ testName <.> "sol"
-                content = foundryTest cliSelectedContract test
+                reproducerHash = (show . abs . hash) test.reproducer
+                fileName = foundryDir </> "Test" ++ reproducerHash <.> "sol"
+                content = foundryTest cliSelectedContract reproducerHash test
               liftIO $ writeFile fileName content
             (AssertionTest{}, Large _) -> do
               let
-                testName = getAssertionFunctionName test
-                fileName = foundryDir </> "Test" ++ testName <.> "sol"
-                content = foundryTest cliSelectedContract test
+                reproducerHash = (show . abs . hash) test.reproducer
+                fileName = foundryDir </> "Test" ++ reproducerHash <.> "sol"
+                content = foundryTest cliSelectedContract reproducerHash test
               liftIO $ writeFile fileName content
             _ -> pure ()
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -120,7 +120,6 @@ main = withUtf8 $ withCP65001 $ do
               liftIO $ writeFile fileName (TL.unpack content)
             _ -> pure ()
 
-      -- TODO: We use the corpus dir to save coverage reports which is confusing.
 
   -- save coverage reports
   let coverageDir = cfg.campaignConf.coverageDir <|> cfg.campaignConf.corpusDir


### PR DESCRIPTION
This PR add a basic support for the generation of Foundry reproducers, with the code inspired by [Runes](https://github.com/Enigma-Dark/runes).