### PR TITLE
[Do Not Merge] Avoid crashing when cheatcode is invalid

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,8 +5,8 @@ packages:
 - '.'
 
 extra-deps:
-- git: https://github.com/argotorg/hevm.git
-  commit: 9982c580ed19b88ebab9744d29d940fd2f0bd8c6
+- git: https://github.com/gustavo-grieco/hevm.git
+  commit: 149a4d6aea7ca4dcb1add73c1f752fced8ab5140 
 
 - smt2-parser-0.1.0.1@sha256:1e1a4565915ed851c13d1e6b8bb5185cf5d454da3b43170825d53e221f753d77,1421
 - spawn-0.3@sha256:b91e01d8f2b076841410ae284b32046f91471943dc799c1af77d666c72101f02,1162


### PR DESCRIPTION
A draft PR with the fix from hevm applied from my branch for testing. It should not crash with invalid cheatcodes.