### PR TITLE
fix: ppAbiValue mapping in JSON.mapCall for SolCall

### DIFF
--- a/lib/Echidna/Output/JSON.hs
+++ b/lib/Echidna/Output/JSON.hs
@@ -144,6 +144,6 @@ mapTest dappInfo test =
 
   mapCall = \case
     SolCreate _          -> ("<CREATE>", Nothing)
-    SolCall (name, args) -> (name, Just $ ppAbiValue <$> mempty <*> args)
+    SolCall (name, args) -> (name, Just $ ppAbiValue mempty <$> args)
     NoCall               -> ("*wait*", Nothing)
     SolCalldata x        -> (decodeUtf8 $ "0x" <> BS16.encode x, Nothing)


### PR DESCRIPTION
Replace incorrect applicative usage ppAbiValue <$> mempty <*> args with ppAbiValue mempty <$> args. The previous form attempted to fmap over mempty as a Functor, producing a type mismatch and not actually applying labels. The corrected code explicitly applies an empty label map to ppAbiValue and maps over the AbiValue list, aligning with how ppAbiValue is used elsewhere (e.g., Pretty.hs) and ensuring arguments encodes as [String] as intended.