### PR TITLE
Fixed event decoding crash

### DIFF
--- a/tests/solidity/values/events.sol
+++ b/tests/solidity/values/events.sol
@@ -1,10 +1,10 @@
 contract EventAssert {
     bytes32 private hash;
-    event Secret(bytes32);
+    event Secret(uint256, string, bytes32);
     function reset(uint seed) public {
         require(hash == 0);
 	bytes32 secret = keccak256(abi.encodePacked(seed));
-	emit Secret(secret);
+	emit Secret(1, "abc", secret);
         hash = keccak256(abi.encodePacked(secret));
     }
     function check(bytes32 seed) public {


### PR DESCRIPTION
Decoding certain types of events crashed the worker:

```
[2025-09-14 15:22:21.32] [Worker 3] Crashed:

TryFromException @Word256 @Int 24540235952376858153213464 Nothing
```

This can be reproduced replying the drips fuzzing campaign. This changes fixes the crash.