### PR TITLE
ci: macos-13 -> macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-latest
             shell: bash
             container: "{\"image\": \"elopeztob/alpine-haskell-stack-echidna:ghc-9.8.4\", \"options\": \"--user 1001\"}"
-          - os: macos-13 # x86_64 macOS
+          - os: macos-15-intel # x86_64 macOS
             shell: bash
           - os: windows-latest
             shell: msys2 {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             name: Linux (aarch64)
             tuple: aarch64-linux
             timeout: 180
-          - os: macos-13
+          - os: macos-15-intel
             name: macOS (x86_64)
             tuple: x86_64-macos
           - os: macos-14


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/