### PR TITLE
echidna: enable rtsopts

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -94,6 +94,7 @@ executables:
       - with-utf8
     ghc-options:
       - -threaded
+      - -rtsopts
       - '"-with-rtsopts=-A64m -N"'
     when:
       - condition: (os(linux) || os(windows)) && flag(static)


### PR DESCRIPTION
This will allow users to experiment with different garbage collection options such as -A

https://downloads.haskell.org/ghc/9.8.4/docs/users_guide/runtime_control.html#rts-options-to-control-the-garbage-collector