### PR TITLE
Downgrade z3 to 4.12.6

### DIFF
--- a/.github/scripts/install-z3.sh
+++ b/.github/scripts/install-z3.sh
@@ -12,5 +12,5 @@ if [ "$HOST_OS" = "Linux" ]; then
   rm -rf z3-*/ z3.zip
 fi
 if [ "$HOST_OS" = "Windows" ]; then
-  choco install z3
+  choco install z3 --version=4.12.6
 fi


### PR DESCRIPTION
Some symbolic execution related tests are failing when using z3 (4.15) but work correctly with 4.12.6 for some unknown reason. While we investigate, we will downgrade z3 to have the tests passing (they are also passing with other solvers such as bitwuzla).