### PR TITLE
Add support for Foundry `assume`

### DIFF
--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -56,6 +56,7 @@ classifyError = \case
   StackUnderrun        -> IllegalE
   BadJumpDestination   -> IllegalE
   IllegalOverflow      -> RevertE
+  AssumeCheatFailed    -> RevertE
   _                    -> UnknownE
 
 -- | Extracts the 'Query' if there is one.

--- a/lib/Echidna/SymExec/Common.hs
+++ b/lib/Echidna/SymExec/Common.hs
@@ -22,13 +22,13 @@ import EVM.Effects (TTY, ReadConfig)
 import EVM.Expr qualified
 import EVM.Fetch qualified as Fetch
 import EVM.Format (formatPartialDetailed)
-import EVM.Solidity (SolcContract(..), SourceCache(..), Method(..), WarningData(..))
+import EVM.Solidity (SolcContract(..), SourceCache(..), Method(..))
 import EVM.Solvers (SolverGroup)
 import EVM.SymExec (mkCalldata, verifyInputsWithHandler, VeriOpts(..), subModel, defaultSymbolicValues, Postcondition)
 import EVM.Types (Addr, VMType(..), EType(..), EvmError(..), Expr(..), Block(..), W256, SMTCex(..), ProofResult(..), Prop(..), forceLit, isQed)
 import qualified EVM.Types (VM(..))
 
-import Echidna.Test (assumeMagicReturnCode, isFoundryMode)
+import Echidna.Test (isFoundryMode)
 import Echidna.Types (fromEVM)
 import Echidna.Types.Config (EConfig(..))
 import Echidna.Types.Solidity (SolConf(..))
@@ -45,8 +45,7 @@ checkAssertions :: [Word256] -> Bool -> Postcondition
 checkAssertions errs isFoundry _ vmres
   | isFoundry = case vmres of
       -- vm.assume failures should not be treated as test failures
-      Failure _ _ (Revert (ConcreteBuf bs))
-        | assumeMagicReturnCode `BS.isSuffixOf` bs -> PBool True
+      Failure _ _ AssumeCheatFailed -> PBool True
       -- All other failures are test failures in foundry mode
       Failure {} -> PBool False
       _ -> PBool True
@@ -168,7 +167,7 @@ getUnknownLogs = mapMaybe (\case
 exploreMethod :: (MonadUnliftIO m, ReadConfig m, TTY m) =>
   Method -> SolcContract -> SourceCache -> EVM.Types.VM Concrete -> Addr -> EConfig -> VeriOpts -> SolverGroup -> Fetch.RpcInfo -> Fetch.Session -> m ([TxOrError], PartialsLogs)
 
-exploreMethod method contract sources vm defaultSender conf veriOpts solvers rpcInfo session = do
+exploreMethod method _contract _sources vm defaultSender conf veriOpts solvers rpcInfo session = do
   calldataSym@(_, constraints) <- mkCalldata (Just (Sig method.methodSignature (snd <$> method.inputs))) []
   let
     cd = fst calldataSym
@@ -193,6 +192,5 @@ exploreMethod method contract sources vm defaultSender conf veriOpts solvers rpc
   let foundry = isFoundryMode conf.solConf.testMode
   (models, partials) <- verifyInputsWithHandler solvers veriOpts fetcher vm'' (checkAssertions [0x1] foundry) Nothing
   let results = filter (\(r, _) -> not (isQed r)) models & map fst
-  let warnData = Just $ WarningData contract sources vm'
   --liftIO $ mapM_ print partials
-  return (map (modelToTx dst vm.block.timestamp vm.block.number method conf.solConf.sender defaultSender cd) results, map (formatPartialDetailed warnData . fst) partials)
+  return (map (modelToTx dst vm.block.timestamp vm.block.number method conf.solConf.sender defaultSender cd) results, map (\(p, _) -> formatPartialDetailed Nothing Map.empty p) partials)

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -232,11 +232,6 @@ checkStatefulAssertion vm sig addr = do
     isFailure = isCorrectTarget && (eventFailure || isAssertionFailure)
   pure (BoolValue (not isFailure), vm)
 
--- | Magic return code used by hevm to signal a foundry vm.assume failure.
--- See: https://github.com/ethereum/hevm/blob/main/src/EVM.hs (search for FOUNDRY::ASSUME)
-assumeMagicReturnCode :: BS.ByteString
-assumeMagicReturnCode = "FOUNDRY::ASSUME\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-
 checkFoundryAssertion
   :: (MonadReader Env m, MonadThrow m)
   => VM Concrete
@@ -252,9 +247,10 @@ checkFoundryAssertion vm sig addr = do
       BS.isPrefixOf (BS.take 4 (abiCalldata (encodeSig sig) mempty))
                     (forceBuf vm.state.calldata)
     isAssertionFailure = case vm.result of
-      Just (VMFailure (Revert (ConcreteBuf bs))) ->
-        T.isPrefixOf "test" (fst sig) && not (BS.isSuffixOf assumeMagicReturnCode bs) ||
-        T.isPrefixOf "invariant_" (fst sig) && not (BS.isSuffixOf assumeMagicReturnCode bs)
+      -- vm.assume failures should not be treated as test failures
+      Just (VMFailure AssumeCheatFailed) -> False
+      Just (VMFailure (Revert _)) ->
+        T.isPrefixOf "test" (fst sig) || T.isPrefixOf "invariant_" (fst sig)
       Just (VMFailure _) -> True
       _ -> False
     isCorrectAddr = LitAddr addr == vm.state.codeContract

--- a/lib/Echidna/Types/Tx.hs
+++ b/lib/Echidna/Types/Tx.hs
@@ -197,6 +197,7 @@ data TxResult
   | ErrorReturnDataOutOfBounds
   | ErrorNonexistentFork
   | ErrorNonexistentPrecompile
+  | ErrorAssumeCheatFailed
   deriving (Eq, Ord, Show, Enum)
 $(deriveJSON defaultOptions ''TxResult)
 
@@ -263,6 +264,7 @@ getResult = \case
   VMFailure ReturnDataOutOfBounds         -> ErrorReturnDataOutOfBounds
   VMFailure (NonexistentFork _)           -> ErrorNonexistentFork
   VMFailure (NonexistentPrecompile _)     -> ErrorNonexistentPrecompile
+  VMFailure AssumeCheatFailed             -> ErrorAssumeCheatFailed
 
 makeSingleTx :: Addr -> Addr -> W256 -> TxCall -> [Tx]
 makeSingleTx a d v (SolCall c) = [Tx (SolCall c) a d maxGasPerBlock 0 v (0, 0)]

--- a/src/test/Tests/FoundryTestGen.hs
+++ b/src/test/Tests/FoundryTestGen.hs
@@ -14,7 +14,7 @@ import System.IO.Unsafe (unsafePerformIO)
 import System.Process (readProcessWithExitCode)
 import Text.Read (readMaybe)
 
-import Common (solved, testContract, testContractNamed)
+import Common (solved, passed, testContract, testContractNamed)
 import Echidna.Types.Config (Env)
 import Echidna.Types.Campaign (WorkerState)
 import EVM.ABI (AbiValue(..))
@@ -152,6 +152,12 @@ foundryTestGenTests = testGroup "Foundry test generation"
           (Just "InvariantTest") (Just "foundry/FoundryInvariant.yaml")
           FuzzWorker
           [ ("invariant should be detected with seqLen > 1", solved "invariant_counter_below_limit")
+          ]
+      , testForgeStd "vm.assume filters inputs"
+          "foundry/FoundryAsserts.sol"
+          (Just "AssumeTest") (Just "foundry/FoundryAsserts.yaml")
+          FuzzWorker
+          [ ("vm.assume should not be treated as test failure", passed "test_assume_filters")
           ]
       ]
   , testGroup "Symbolic execution (SMT solving)"

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/argotorg/hevm.git
-  commit: 41e6d1304411749ea8c816d131991663b5dca67a
+  commit: ed90053fa0ed69e658a75ab0ed64d467f5a5448d
 
 - smt2-parser-0.1.0.1@sha256:1e1a4565915ed851c13d1e6b8bb5185cf5d454da3b43170825d53e221f753d77,1421
 - spawn-0.3@sha256:b91e01d8f2b076841410ae284b32046f91471943dc799c1af77d666c72101f02,1162

--- a/tests/solidity/foundry-basic/basic.sol
+++ b/tests/solidity/foundry-basic/basic.sol
@@ -2,6 +2,11 @@
 pragma abicoder v2;
 pragma solidity >=0.7.5;
 
+// Minimal Vm interface (this contract doesn't use forge-std).
+interface Vm {
+    function assume(bool condition) external pure;
+}
+
 contract Greeter {
     string public greeting;
 
@@ -85,7 +90,9 @@ contract GreeterTest is GreeterTestSetup {
     }
 
     function testFuzzAssume(uint256 x) public {
-        require(false, "FOUNDRY::ASSUME");
-        // unreachable
+        // keccak256("hevm cheat code") - standard hevm cheatcode address
+        // https://github.com/argotorg/hevm/blob/ed90053fa0ed69e658a75ab0ed64d467f5a5448d/src/EVM.hs#L1861
+        Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D).assume(x <= 100);
+        assert(x <= 100);
     }
 }

--- a/tests/solidity/foundry/FoundryAsserts.sol
+++ b/tests/solidity/foundry/FoundryAsserts.sol
@@ -158,3 +158,13 @@ contract RevertTest is Test {
         }
     }
 }
+
+contract AssumeTest is Test {
+    // vm.assume should filter inputs without counting as a test failure.
+    // When x > 100, vm.assume(false) triggers AssumeCheatFailed which
+    // echidna should ignore. The assertion always holds for accepted inputs
+    function test_assume_filters(uint256 x) public pure {
+        vm.assume(x <= 100);
+        assertTrue(x <= 100);
+    }
+}


### PR DESCRIPTION
This PR updates to latest `hevm` `main` branch commit SHA which updates the behavior around the Foundry assume cheatcode (check https://github.com/argotorg/hevm/issues/963 and https://github.com/argotorg/hevm/pull/986). It also updates the assume cheatcode handling inside echidna.