### PR TITLE
Add giveth.io url as a custom field in FUNDING.json

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -8,5 +8,6 @@
         "ethereum": {
             "ownedBy": "0xc44F30Be3eBBEfdDBB5a85168710b4f0e18f4Ff0"
         }
-    }
+    },
+    "custom": ["https://giveth.io/project/echidna:-a-fast-smart-contract-fuzzer"]
 }


### PR DESCRIPTION
This is required for the [Ethereum Security QF](https://qf.giveth.io/qf/ethereum-security) submission form.