### PR TITLE
Fix RPC Out of Memory issues in TUI [Vibecoded] 

### DIFF
--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -15,6 +15,7 @@ import Control.Monad.State.Strict hiding (state)
 import Data.ByteString.Lazy qualified as BS
 import Data.List.Split (chunksOf)
 import Data.Map (Map)
+import Data.Map qualified as Map
 import Data.Maybe (isJust, mapMaybe)
 import Data.Sequence ((|>))
 import Data.Text (Text)
@@ -138,8 +139,11 @@ ui vm dict initialCorpus cliSelectedContract = do
           , timeStopped = Nothing
           , now = now
           , slitherSucceeded = not $ isEmptySlitherInfo env.slitherInfo
-          , fetchedContracts = mempty
-          , fetchedSlots = mempty
+          , fetchedContractsSuccess = 0
+          , fetchedContractsTotal = 0
+          , fetchedSlotsSuccess = 0
+          , fetchedSlotsTotal = 0
+          , fetchedDialogData = Nothing
           , fetchedDialog = B.dialog (Just $ str " Fetched contracts/slots ") Nothing 80
           , displayFetchedDialog = False
           , displayLogPane = True
@@ -289,9 +293,9 @@ monitor = do
   let
     drawUI :: UIState -> [Widget Name]
     drawUI uiState =
-      [ if uiState.displayFetchedDialog
-           then fetchedDialogWidget uiState
-           else emptyWidget
+      [ case (uiState.displayFetchedDialog, uiState.fetchedDialogData) of
+          (True, Just (c, s)) -> fetchedDialogWidget uiState.fetchedDialog c s
+          _                   -> emptyWidget
       , uiState.campaignWidget ]
 
     toggleFocus :: UIState -> UIState
@@ -321,8 +325,20 @@ monitor = do
         modify $ const updatedState { campaignWidget = newWidget }
       AppEvent (FetchCacheUpdated contracts slots) ->
         modify' $ \state ->
-          state { fetchedContracts = contracts
-                , fetchedSlots = slots }
+          let !cTotal = Map.size contracts
+              !cSuccess = Map.size (Map.filter isJust contracts)
+              slotVals = concat (Map.elems (Map.elems <$> slots))
+              !sTotal = length slotVals
+              !sSuccess = length (filter isJust slotVals)
+              !dialogData = if state.displayFetchedDialog
+                               then Just (contracts, slots)
+                               else Nothing
+          in state { fetchedContractsSuccess = cSuccess
+                   , fetchedContractsTotal = cTotal
+                   , fetchedSlotsSuccess = sSuccess
+                   , fetchedSlotsTotal = sTotal
+                   , fetchedDialogData = dialogData
+                   }
       AppEvent (EventReceived event@(time,campaignEvent)) -> do
         modify' $ \state -> state { events = state.events |> event }
 
@@ -342,9 +358,14 @@ monitor = do
                     }
 
           _ -> pure ()
-      VtyEvent (EvKey (KChar 'f') _) ->
-        modify' $ \state ->
-          state { displayFetchedDialog = not state.displayFetchedDialog }
+      VtyEvent (EvKey (KChar 'f') _) -> do
+        state <- get
+        let opening = not state.displayFetchedDialog
+        snapshot <- if opening
+                    then liftIO $ Just <$> EVM.Fetch.getCacheState env.fetchSession
+                    else pure Nothing
+        modify' $ \s -> s { displayFetchedDialog = opening
+                          , fetchedDialogData = snapshot }
       VtyEvent (EvKey (KChar 'l') _) ->
         modify' $ \state ->
           refocusIfNeeded $ state { displayLogPane = not state.displayLogPane }

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -12,7 +12,7 @@ import Control.Monad.Reader (MonadReader, asks, ask)
 import Data.List (nub, intersperse, sortBy)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe, isJust, fromJust)
+import Data.Maybe (fromMaybe, fromJust)
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import Data.String.AnsiEscapeCodes.Strip.Text (stripAnsiEscapeCodes)
@@ -45,8 +45,12 @@ data UIState = UIState
   , timeStopped :: Maybe LocalTime
   , now :: LocalTime
   , slitherSucceeded :: Bool
-  , fetchedContracts :: Map Addr (Maybe Contract)
-  , fetchedSlots :: Map Addr (Map W256 (Maybe W256))
+  , fetchedContractsSuccess :: !Int
+  , fetchedContractsTotal :: !Int
+  , fetchedSlotsSuccess :: !Int
+  , fetchedSlotsTotal :: !Int
+  , fetchedDialogData :: Maybe ( Map Addr (Maybe Contract)
+                               , Map Addr (Map W256 (Maybe W256)) )
   , fetchedDialog :: B.Dialog () Name
   , displayFetchedDialog :: Bool
   , displayLogPane :: Bool
@@ -211,7 +215,12 @@ summaryWidget env uiState =
       slitherWidget uiState.slitherSucceeded
   rightSide =
     padLeft (Pad 1)
-      (rpcInfoWidget uiState.fetchedContracts uiState.fetchedSlots env.chainId)
+      (rpcInfoWidget
+         uiState.fetchedContractsSuccess
+         uiState.fetchedContractsTotal
+         uiState.fetchedSlotsSuccess
+         uiState.fetchedSlotsTotal
+         env.chainId)
 
 timeElapsed :: UIState -> LocalTime -> String
 timeElapsed uiState since =
@@ -227,20 +236,15 @@ formatNominalDiffTime diff =
   in formatTime defaultTimeLocale fmt diff
 
 rpcInfoWidget
-  :: Map Addr (Maybe Contract)
-  -> Map Addr (Map W256 (Maybe W256))
+  :: Int -> Int -> Int -> Int
   -> Maybe W256
   -> Widget Name
-rpcInfoWidget contracts slots chainId =
+rpcInfoWidget contractsSuccess contractsTotal slotsSuccess slotsTotal chainId =
   (str "Chain ID: " <+> str (maybe "-" show chainId))
   <=>
-  (str "Fetched contracts: " <+> countWidget (Map.elems contracts))
+  (str "Fetched contracts: " <+> outOf contractsSuccess contractsTotal)
   <=>
-  (str "Fetched slots: " <+> countWidget (concat $ Map.elems (Map.elems <$> slots)))
-  where
-  countWidget fetches =
-    let successful = filter isJust fetches
-    in outOf (length successful) (length fetches)
+  (str "Fetched slots: " <+> outOf slotsSuccess slotsTotal)
 
 slitherWidget
   :: Bool
@@ -278,10 +282,14 @@ gasPerfWidget uiState =
     diffLocalTime (fromMaybe uiState.now uiState.timeStopped)
                   uiState.timeStarted
 
-fetchedDialogWidget :: UIState -> Widget Name
-fetchedDialogWidget uiState =
-  B.renderDialog uiState.fetchedDialog $ padLeftRight 1 $
-    foldl (<=>) emptyWidget (Map.mapWithKey renderContract uiState.fetchedContracts)
+fetchedDialogWidget
+  :: B.Dialog () Name
+  -> Map Addr (Maybe Contract)
+  -> Map Addr (Map W256 (Maybe W256))
+  -> Widget Name
+fetchedDialogWidget dialog contracts slots =
+  B.renderDialog dialog $ padLeftRight 1 $
+    foldl (<=>) emptyWidget (Map.mapWithKey renderContract contracts)
   where
   renderContract addr (Just _code) =
     bold (str (show addr))
@@ -291,7 +299,7 @@ fetchedDialogWidget uiState =
     bold $ failure (str (show addr))
   renderSlots addr =
     foldl (<=>) emptyWidget $
-      Map.mapWithKey renderSlot (fromMaybe mempty $ Map.lookup addr uiState.fetchedSlots)
+      Map.mapWithKey renderSlot (fromMaybe mempty $ Map.lookup addr slots)
   renderSlot slot (Just value) =
     padLeft (Pad 1) $ strBreak (show slot <> " => " <> show value)
   renderSlot slot Nothing =


### PR DESCRIPTION
**WARNING: This is 100% vibecoded***

Tested locally and works without any obvious issues.

The TUI ticker called EVM.Fetch.getCacheState every 200ms, which built two fresh nested Maps mirroring the full RPC cache and stored them in UIState. Widgets rebuilt on each CampaignUpdated tick closed over those fields via uiState references, so each tick's snapshot was retained until its widget was replaced — and with lazy record sharing across ticks, the chain grew linearly. Heap-cost-centre profiling attributed 9.7GB of growth over a 2h TUI run to getCacheState allocations.

Replace the two Maps in UIState with four strict Int counts for the always-visible top-right "Fetched contracts/slots" counter, and an on-demand Maybe snapshot used only while the fetched-cache popup dialog is open. The handler computes the counts strictly on every tick and only stores the Maps in UIState while the dialog is actually displayed; otherwise they fall out of scope and get GC'd. The 'f' keypress populates the snapshot synchronously on open (so the dialog renders real data immediately) and clears it on close.