### PR TITLE
Added useColor config [Vibecoded]

### DIFF
--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -54,7 +54,7 @@ instance FromJSON EConfigWithUsage where
               <*> solConfParser
               <*> testConfParser
               <*> txConfParser
-              <*> (UIConf <$> v ..:? "timeout" <*> formatParser <*> (v ..:? "noColor" ..!= False))
+              <*> (UIConf <$> v ..:? "timeout" <*> formatParser <*> useColor)
               <*> v ..:? "allEvents" ..!= False
               <*> v ..:? "rpcUrl"
               <*> v ..:? "rpcBlock"
@@ -65,6 +65,7 @@ instance FromJSON EConfigWithUsage where
       useKey k = modify' $ Set.insert k
       x ..:? k = useKey k >> lift (x .:? k)
       x ..!= y = fromMaybe y <$> x
+      useColor = v ..:? "useColor" ..!= True
       -- Parse as unbounded Integer and see if it fits into W256
       getWord256 k def = do
         value :: Integer <- fromMaybe (fromIntegral (def :: W256)) <$> v ..:? k

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -54,7 +54,7 @@ instance FromJSON EConfigWithUsage where
               <*> solConfParser
               <*> testConfParser
               <*> txConfParser
-              <*> (UIConf <$> v ..:? "timeout" <*> formatParser)
+              <*> (UIConf <$> v ..:? "timeout" <*> formatParser <*> (v ..:? "noColor" ..!= False))
               <*> v ..:? "allEvents" ..!= False
               <*> v ..:? "rpcUrl"
               <*> v ..:? "rpcBlock"

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -41,7 +41,7 @@ import Echidna.Types.Config (Env(..), EConfig(..), UIConf(..), OperationMode(..)
 import Echidna.Types.Coverage (CoverageInfo)
 import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Tx (TxCall(..), Tx(call, dst), TxResult(..), initialTimestamp, initialBlockNumber, getResult)
-import Echidna.Utility (getTimestamp, maybeStripAnsi, timePrefix)
+import Echidna.Utility (applyAnsiColor, getTimestamp, timePrefix)
 
 -- | Broad categories of execution failures: reversions, illegal operations, and ???.
 data ErrorClass = RevertE | IllegalE | UnknownE
@@ -75,8 +75,8 @@ pattern Illegal <- VMFailure (classifyError -> IllegalE)
 -- | Given an execution error, throw the appropriate exception.
 -- Also optionally takes a DappInfo and VM, which are used to show the stack trace.
 vmExcept :: MonadThrow m => Bool -> Maybe (DappInfo, VM Concrete) -> EvmError -> m ()
-vmExcept noColor traceInfo e =
-  let trace = (\(dappInfo, vm) -> maybeStripAnsi noColor $ showTraceTree dappInfo vm) <$> traceInfo
+vmExcept useColor traceInfo e =
+  let trace = (\(dappInfo, vm) -> applyAnsiColor useColor $ showTraceTree dappInfo vm) <$> traceInfo
   in throwM $
     case VMFailure e of {Illegal -> IllegalExec e; _ -> UnknownFailure e trace}
 
@@ -194,10 +194,10 @@ execTxWith executeTx tx = do
       #state % #codeContract .= codeContractBeforeVMReset
       #burned .= burnedGas
     (VMFailure x, _) -> do
-      noColor <- asks (.cfg.uiConf.noColor)
+      useColor <- asks (.cfg.uiConf.useColor)
       dapp <- asks (.dapp)
       vm <- get
-      vmExcept noColor (Just (dapp, vm)) x
+      vmExcept useColor (Just (dapp, vm)) x
     (VMSuccess (ConcreteBuf bytecode'), SolCreate _) -> do
       -- Handle contract creation.
       #env % #contracts % at (LitAddr tx.dst) % _Just % #code .= InitCode mempty mempty

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -41,7 +41,7 @@ import Echidna.Types.Config (Env(..), EConfig(..), UIConf(..), OperationMode(..)
 import Echidna.Types.Coverage (CoverageInfo)
 import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Tx (TxCall(..), Tx(call, dst), TxResult(..), initialTimestamp, initialBlockNumber, getResult)
-import Echidna.Utility (getTimestamp, timePrefix)
+import Echidna.Utility (getTimestamp, maybeStripAnsi, timePrefix)
 
 -- | Broad categories of execution failures: reversions, illegal operations, and ???.
 data ErrorClass = RevertE | IllegalE | UnknownE
@@ -74,9 +74,9 @@ pattern Illegal <- VMFailure (classifyError -> IllegalE)
 
 -- | Given an execution error, throw the appropriate exception.
 -- Also optionally takes a DappInfo and VM, which are used to show the stack trace.
-vmExcept :: MonadThrow m => Maybe (DappInfo, VM Concrete) -> EvmError -> m ()
-vmExcept traceInfo e =
-  let trace = uncurry showTraceTree <$> traceInfo
+vmExcept :: MonadThrow m => Bool -> Maybe (DappInfo, VM Concrete) -> EvmError -> m ()
+vmExcept noColor traceInfo e =
+  let trace = (\(dappInfo, vm) -> maybeStripAnsi noColor $ showTraceTree dappInfo vm) <$> traceInfo
   in throwM $
     case VMFailure e of {Illegal -> IllegalExec e; _ -> UnknownFailure e trace}
 
@@ -194,9 +194,10 @@ execTxWith executeTx tx = do
       #state % #codeContract .= codeContractBeforeVMReset
       #burned .= burnedGas
     (VMFailure x, _) -> do
+      noColor <- asks (.cfg.uiConf.noColor)
       dapp <- asks (.dapp)
       vm <- get
-      vmExcept (Just (dapp, vm)) x
+      vmExcept noColor (Just (dapp, vm)) x
     (VMSuccess (ConcreteBuf bytecode'), SolCreate _) -> do
       -- Handle contract creation.
       #env % #contracts % at (LitAddr tx.dst) % _Just % #code .= InitCode mempty mempty

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -53,7 +53,7 @@ import Echidna.Types.Tx
   ( basicTx, createTxWithValue, unlimitedGasPerBlock, initialTimestamp
   , initialBlockNumber )
 import Echidna.Types.World (World(..))
-import Echidna.Utility (maybeStripAnsi, measureIO)
+import Echidna.Utility (applyAnsiColor, measureIO)
 
 readSolcBatch :: FilePath -> IO [BuildOutput]
 readSolcBatch d = do
@@ -222,7 +222,7 @@ loadSpecified env mainContract cs = do
     vm3 <- deployment
     when (isNothing $ currentContract vm3) $
       throwM $ DeploymentFailed solConf.contractAddr $
-        maybeStripAnsi env.cfg.uiConf.noColor $ showTraceTree env.dapp vm3
+        applyAnsiColor env.cfg.uiConf.useColor $ showTraceTree env.dapp vm3
 
     -- Run setUp function
     let
@@ -244,7 +244,7 @@ loadSpecified env mainContract cs = do
 
     case vm4.result of
       Just (VMFailure _) -> throwM $ SetUpCallFailed $
-        maybeStripAnsi env.cfg.uiConf.noColor $ showTraceTree env.dapp vm4
+        applyAnsiColor env.cfg.uiConf.useColor $ showTraceTree env.dapp vm4
       _ -> pure vm4
 
   where

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -44,7 +44,7 @@ import Echidna.Exec (execTx, execTxWithCov, initialVM)
 import Echidna.SourceAnalysis.Slither
 import Echidna.Test (createTests, isAssertionMode, isPropertyMode, isFoundryMode, isOptimizationMode)
 import Echidna.Types.Campaign (CampaignConf(..))
-import Echidna.Types.Config (EConfig(..), Env(..))
+import Echidna.Types.Config (EConfig(..), Env(..), UIConf(..))
 import Echidna.Types.Signature
   (ContractName, SolSignature, SignatureMap, FunctionName)
 import Echidna.Types.Solidity
@@ -53,7 +53,7 @@ import Echidna.Types.Tx
   ( basicTx, createTxWithValue, unlimitedGasPerBlock, initialTimestamp
   , initialBlockNumber )
 import Echidna.Types.World (World(..))
-import Echidna.Utility (measureIO)
+import Echidna.Utility (maybeStripAnsi, measureIO)
 
 readSolcBatch :: FilePath -> IO [BuildOutput]
 readSolcBatch d = do
@@ -221,7 +221,8 @@ loadSpecified env mainContract cs = do
 
     vm3 <- deployment
     when (isNothing $ currentContract vm3) $
-      throwM $ DeploymentFailed solConf.contractAddr $ showTraceTree env.dapp vm3
+      throwM $ DeploymentFailed solConf.contractAddr $
+        maybeStripAnsi env.cfg.uiConf.noColor $ showTraceTree env.dapp vm3
 
     -- Run setUp function
     let
@@ -242,7 +243,8 @@ loadSpecified env mainContract cs = do
               else pure vm3
 
     case vm4.result of
-      Just (VMFailure _) -> throwM $ SetUpCallFailed $ showTraceTree env.dapp vm4
+      Just (VMFailure _) -> throwM $ SetUpCallFailed $
+        maybeStripAnsi env.cfg.uiConf.noColor $ showTraceTree env.dapp vm4
       _ -> pure vm4
 
   where

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -28,6 +28,7 @@ data OperationMode = Interactive | NonInteractive OutputFormat deriving (Show, E
 data OutputFormat = Text | JSON | None deriving (Show, Eq)
 data UIConf = UIConf { maxTime       :: Maybe Int
                      , operationMode :: OperationMode
+                     , noColor       :: Bool
                      }
 
 -- | An address involved with a 'Transaction' is either the sender, the recipient, or neither of those things.

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -28,7 +28,7 @@ data OperationMode = Interactive | NonInteractive OutputFormat deriving (Show, E
 data OutputFormat = Text | JSON | None deriving (Show, Eq)
 data UIConf = UIConf { maxTime       :: Maybe Int
                      , operationMode :: OperationMode
-                     , noColor       :: Bool
+                     , useColor      :: Bool
                      }
 
 -- | An address involved with a 'Transaction' is either the sender, the recipient, or neither of those things.

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -26,7 +26,7 @@ import Echidna.Types.Coverage (coverageStats)
 import Echidna.Types.Test (EchidnaTest(..), TestState(..), TestType(..))
 import Echidna.Types.Tx (Tx(..), TxCall(..), TxConf(..))
 import Echidna.Types.Worker
-import Echidna.Utility (maybeStripAnsi, timePrefix)
+import Echidna.Utility (applyAnsiColor, timePrefix)
 import Echidna.Worker
 
 ppLogLine :: (MonadReader Env m, MonadIO m) => VM Concrete -> (LocalTime, CampaignEvent) -> m String
@@ -46,8 +46,8 @@ ppCampaignEventLog vm ev = (ppCampaignEvent ev <>) <$> ppTxIfHas where
 ppTraceTree :: (MonadReader Env m, MonadIO m) => VM Concrete -> m String
 ppTraceTree vm = do
   dappInfo <- asks (.dapp)
-  noColor <- asks (.cfg.uiConf.noColor)
-  pure . T.unpack $ maybeStripAnsi noColor (showTraceTree dappInfo vm)
+  useColor <- asks (.cfg.uiConf.useColor)
+  pure . T.unpack $ applyAnsiColor useColor (showTraceTree dappInfo vm)
 
 ppTotalCalls :: [WorkerState] -> String
 ppTotalCalls workerStates = "Total calls: " <> show calls

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -26,7 +26,7 @@ import Echidna.Types.Coverage (coverageStats)
 import Echidna.Types.Test (EchidnaTest(..), TestState(..), TestType(..))
 import Echidna.Types.Tx (Tx(..), TxCall(..), TxConf(..))
 import Echidna.Types.Worker
-import Echidna.Utility (timePrefix)
+import Echidna.Utility (maybeStripAnsi, timePrefix)
 import Echidna.Worker
 
 ppLogLine :: (MonadReader Env m, MonadIO m) => VM Concrete -> (LocalTime, CampaignEvent) -> m String
@@ -42,6 +42,12 @@ ppCampaignEventLog vm ev = (ppCampaignEvent ev <>) <$> ppTxIfHas where
   ppTxIfHas = case ev of
     (WorkerEvent _ _ (TestFalsified test)) -> ("\n  Call sequence:\n" <>) . unlines <$> mapM (ppTx vm $ length (nub $ (.src) <$> test.reproducer) /= 1) test.reproducer
     _ -> pure ""
+
+ppTraceTree :: (MonadReader Env m, MonadIO m) => VM Concrete -> m String
+ppTraceTree vm = do
+  dappInfo <- asks (.dapp)
+  noColor <- asks (.cfg.uiConf.noColor)
+  pure . T.unpack $ maybeStripAnsi noColor (showTraceTree dappInfo vm)
 
 ppTotalCalls :: [WorkerState] -> String
 ppTotalCalls workerStates = "Total calls: " <> show calls
@@ -146,16 +152,15 @@ ppFail b vm xs = do
         Nothing    -> ""
         Just (n,m) -> ", shrinking " <> progress n m
   prettyTxs <- mapM (ppTx vm $ length (nub $ (.src) <$> xs) /= 1) xs
-  dappInfo <- asks (.dapp)
+  traces <- ppTraceTree vm
   pure $ "failed!💥  \n  Call sequence" <> status <> ":\n"
          <> unlines (("    " <>) <$> prettyTxs) <> "\n"
-         <> "Traces: \n" <> T.unpack (showTraceTree dappInfo vm)
+         <> "Traces: \n" <> traces
 
 -- | Pretty-print the status of a solved test.
 ppFailWithTraces :: (MonadReader Env m, MonadIO m) => Maybe (Int, Int) -> VM Concrete -> [(Tx, VM Concrete)] -> m String
 ppFailWithTraces  _ _ []  = pure "failed with no transactions made ⁉️ "
 ppFailWithTraces b finalVM results = do
-  dappInfo <- asks (.dapp)
   let xs = fst <$> results
   let status = case b of
         Nothing    -> ""
@@ -163,10 +168,12 @@ ppFailWithTraces b finalVM results = do
   let printName = length (nub $ (.src) <$> xs) /= 1
   prettyTxs <- forM results $ \(tx, vm) -> do
     txPrinted <- ppTx vm printName tx
-    pure $ txPrinted <> "\nTraces:\n" <> T.unpack (showTraceTree dappInfo vm)
+    traces <- ppTraceTree vm
+    pure $ txPrinted <> "\nTraces:\n" <> traces
+  finalTraces <- ppTraceTree finalVM
   pure $ "failed!💥  \n  Call sequence" <> status <> ":\n"
          <> unlines (("    " <>) <$> prettyTxs) <> "\n"
-         <> "Test traces: \n" <> T.unpack (showTraceTree dappInfo finalVM)
+         <> "Test traces: \n" <> finalTraces
 
 -- | Pretty-print the status of a test.
 
@@ -199,10 +206,10 @@ ppOptimized b vm xs = do
         Nothing    -> ""
         Just (n,m) -> ", shrinking " <> progress n m
   prettyTxs <- mapM (ppTx vm $ length (nub $ (.src) <$> xs) /= 1) xs
-  dappInfo <- asks (.dapp)
+  traces <- ppTraceTree vm
   pure $ "\n  Call sequence" <> status <> ":\n"
          <> unlines (("    " <>) <$> prettyTxs) <> "\n"
-         <> "Traces: \n" <> T.unpack (showTraceTree dappInfo vm)
+         <> "Traces: \n" <> traces
 
 -- | Pretty-print the status of all 'SolTest's in a 'Campaign'.
 ppTests :: (MonadReader Env m, MonadIO m) => [EchidnaTest] -> m String

--- a/lib/Echidna/Utility.hs
+++ b/lib/Echidna/Utility.hs
@@ -28,9 +28,9 @@ timePrefix :: LocalTime -> String
 timePrefix time =
   "[" <> formatTime defaultTimeLocale "%F %T.%2q" time <> "] "
 
-maybeStripAnsi :: Bool -> Text -> Text
-maybeStripAnsi noColor =
-  if noColor then stripAnsiEscapeCodes else id
+applyAnsiColor :: Bool -> Text -> Text
+applyAnsiColor useColor =
+  if useColor then id else stripAnsiEscapeCodes
 
 listDirectory :: FilePath -> IO [FilePath]
 listDirectory path = filter f <$> getDirectoryContents path

--- a/lib/Echidna/Utility.hs
+++ b/lib/Echidna/Utility.hs
@@ -2,6 +2,8 @@ module Echidna.Utility where
 
 import Control.Monad (unless)
 import Control.Monad.Catch (bracket)
+import Data.String.AnsiEscapeCodes.Strip.Text (stripAnsiEscapeCodes)
+import Data.Text (Text)
 import Data.Time (diffUTCTime, getCurrentTime, zonedTimeToLocalTime, LocalTime, getZonedTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.Directory (getDirectoryContents, getCurrentDirectory, setCurrentDirectory)
@@ -25,6 +27,10 @@ getTimestamp =
 timePrefix :: LocalTime -> String
 timePrefix time =
   "[" <> formatTime defaultTimeLocale "%F %T.%2q" time <> "] "
+
+maybeStripAnsi :: Bool -> Text -> Text
+maybeStripAnsi noColor =
+  if noColor then stripAnsiEscapeCodes else id
 
 listDirectory :: FilePath -> IO [FilePath]
 listDirectory path = filter f <$> getDirectoryContents path

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -135,6 +135,7 @@ data Options = Options
   , cliSelectedContract :: Maybe Text
   , cliConfigFilepath   :: Maybe FilePath
   , cliOutputFormat     :: Maybe OutputFormat
+  , cliNoColor          :: Bool
   , cliCorpusDir        :: Maybe FilePath
   , cliCoverageDir      :: Maybe FilePath
   , cliTestMode         :: Maybe TestMode
@@ -189,6 +190,8 @@ options = Options . NE.fromList
   <*> optional (option auto $ long "format"
     <> metavar "FORMAT"
     <> help "Output format. Either 'json', 'text', 'none'. All these disable interactive UI")
+  <*> switch (long "no-color"
+    <> help "Disable ANSI color codes in text output.")
   <*> optional (option str $ long "corpus-dir"
     <> metavar "PATH"
     <> help "Directory to save and load corpus data.")
@@ -275,6 +278,7 @@ overrideConfig config Options{..} = do
   where
     overrideUiConf uiConf = uiConf
       { maxTime = cliTimeout <|> uiConf.maxTime
+      , noColor = cliNoColor || uiConf.noColor
       }
 
     overrideFormat cfg =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -135,7 +135,7 @@ data Options = Options
   , cliSelectedContract :: Maybe Text
   , cliConfigFilepath   :: Maybe FilePath
   , cliOutputFormat     :: Maybe OutputFormat
-  , cliNoColor          :: Bool
+  , cliUseColor         :: Maybe Bool
   , cliCorpusDir        :: Maybe FilePath
   , cliCoverageDir      :: Maybe FilePath
   , cliTestMode         :: Maybe TestMode
@@ -190,8 +190,9 @@ options = Options . NE.fromList
   <*> optional (option auto $ long "format"
     <> metavar "FORMAT"
     <> help "Output format. Either 'json', 'text', 'none'. All these disable interactive UI")
-  <*> switch (long "no-color"
-    <> help "Disable ANSI color codes in text output.")
+  <*> optional (option bool $ long "use-color"
+    <> metavar "BOOL"
+    <> help "Whether to use ANSI color codes in text output.")
   <*> optional (option str $ long "corpus-dir"
     <> metavar "PATH"
     <> help "Directory to save and load corpus data.")
@@ -278,7 +279,7 @@ overrideConfig config Options{..} = do
   where
     overrideUiConf uiConf = uiConf
       { maxTime = cliTimeout <|> uiConf.maxTime
-      , noColor = cliNoColor || uiConf.noColor
+      , useColor = fromMaybe uiConf.useColor cliUseColor
       }
 
     overrideFormat cfg =

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -39,11 +39,19 @@ configTests = testGroup "Configuration tests" $
       assertBool "" $ isNothing (defaultConfig.campaignConf.corpusDir)
   , testCase "coverageDir defaults to Nothing" $
       assertBool "" $ isNothing (defaultConfig.campaignConf.coverageDir)
+  , testCase "noColor defaults to False" $
+      assertBool "" $ not defaultConfig.uiConf.noColor
   , testCase "default.yaml" $ do
       EConfigWithUsage _ bad unset <- parseConfig "basic/default.yaml"
       assertBool ("unused options: " ++ show bad) $ null bad
       let unset' = unset & sans "seed"
       assertBool ("unset options: " ++ show unset') $ null unset'
+  , testCase "parse noColor" $ do
+      config <- (.econfig) <$> parseConfig "basic/default.yaml"
+      assertBool "" $ not config.uiConf.noColor
+      case Y.decodeEither' "noColor: true" of
+        Right (c :: EConfigWithUsage) -> assertBool "" c.econfig.uiConf.noColor
+        Left e -> assertFailure $ "unexpected decoding error: " <> show e
   , testCase "W256 decoding" $ do
       let maxW256  = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
           overW256 = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0"

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -10,7 +10,7 @@ import Test.Tasty.HUnit (testCase, assertBool, assertFailure)
 
 import Echidna.Config (defaultConfig, parseConfig)
 import Echidna.Types.Campaign (CampaignConf(..))
-import Echidna.Types.Config (EConfigWithUsage(..), EConfig(..))
+import Echidna.Types.Config (EConfigWithUsage(..), EConfig(..), UIConf(..))
 import Echidna.Types.Tx (TxConf(..))
 
 configTests :: TestTree
@@ -39,18 +39,18 @@ configTests = testGroup "Configuration tests" $
       assertBool "" $ isNothing (defaultConfig.campaignConf.corpusDir)
   , testCase "coverageDir defaults to Nothing" $
       assertBool "" $ isNothing (defaultConfig.campaignConf.coverageDir)
-  , testCase "noColor defaults to False" $
-      assertBool "" $ not defaultConfig.uiConf.noColor
+  , testCase "color output is enabled by default" $
+      assertBool "" defaultConfig.uiConf.useColor
   , testCase "default.yaml" $ do
       EConfigWithUsage _ bad unset <- parseConfig "basic/default.yaml"
       assertBool ("unused options: " ++ show bad) $ null bad
       let unset' = unset & sans "seed"
       assertBool ("unset options: " ++ show unset') $ null unset'
-  , testCase "parse noColor" $ do
+  , testCase "parse useColor" $ do
       config <- (.econfig) <$> parseConfig "basic/default.yaml"
-      assertBool "" $ not config.uiConf.noColor
-      case Y.decodeEither' "noColor: true" of
-        Right (c :: EConfigWithUsage) -> assertBool "" c.econfig.uiConf.noColor
+      assertBool "" config.uiConf.useColor
+      case Y.decodeEither' "useColor: false" of
+        Right (c :: EConfigWithUsage) -> assertBool "" $ not c.econfig.uiConf.useColor
         Left e -> assertFailure $ "unexpected decoding error: " <> show e
   , testCase "W256 decoding" $ do
       let maxW256  = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -29,6 +29,8 @@ coverage: true
 #format can be "text" or "json" for different output (human or machine readable)
 #default is interactive if running on an interactive tty or text mode if not
 format: null
+#disable ANSI color codes in plain-text traces and reports
+noColor: false
 #contractAddr is the address of the contract itself
 contractAddr: "0x00a329c0648769a73afac7f9381e08fb43dbea72"
 #deployer is address of the contract deployer (who often is privileged owner, etc.)

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -29,8 +29,8 @@ coverage: true
 #format can be "text" or "json" for different output (human or machine readable)
 #default is interactive if running on an interactive tty or text mode if not
 format: null
-#disable ANSI color codes in plain-text traces and reports
-noColor: false
+#enable ANSI color codes in plain-text traces and reports
+useColor: true
 #contractAddr is the address of the contract itself
 contractAddr: "0x00a329c0648769a73afac7f9381e08fb43dbea72"
 #deployer is address of the contract deployer (who often is privileged owner, etc.)


### PR DESCRIPTION
**WARNING: This is 100% vibecoded***

Tested locally and works without any obvious issues.

Add the option of removing colored text output. The main purpose of this is to get rid of un-renderable coloring characters from .txt output.

Before:
<img width="202" height="146" alt="image" src="https://github.com/user-attachments/assets/40420e59-726c-498c-9952-304773e04630" />


After:
<img width="163" height="182" alt="image" src="https://github.com/user-attachments/assets/edcd3546-756c-49e0-a73a-df58688f4746" />
