### PR TITLE
Fix unlimited memory usage by bounding dynamic dict growth [Vibecoded]

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -100,6 +100,9 @@ prepareContract cfg solFiles buildOutput selectedContract seed = do
                      Set.empty
                      seed
                      (returnTypes contracts)
+                     env.cfg.campaignConf.dictDynamicConstantsLimit
+                     env.cfg.campaignConf.dictDynamicValuesLimit
+                     env.cfg.campaignConf.dictDynamicCallsLimit
                      nonViewPureSigs
   pure (vm, env, dict)
 

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -17,7 +17,9 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe, catMaybes)
+import Data.Maybe (catMaybes)
+import Data.Sequence (Seq, (|>))
+import Data.Sequence qualified as Seq
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -111,19 +113,73 @@ hashSig = abiKeccak . TE.encodeUtf8
 data GenDict = GenDict
   { pSynthA    :: Float
     -- ^ Fraction of time to use dictionary vs. synthesize
-  , constants  :: !(Map AbiType (Set AbiValue))
-    -- ^ Constants to use, sorted by type
-  , wholeCalls :: !(Map SolSignature (Set SolCall))
-    -- ^ Whole calls to use, sorted by type
+  , staticConstants  :: !(Map AbiType (Set AbiValue))
+    -- ^ Static constants to use, sorted by type
+  , dynamicConstants :: !(Map AbiType (BoundedSet AbiValue))
+    -- ^ Runtime-mined constants to use, sorted by type
+  , staticWholeCalls :: !(Map SolSignature (Set SolCall))
+    -- ^ Static whole calls to use, sorted by type
+  , dynamicWholeCalls :: !(Map SolSignature (BoundedSet SolCall))
+    -- ^ Runtime-mined whole calls to use, sorted by type
   , defSeed    :: Int
     -- ^ Default seed to use if one is not provided in EConfig
   , rTypes     :: Text -> Maybe AbiType
     -- ^ Return types of any methods we scrape return values from
-  , dictValues :: !(Set W256)
-    -- ^ A set of int/uint constants for better performance
+  , staticDictValues :: !(Set W256)
+    -- ^ Static int/uint constants for better performance
+  , dynamicDictValues :: !(BoundedSet W256)
+    -- ^ Runtime-mined int/uint constants for better performance
+  , dynamicConstantsLimit :: !Int
+    -- ^ Maximum runtime-mined constants to keep per ABI type
+  , dynamicValuesLimit :: !Int
+    -- ^ Maximum runtime-mined int/uint constants to keep
+  , dynamicCallsLimit :: !Int
+    -- ^ Maximum runtime-mined whole calls to keep per signature
   , callbackSigs    :: ![SolSignature]
     -- ^ A list of callback signatures (for generating random callbacks)
   }
+
+data BoundedSet a = BoundedSet
+  { boundedOrder :: !(Seq a)
+  , boundedMembers :: !(Set a)
+  }
+
+emptyBoundedSet :: BoundedSet a
+emptyBoundedSet = BoundedSet mempty Set.empty
+
+boundedSize :: BoundedSet a -> Int
+boundedSize = Set.size . (.boundedMembers)
+
+boundedInsert :: Ord a => Int -> Set a -> a -> BoundedSet a -> BoundedSet a
+boundedInsert limit staticMembers value bounded
+  | limit <= 0 = emptyBoundedSet
+  | value `Set.member` staticMembers = bounded
+  | value `Set.member` bounded.boundedMembers = bounded
+  | otherwise = trimBounded limit $
+      BoundedSet (bounded.boundedOrder |> value) (Set.insert value bounded.boundedMembers)
+
+boundedInsertSet :: Ord a => Int -> Set a -> Set a -> BoundedSet a -> BoundedSet a
+boundedInsertSet limit staticMembers values bounded =
+  Set.foldl' (\acc value -> boundedInsert limit staticMembers value acc) bounded values
+
+trimBounded :: Ord a => Int -> BoundedSet a -> BoundedSet a
+trimBounded limit bounded
+  | boundedSize bounded <= limit = bounded
+  | otherwise =
+      case Seq.viewl bounded.boundedOrder of
+        Seq.EmptyL -> emptyBoundedSet
+        value Seq.:< rest -> trimBounded limit $ BoundedSet rest (Set.delete value bounded.boundedMembers)
+
+rElemStaticDynamic :: (MonadRandom m, Ord a) => Set a -> BoundedSet a -> m (Maybe a)
+rElemStaticDynamic staticMembers dynamicMembers =
+  case Set.size staticMembers + boundedSize dynamicMembers of
+    0 -> pure Nothing
+    total -> do
+      idx <- getRandomR (0, total - 1)
+      pure . Just $
+        if idx < Set.size staticMembers
+          then Set.elemAt idx staticMembers
+          else Seq.index dynamicMembers.boundedOrder (idx - Set.size staticMembers)
 
 hashMapBy
   :: (Ord k, Eq k, Ord a)
@@ -134,7 +190,32 @@ hashMapBy f = Map.fromListWith Set.union . fmap (\v -> (f v, Set.singleton v)) .
 
 gaddCalls :: Set SolCall -> GenDict -> GenDict
 gaddCalls calls dict =
-  dict { wholeCalls = dict.wholeCalls <> hashMapBy (fmap $ fmap abiValueType) calls }
+  dict { dynamicWholeCalls = Map.foldlWithKey' insertCalls dict.dynamicWholeCalls callsBySig }
+  where
+    callsBySig = hashMapBy (fmap $ fmap abiValueType) calls
+    insertCalls acc sig callsForSig =
+      let staticCalls = Map.findWithDefault Set.empty sig dict.staticWholeCalls
+          existingCalls = Map.findWithDefault emptyBoundedSet sig acc
+          updatedCalls = boundedInsertSet dict.dynamicCallsLimit staticCalls callsForSig existingCalls
+      in if boundedSize updatedCalls == 0
+         then Map.delete sig acc
+         else Map.insert sig updatedCalls acc
+
+addDynamicConstants :: Map AbiType (Set AbiValue) -> GenDict -> GenDict
+addDynamicConstants additions dict =
+  dict
+    { dynamicConstants = Map.foldlWithKey' insertConstants dict.dynamicConstants additions
+    , dynamicDictValues = boundedInsertSet dict.dynamicValuesLimit dict.staticDictValues dynamicValues dict.dynamicDictValues
+    }
+  where
+    insertConstants acc abiType values =
+      let staticValues = Map.findWithDefault Set.empty abiType dict.staticConstants
+          existingValues = Map.findWithDefault emptyBoundedSet abiType acc
+          updatedValues = boundedInsertSet dict.dynamicConstantsLimit staticValues values existingValues
+      in if boundedSize updatedValues == 0
+         then Map.delete abiType acc
+         else Map.insert abiType updatedValues acc
+    dynamicValues = mkDictValues $ Set.unions $ Map.elems additions
 
 -- | Construct a 'GenDict' from some dictionaries, a 'Float', a default seed,
 -- and a typing rule for return values
@@ -144,18 +225,27 @@ mkGenDict
   -> Set SolCall  -- ^ A list of complete 'SolCall's to mutate
   -> Int          -- ^ A default seed
   -> (Text -> Maybe AbiType) -- ^ A return value typing rule
+  -> Int
+  -> Int
+  -> Int
   -> [SolSignature]
   -> GenDict
-mkGenDict mutationChance abiValues solCalls seed typingRule =
+mkGenDict mutationChance abiValues solCalls seed typingRule constantsLimit valuesLimit callsLimit =
   GenDict mutationChance
           (hashMapBy abiValueType abiValues)
+          Map.empty
           (hashMapBy (fmap $ fmap abiValueType) solCalls)
+          Map.empty
           seed
           typingRule
           (mkDictValues abiValues)
+          emptyBoundedSet
+          constantsLimit
+          valuesLimit
+          callsLimit
 
 emptyDict :: GenDict
-emptyDict = mkGenDict 0 Set.empty Set.empty 0 (const Nothing) []
+emptyDict = mkGenDict 0 Set.empty Set.empty 0 (const Nothing) 0 0 0 []
 
 mkDictValues :: Set AbiValue -> Set W256
 mkDictValues =
@@ -361,19 +451,32 @@ mutateAbiCall = traverse f
 -- @a@ from a 'GenDict', return a generator that takes an @a@ and either synthesizes new @b@s with the
 -- provided generator or uses the 'GenDict' dictionary (when available).
 genWithDict
-  :: (Eq a, Ord a, MonadRandom m)
+  :: (MonadRandom m)
   => GenDict
-  -> Map a (Set b)
+  -> (a -> m (Maybe b))
   -> (a -> m b)
   -> a
   -> m b
-genWithDict genDict m g t = do
+genWithDict genDict fromDict g t = do
   r <- getRandom
-  let maybeValM = if genDict.pSynthA >= r then fromDict else pure Nothing
-      fromDict = case Map.lookup t m of
-                   Nothing -> pure Nothing
-                   Just cs -> Just <$> rElem' cs
-  fromMaybe <$> g t <*> maybeValM
+  maybeVal <- if genDict.pSynthA >= r then fromDict t else pure Nothing
+  maybe (g t) pure maybeVal
+
+constantFromDict :: MonadRandom m => GenDict -> AbiType -> m (Maybe AbiValue)
+constantFromDict genDict abiType =
+  rElemStaticDynamic
+    (Map.findWithDefault Set.empty abiType genDict.staticConstants)
+    (Map.findWithDefault emptyBoundedSet abiType genDict.dynamicConstants)
+
+wholeCallFromDict :: MonadRandom m => GenDict -> SolSignature -> m (Maybe SolCall)
+wholeCallFromDict genDict sig =
+  rElemStaticDynamic
+    (Map.findWithDefault Set.empty sig genDict.staticWholeCalls)
+    (Map.findWithDefault emptyBoundedSet sig genDict.dynamicWholeCalls)
+
+dictValueFromDict :: MonadRandom m => GenDict -> m (Maybe W256)
+dictValueFromDict genDict =
+  rElemStaticDynamic genDict.staticDictValues genDict.dynamicDictValues
 
 -- | A small number of dummy addresses
 pregenAdds :: [Addr]
@@ -418,7 +521,7 @@ genAbiValueM' genDict funcName depth t =
         AbiTupleType v        -> AbiTuple <$> traverse (genAbiValueM' genDict funcName (depth + 1)) v
         AbiFunctionType       -> AbiFunction <$> rElem (NE.fromList pregenAdds)
                                              <*> (FunctionSelector <$> getRandom)
-  in genWithDict genDict genDict.constants go t
+  in genWithDict genDict (constantFromDict genDict) go t
 
 -- | Given a 'SolSignature', generate a random 'SolCall' with that signature,
 -- possibly with a dictionary.
@@ -426,7 +529,7 @@ genAbiCallM :: MonadRandom m => GenDict -> SolSignature -> m SolCall
 genAbiCallM genDict (name, types) = do
   let genVals = zipWithM (flip (genAbiValueM' genDict name)) types (repeat 0)
   solCall <- genWithDict genDict
-                         genDict.wholeCalls
+                         (wholeCallFromDict genDict)
                          (const ((name,) <$> genVals))
                          (name, types)
   mutateAbiCall solCall

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -500,12 +500,8 @@ callseq vm txSeq = do
       eventDiffs = extractEventValues env.dapp vm vm'
       -- union the return results with the new addresses
       additions = Map.unionsWith Set.union [resultMap, eventDiffs, diffs]
-      -- append to the constants dictionary
-      updatedDict = workerState.genDict
-        { constants = Map.unionWith Set.union workerState.genDict.constants additions
-        , dictValues = Set.union (mkDictValues $ Set.unions $ Map.elems additions)
-                                 workerState.genDict.dictValues
-        }
+      -- append to the runtime-mined constants dictionary
+      updatedDict = addDynamicConstants additions workerState.genDict
 
     -- Update the worker state
     in workerState

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -72,6 +72,12 @@ instance FromJSON EConfigWithUsage where
           fail $ show k <> ": value does not fit in 256 bits"
         else
           pure $ fromIntegral value
+      nonNegative k def = do
+        value <- v ..:? k ..!= def
+        if value < 0 then
+          lift $ fail $ show k <> ": value must be non-negative"
+        else
+          pure value
 
       txConfParser = TxConf
         <$> v ..:? "propMaxGas" ..!= maxGasPerBlock
@@ -96,6 +102,9 @@ instance FromJSON EConfigWithUsage where
         <*> (v ..:? "coverage" <&> \case Just False -> Nothing;  _ -> Just mempty)
         <*> v ..:? "seed"
         <*> v ..:? "dictFreq" ..!= 0.40
+        <*> nonNegative "dictDynamicConstantsLimit" defaultDictDynamicConstantsLimit
+        <*> nonNegative "dictDynamicValuesLimit" defaultDictDynamicValuesLimit
+        <*> nonNegative "dictDynamicCallsLimit" defaultDictDynamicCallsLimit
         <*> v ..:? "corpusDir" ..!= Nothing
         <*> v ..:? "coverageDir" ..!= Nothing
         <*> v ..:? "mutConsts" ..!= defaultMutationConsts

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -11,7 +11,6 @@ import Control.Monad.State.Strict (MonadState, gets, modify', execState)
 import Data.ByteString qualified as BS
 import Data.Map (Map, toList)
 import Data.Maybe (catMaybes)
-import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Vector qualified as V
 import Optics.Core
@@ -70,9 +69,9 @@ genTx world deployedContracts = do
   contractAList <- liftIO $ mapM (toContractA env sigMap) (toList deployedContracts)
   (dstAddr, dstAbis) <- rElem' $ Set.fromList $ catMaybes contractAList
   solCall <- genInteractionsM genDict dstAbis
-  value <- genValue txConf.maxValue genDict.dictValues world.payableSigs solCall
-  ts <- (,) <$> genDelay txConf.maxTimeDelay genDict.dictValues
-            <*> genDelay txConf.maxBlockDelay genDict.dictValues
+  value <- genValue txConf.maxValue genDict world.payableSigs solCall
+  ts <- (,) <$> genDelay txConf.maxTimeDelay genDict
+            <*> genDelay txConf.maxBlockDelay genDict
   pure $ Tx { call = SolCall solCall
             , src = sender
             , dst = dstAddr
@@ -86,20 +85,20 @@ genTx world deployedContracts = do
     toContractA env sigMap (addr, c) =
       fmap (forceAddr addr,) . snd <$> lookupUsingCodehash env.codehashMap c env.dapp sigMap
 
-genDelay :: MonadRandom m => W256 -> Set W256 -> m W256
-genDelay mv ds =
+genDelay :: MonadRandom m => W256 -> GenDict -> m W256
+genDelay mv genDict =
   join $ oftenUsually fromDict randValue
   where randValue = fromIntegral <$> getRandomR (0 :: Integer, fromIntegral mv)
-        fromDict = (`mod` (mv + 1)) <$> rElem' ds
+        fromDict = maybe randValue (pure . (`mod` (mv + 1))) =<< dictValueFromDict genDict
 
 genValue
   :: MonadRandom m
   => W256
-  -> Set W256
+  -> GenDict
   -> [FunctionSelector]
   -> SolCall
   -> m W256
-genValue mv ds ps sc =
+genValue mv genDict ps sc =
   if sig `elem` ps then
     join $ oftenUsually fromDict randValue
   else
@@ -108,7 +107,7 @@ genValue mv ds ps sc =
   where
     randValue = fromIntegral <$> getRandomR (0 :: Integer, fromIntegral mv)
     sig = (hashSig . encodeSig . signatureCall) sc
-    fromDict = (`mod` (mv + 1)) <$> rElem' ds
+    fromDict = maybe randValue (pure . (`mod` (mv + 1))) =<< dictValueFromDict genDict
 
 -- | Check if a 'Transaction' is as \"small\" (simple) as possible (using ad-hoc heuristics).
 canShrinkTx :: Tx -> Bool

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -29,6 +29,12 @@ data CampaignConf = CampaignConf
     -- ^ Seed used for the generation of random transactions
   , dictFreq           :: Float
     -- ^ Frequency for the use of dictionary values in the random transactions
+  , dictDynamicConstantsLimit :: Int
+    -- ^ Maximum runtime-mined constants to keep per ABI type
+  , dictDynamicValuesLimit :: Int
+    -- ^ Maximum runtime-mined int/uint constants to keep
+  , dictDynamicCallsLimit :: Int
+    -- ^ Maximum runtime-mined whole calls to keep per signature
   , corpusDir          :: Maybe FilePath
     -- ^ Directory to load and save lists of transactions
   , coverageDir        :: Maybe FilePath
@@ -107,6 +113,15 @@ defaultSequenceLength = 100
 
 defaultShrinkLimit :: Int
 defaultShrinkLimit = 5000
+
+defaultDictDynamicConstantsLimit :: Int
+defaultDictDynamicConstantsLimit = 4096
+
+defaultDictDynamicValuesLimit :: Int
+defaultDictDynamicValuesLimit = 8192
+
+defaultDictDynamicCallsLimit :: Int
+defaultDictDynamicCallsLimit = 1024
 
 defaultSymExecTimeout :: Int
 defaultSymExecTimeout = 30

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -6,6 +6,7 @@ import Tests.Cheat (cheatTests)
 import Tests.Compile (compilationTests)
 import Tests.Config (configTests)
 import Tests.Coverage (coverageTests)
+import Tests.Dict (dictTests)
 import Tests.Encoding (encodingJSONTests)
 import Tests.Foundry (foundryTests)
 import Tests.FoundryTestGen (foundryTestGenTests)
@@ -21,6 +22,7 @@ main :: IO ()
 main = withCurrentDirectory "./tests/solidity" . defaultMain $
          testGroup "Echidna"
            [ configTests
+           , dictTests
            , compilationTests
            , seedTests
            , integrationTests

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -1,6 +1,7 @@
 module Tests.Config (configTests) where
 
 import Control.Monad (void)
+import Data.ByteString (ByteString)
 import Data.Function ((&))
 import Data.Maybe (isJust, isNothing)
 import Data.Yaml qualified as Y
@@ -9,7 +10,12 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, assertBool, assertFailure)
 
 import Echidna.Config (defaultConfig, parseConfig)
-import Echidna.Types.Campaign (CampaignConf(..))
+import Echidna.Types.Campaign
+  ( CampaignConf(..)
+  , defaultDictDynamicCallsLimit
+  , defaultDictDynamicConstantsLimit
+  , defaultDictDynamicValuesLimit
+  )
 import Echidna.Types.Config (EConfigWithUsage(..), EConfig(..))
 import Echidna.Types.Tx (TxConf(..))
 
@@ -39,6 +45,16 @@ configTests = testGroup "Configuration tests" $
       assertBool "" $ isNothing (defaultConfig.campaignConf.corpusDir)
   , testCase "coverageDir defaults to Nothing" $
       assertBool "" $ isNothing (defaultConfig.campaignConf.coverageDir)
+  , testCase "dynamic dictionary limits default" $ do
+      assertBool "" $ defaultConfig.campaignConf.dictDynamicConstantsLimit == defaultDictDynamicConstantsLimit
+      assertBool "" $ defaultConfig.campaignConf.dictDynamicValuesLimit == defaultDictDynamicValuesLimit
+      assertBool "" $ defaultConfig.campaignConf.dictDynamicCallsLimit == defaultDictDynamicCallsLimit
+  , testCase "dynamic dictionary limits reject negative values" $
+      mapM_ assertRejectsNegative
+        ([ "dictDynamicConstantsLimit"
+        , "dictDynamicValuesLimit"
+        , "dictDynamicCallsLimit"
+        ] :: [ByteString])
   , testCase "default.yaml" $ do
       EConfigWithUsage _ bad unset <- parseConfig "basic/default.yaml"
       assertBool ("unused options: " ++ show bad) $ null bad
@@ -56,3 +72,7 @@ configTests = testGroup "Configuration tests" $
         Left _ -> pure ()
   ]
   where files = ["basic/config.yaml", "basic/default.yaml", "basic/coverage-test.yaml", "basic/corpus-fallback-test.yaml"]
+        assertRejectsNegative key =
+          case Y.decodeEither' (key <> ": -1") of
+            Right (_ :: EConfigWithUsage) -> assertFailure $ show key <> " should not decode"
+            Left _ -> pure ()

--- a/src/test/Tests/Dict.hs
+++ b/src/test/Tests/Dict.hs
@@ -1,0 +1,83 @@
+module Tests.Dict (dictTests) where
+
+import Data.Foldable qualified as Foldable
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+
+import EVM.ABI (AbiType(AbiUIntType), AbiValue(AbiUInt))
+
+import Echidna.ABI
+import Echidna.Types.Signature (SolCall, SolSignature)
+
+dictTests :: TestTree
+dictTests =
+  testGroup "Dictionary tests"
+    [ boundedSetTests
+    , genDictTests
+    ]
+
+boundedSetTests :: TestTree
+boundedSetTests =
+  testGroup "BoundedSet"
+    [ testCase "evicts oldest values by FIFO order" $ do
+        let bounded = boundedInsertSet 2 Set.empty (Set.fromList [1 :: Int, 2, 3]) emptyBoundedSet
+        assertEqual "" [2, 3] (boundedElems bounded)
+    , testCase "duplicate insert does not refresh position" $ do
+        let bounded = boundedInsertSet 2 Set.empty (Set.fromList [1 :: Int, 2]) emptyBoundedSet
+            bounded' = boundedInsert 2 Set.empty 1 bounded
+            bounded'' = boundedInsert 2 Set.empty 3 bounded'
+        assertEqual "" [2, 3] (boundedElems bounded'')
+    , testCase "limit zero stores nothing" $ do
+        let bounded = boundedInsert 0 Set.empty (1 :: Int) emptyBoundedSet
+        assertEqual "" [] (boundedElems bounded)
+    , testCase "static values are not inserted dynamically" $ do
+        let bounded = boundedInsert 2 (Set.singleton (1 :: Int)) 1 emptyBoundedSet
+        assertEqual "" [] (boundedElems bounded)
+    ]
+
+genDictTests :: TestTree
+genDictTests =
+  testGroup "GenDict"
+    [ testCase "dynamic constants are capped per ABI type and static constants survive" $ do
+        let dict = mkGenDict 1 (Set.singleton abi1) Set.empty 0 (const Nothing) 2 10 10 []
+            dict' = addDynamicConstants (Map.singleton abiUInt (Set.fromList [abi1, abi2, abi3, abi4])) dict
+        assertBool "static constant should remain static" $
+          abi1 `Set.member` Map.findWithDefault Set.empty abiUInt dict'.staticConstants
+        assertEqual "" [abi3, abi4] $
+          boundedElems (Map.findWithDefault emptyBoundedSet abiUInt dict'.dynamicConstants)
+    , testCase "dynamic int dictionary is capped separately from static values" $ do
+        let dict = mkGenDict 1 (Set.singleton abi1) Set.empty 0 (const Nothing) 10 2 10 []
+            dict' = addDynamicConstants (Map.singleton abiUInt (Set.fromList [abi1, abi2, abi3, abi4])) dict
+        assertBool "static numeric value should remain static" $
+          1 `Set.member` dict'.staticDictValues
+        assertEqual "" [3, 4] (boundedElems dict'.dynamicDictValues)
+    , testCase "dynamic whole calls are capped per signature" $ do
+        let call1 = solCall "f" [abi1]
+            call2 = solCall "f" [abi2]
+            sig = solSig "f" [abiUInt]
+            dict = mkGenDict 1 Set.empty Set.empty 0 (const Nothing) 10 10 1 []
+            dict' = gaddCalls (Set.fromList [call1, call2]) dict
+        assertEqual "" [call2] $
+          boundedElems (Map.findWithDefault emptyBoundedSet sig dict'.dynamicWholeCalls)
+    ]
+
+boundedElems :: BoundedSet a -> [a]
+boundedElems = Foldable.toList . (.boundedOrder)
+
+abiUInt :: AbiType
+abiUInt = AbiUIntType 256
+
+abi1, abi2, abi3, abi4 :: AbiValue
+abi1 = AbiUInt 256 1
+abi2 = AbiUInt 256 2
+abi3 = AbiUInt 256 3
+abi4 = AbiUInt 256 4
+
+solCall :: Text -> [AbiValue] -> SolCall
+solCall name values = (name, values)
+
+solSig :: Text -> [AbiType] -> SolSignature
+solSig name types = (name, types)

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -64,6 +64,12 @@ timeout: null
 #dictFreq controls how often to use echidna's internal dictionary vs random
 #values
 dictFreq: 0.40
+#maximum runtime-mined constants to keep per ABI type
+dictDynamicConstantsLimit: 4096
+#maximum runtime-mined int/uint constants to keep
+dictDynamicValuesLimit: 8192
+#maximum runtime-mined whole calls to keep per signature
+dictDynamicCallsLimit: 1024
 maxTimeDelay: 604800
 #maximum time between generated txs; default is one week
 maxBlockDelay: 60480


### PR DESCRIPTION
 **WARNING: This is 100% vibecoded**

Successfully tested locally
 
  This PR splits Echidna’s generation dictionary into permanent static entries and FIFO-capped  runtime entries.

  Runtime-mined constants from return values, events, created addresses, numeric dict values, and  coverage-discovered whole calls were previously retained without bounds. Long-running campaigns could accumulate large Set/Map structures and drive high residency.

  Changes:

  - Keep Slither/static constants permanently.
  - Store runtime-mined constants in FIFO-capped dynamic dictionaries.
  - Add config limits:
      - dictDynamicConstantsLimit default 4096 per ABI type
      - dictDynamicValuesLimit default 8192
      - dictDynamicCallsLimit default 1024 per signature
  - Reject negative dynamic dictionary limits.
  - Add tests for FIFO eviction, static preservation, limit-zero behavior, and config validation.

  Tested with:

  - stack build
  - Dictionary tests
  - Dynamic dictionary config tests
