### PR TITLE
Distribute replay corpus evenly across all fuzz workers [Vibecoded]

### DIFF
--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -13,7 +13,7 @@ import Control.Monad.Catch
 import Control.Monad.Reader
 import Control.Monad.State.Strict hiding (state)
 import Data.ByteString.Lazy qualified as BS
-import Data.List.Split (chunksOf)
+import Data.List.Split (splitPlaces)
 import Data.Map (Map)
 import Data.Maybe (isJust, mapMaybe)
 import Data.Sequence ((|>))
@@ -89,9 +89,11 @@ ui vm dict initialCorpus cliSelectedContract = do
     perWorkerTestLimit = ceiling
       (fromIntegral conf.campaignConf.testLimit / fromIntegral nFuzzWorkers :: Double)
 
-    chunkSize = ceiling
-      (fromIntegral (length initialCorpus) / fromIntegral nFuzzWorkers :: Double)
-    corpusChunks = chunksOf chunkSize initialCorpus ++ repeat []
+    (corpusChunkSize, largerCorpusChunks) = length initialCorpus `divMod` nFuzzWorkers
+    corpusChunkSizes =
+      replicate largerCorpusChunks (corpusChunkSize + 1) <>
+      replicate (nFuzzWorkers - largerCorpusChunks) corpusChunkSize
+    corpusChunks = splitPlaces corpusChunkSizes initialCorpus ++ repeat []
 
   corpusSaverStopVar <- spawnListener (saveCorpusEvent env)
 


### PR DESCRIPTION
**WARNING: This is 100% vibecoded**

Successfully tested locally

Code suggested by @elopez 

Fixes corpus replay chunking so the initial corpus is distributed evenly across all fuzz workers.

  Previously, Echidna used ceiling (corpusSize / nWorkers) with chunksOf. For corpus sizes like 64  and 12 workers, this produced 11 chunks plus an empty chunk, leaving one worker with no replay  work. 

  This PR uses divMod and splitPlaces to produce exactly one chunk per fuzz worker:

  - first r workers get q + 1 corpus entries
  - remaining workers get q corpus entries
  - no accidental empty worker unless the corpus is genuinely smaller than the worker count

