### PR TITLE
Use broadcast TChan for campaign events

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -1,6 +1,5 @@
 module Echidna where
 
-import Control.Concurrent (newChan)
 import Control.Monad.Catch (MonadThrow(..))
 import Control.Monad.IO.Class (liftIO)
 import Data.IORef (newIORef)
@@ -14,6 +13,7 @@ import Data.Text qualified as T
 import System.Console.ANSI (hNowSupportsANSI)
 import System.FilePath ((</>))
 import System.IO (stderr, stdout, hPutStrLn)
+import UnliftIO.STM (newBroadcastTChanIO)
 
 import EVM (cheatCode)
 import EVM.ABI (AbiValue(AbiAddress))
@@ -124,7 +124,7 @@ mkEnv :: EConfig -> BuildOutput -> [EchidnaTest] -> World -> Maybe SlitherInfo -
 mkEnv cfg buildOutput tests world slitherInfo = do
   codehashMap <- newIORef mempty
   chainId <- Onchain.fetchChainIdFrom cfg.rpcUrl
-  eventQueue <- newChan
+  eventQueue <- newBroadcastTChanIO
   coverageRefInit <- newIORef mempty
   coverageRefRuntime <- newIORef mempty
   corpusRef <- newIORef mempty

--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -1,8 +1,6 @@
 module Echidna where
 
-import Control.Concurrent (forkIO, newChan, readChan)
-import Control.Exception (SomeException, handle)
-import Control.Monad (forever, void)
+import Control.Concurrent (newChan)
 import Control.Monad.Catch (MonadThrow(..))
 import Control.Monad.IO.Class (liftIO)
 import Data.IORef (newIORef)
@@ -127,11 +125,6 @@ mkEnv cfg buildOutput tests world slitherInfo = do
   codehashMap <- newIORef mempty
   chainId <- Onchain.fetchChainIdFrom cfg.rpcUrl
   eventQueue <- newChan
-  -- Consumers read events from their own 'dupChan', so this original read end
-  -- is never advanced and would otherwise pin every event ever written. Drain
-  -- it from a dedicated thread so the GC can reclaim delivered events.
-  void $ forkIO $ handle (\(_ :: SomeException) -> pure ()) $
-    forever $ void $ readChan eventQueue
   coverageRefInit <- newIORef mempty
   coverageRefRuntime <- newIORef mempty
   corpusRef <- newIORef mempty

--- a/lib/Echidna/Server.hs
+++ b/lib/Echidna/Server.hs
@@ -1,6 +1,6 @@
 module Echidna.Server where
 
-import Control.Concurrent
+import Control.Concurrent (MVar, forkIO, putMVar)
 import Control.Monad (forever, when, void)
 import Data.Aeson
 import Data.Binary.Builder (fromLazyByteString)
@@ -44,11 +44,11 @@ instance ToJSON SSE where
 runSSEServer :: MVar () -> Env -> Word16 -> Int -> IO ()
 runSSEServer serverStopVar env port nworkers = do
   aliveRef <- newIORef nworkers
-  sseChan <- dupChan env.eventQueue
+  sseChan <- atomically $ dupTChan env.eventQueue
   broadcastChan <- newBroadcastTChanIO
 
   void . forkIO . forever $ do
-    event@(_, campaignEvent) <- readChan sseChan
+    event@(_, campaignEvent) <- atomically $ readTChan sseChan
     let eventName = \case
           WorkerEvent _ _ workerEvent ->
             case workerEvent of

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -1,12 +1,12 @@
 module Echidna.Types.Config where
 
-import Control.Concurrent (Chan)
 import Data.Aeson.Key (Key)
 import Data.IORef (IORef)
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time (LocalTime)
 import Data.Word (Word64)
+import UnliftIO.STM (TChan)
 
 import EVM.Dapp (DappInfo)
 import EVM.Fetch qualified as Fetch
@@ -78,7 +78,7 @@ data Env = Env
 
   -- | Shared between all workers. Events are fairly rare so contention is
   -- minimal.
-  , eventQueue :: Chan (LocalTime, CampaignEvent)
+  , eventQueue :: TChan (LocalTime, CampaignEvent)
 
   , testRefs :: [IORef EchidnaTest]
   , coverageRefInit :: IORef CoverageMap

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -28,6 +28,7 @@ import System.Signal
 import UnliftIO
   ( MonadUnliftIO, IORef, newIORef, readIORef, hFlush, stdout , writeIORef, timeout)
 import UnliftIO.Concurrent hiding (killThread, threadDelay)
+import UnliftIO.STM (atomically, writeTChan)
 
 import EVM.Fetch qualified
 import EVM.Types (Addr, Contract, VM, VMType(Concrete), W256)
@@ -117,7 +118,7 @@ ui vm dict initialCorpus cliSelectedContract = do
       let forwardEvent = void . writeBChanNonBlocking uiChannel . EventReceived
 
       -- Attach the log/event forwarder before workers start so early worker
-      -- events (like startup logs) are not lost by dupChan.
+      -- events (like startup logs) are not lost by dupTChan.
       uiEventsForwarderStopVar <- spawnListener forwardEvent
       workers <- spawnWorkers
 
@@ -190,7 +191,7 @@ ui vm dict initialCorpus cliSelectedContract = do
 
       let forwardEvent ev = putStrLn =<< runReaderT (ppLogLine vm ev) env
       -- Attach the log/event forwarder before workers start so early worker
-      -- events (like startup logs) are not lost by dupChan.
+      -- events (like startup logs) are not lost by dupTChan.
       uiEventsForwarderStopVar <- spawnListener forwardEvent
       workers <- spawnWorkers
 
@@ -291,7 +292,8 @@ ui vm dict initialCorpus cliSelectedContract = do
         _ -> pure ()
 
       time <- liftIO getTimestamp
-      writeChan env.eventQueue (time, WorkerEvent workerId workerType (WorkerStopped stopReason))
+      liftIO $ atomically $
+        writeTChan env.eventQueue (time, WorkerEvent workerId workerType (WorkerStopped stopReason))
 
     pure (threadId, stateRef)
 

--- a/lib/Echidna/Worker.hs
+++ b/lib/Echidna/Worker.hs
@@ -7,6 +7,7 @@ import Control.Monad.State.Strict(MonadState(..), gets)
 import Data.Aeson
 import Data.Text (unpack)
 import Data.Time (LocalTime)
+import UnliftIO.STM (TChan, atomically, dupTChan, readTChan, writeTChan)
 
 import Echidna.ABI (encodeSig)
 import Echidna.Types.Campaign
@@ -51,7 +52,7 @@ pushWorkerEvent event = do
 pushCampaignEvent :: Env -> CampaignEvent -> IO ()
 pushCampaignEvent env event = do
   time <- liftIO getTimestamp
-  writeChan env.eventQueue (time, event)
+  atomically $ writeTChan env.eventQueue (time, event)
 
 -- | Listener reads events and runs the given 'handler' function. It exits after
 -- receiving all 'WorkerStopped' events and sets the returned 'MVar' so the
@@ -70,7 +71,7 @@ spawnListener handler = do
   cfg <- asks (.cfg)
   let nworkers = getNWorkers cfg.campaignConf
   eventQueue <- asks (.eventQueue)
-  chan <- liftIO $ dupChan eventQueue
+  chan <- liftIO $ atomically $ dupTChan eventQueue
   stopVar <- liftIO newEmptyMVar
   liftIO $ void $ forkFinally (listenerLoop handler chan nworkers) (const $ putMVar stopVar ())
   pure stopVar
@@ -81,14 +82,14 @@ listenerLoop
   :: (MonadIO m)
   => ((LocalTime, CampaignEvent) -> m ())
   -- ^ a function that handles the events
-  -> Chan (LocalTime, CampaignEvent)
+  -> TChan (LocalTime, CampaignEvent)
   -- ^ event channel
   -> Int
   -- ^ number of workers which have to stop before loop exits
   -> m ()
 listenerLoop handler chan !workersAlive =
   when (workersAlive > 0) $ do
-    event <- liftIO $ readChan chan
+    event <- liftIO $ atomically $ readTChan chan
     handler event
     case event of
       (_, WorkerEvent _ _ (WorkerStopped _)) -> listenerLoop handler chan (workersAlive - 1)

--- a/lib/Echidna/Worker/Sequence.hs
+++ b/lib/Echidna/Worker/Sequence.hs
@@ -254,10 +254,7 @@ updateOpenTest vm reproducer test = do
                            , result
                            , workerId
                            }
-          -- Publish a VM-free copy, forced strict so the event can't retain the
-          -- VM through a thunk. testRefs keeps the full 'test'' for shrinking.
-          let !vmFreeTest = test' { Test.vm = Nothing }
-          pushWorkerEvent (TestFalsified vmFreeTest)
+          pushWorkerEvent (TestFalsified test')
           pure $ Just test'
 
         IntValue value' | value' > value -> do
@@ -266,9 +263,7 @@ updateOpenTest vm reproducer test = do
                            , vm = Just vm
                            , result
                            }
-          -- VM-free copy, as in the TestFalsified case above.
-          let !vmFreeTest = test' { Test.vm = Nothing }
-          pushWorkerEvent (TestOptimized vmFreeTest)
+          pushWorkerEvent (TestOptimized test')
           pure $ Just test'
           where
           value =

--- a/lib/Echidna/Worker/Sequence.hs
+++ b/lib/Echidna/Worker/Sequence.hs
@@ -254,7 +254,10 @@ updateOpenTest vm reproducer test = do
                            , result
                            , workerId
                            }
-          pushWorkerEvent (TestFalsified test')
+          -- Publish a VM-free copy, forced strict so the event can't retain the
+          -- VM through a thunk. testRefs keeps the full 'test'' for shrinking.
+          let !vmFreeTest = test' { Test.vm = Nothing }
+          pushWorkerEvent (TestFalsified vmFreeTest)
           pure $ Just test'
 
         IntValue value' | value' > value -> do
@@ -263,7 +266,9 @@ updateOpenTest vm reproducer test = do
                            , vm = Just vm
                            , result
                            }
-          pushWorkerEvent (TestOptimized test')
+          -- VM-free copy, as in the TestFalsified case above.
+          let !vmFreeTest = test' { Test.vm = Nothing }
+          pushWorkerEvent (TestOptimized vmFreeTest)
           pure $ Just test'
           where
           value =

--- a/lib/Echidna/Worker/Symbolic.hs
+++ b/lib/Echidna/Worker/Symbolic.hs
@@ -3,7 +3,7 @@
 
 module Echidna.Worker.Symbolic (runSymWorker) where
 
-import Control.Concurrent (dupChan, takeMVar)
+import Control.Concurrent (takeMVar)
 import Control.Monad (forM_, unless, void, when)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Random.Strict (evalRandT)
@@ -17,6 +17,7 @@ import Data.Map qualified as Map
 import Data.Maybe (fromJust)
 import Data.Text (Text, unpack)
 import System.Random (mkStdGen)
+import UnliftIO.STM (atomically, dupTChan)
 
 import EVM.Dapp (DappInfo(..))
 import EVM.Solidity (Method(..), SolcContract(..))
@@ -54,7 +55,7 @@ runSymWorker callback vm dict workerId name = do
   cfg <- asks (.cfg)
   let nworkers = getNFuzzWorkers cfg.campaignConf -- getNFuzzWorkers, NOT getNWorkers
   eventQueue <- asks (.eventQueue)
-  chan <- liftIO $ dupChan eventQueue
+  chan <- liftIO $ atomically $ dupTChan eventQueue
 
   flip runStateT initialState $
     flip evalRandT (mkStdGen effectiveSeed) $ do -- unused but needed for callseq


### PR DESCRIPTION
Replace the campaign event queue with an STM broadcast TChan so subscribers keep the existing events-after-subscribe behavior without the Chan root cursor retention issue. Producers now write through STM, and campaign/UI/SSE listeners subscribe with dupTChan/readTChan.

Avoid retaining full VM snapshots in queued TestFalsified/TestOptimized events by publishing VM-free EchidnaTest copies. The canonical testRefs state still keeps the VM so shrinking, reports, traces, and final JSON continue to work.