### PR TITLE
Fix unbounded thunk accumulation in GenDict constants update

### DIFF
--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -20,6 +20,7 @@ import Data.List qualified as List
 import Data.List.NonEmpty qualified as NEList
 import Data.Map (Map, (\\))
 import Data.Map qualified as Map
+import Data.Map.Strict qualified as MapStrict
 import Data.Maybe (isJust, mapMaybe, fromJust)
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -502,7 +503,13 @@ callseq vm txSeq = do
       additions = Map.unionsWith Set.union [resultMap, eventDiffs, diffs]
       -- append to the constants dictionary
       updatedDict = workerState.genDict
-        { constants = Map.unionWith Set.union workerState.genDict.constants additions
+        -- the union must be strict in the per-key sets: with the lazy Map a
+        -- `Set.union old new` suspension is allocated per colliding key per
+        -- callseq, and it is only ever forced if the generator samples that
+        -- AbiType -- types that never occur as a fuzzed function argument
+        -- (always AbiAddressType, inserted unconditionally above) accumulate
+        -- an unbounded thunk chain
+        { constants = MapStrict.unionWith Set.union workerState.genDict.constants additions
         , dictValues = Set.union (mkDictValues $ Set.unions $ Map.elems additions)
                                  workerState.genDict.dictValues
         }


### PR DESCRIPTION
Every call sequence updates the constants dictionary with the lazy Data.Map's `unionWith Set.union`, which allocates a suspended `Set.union old new` per colliding key. Such a suspension is only forced when the generator samples that key's AbiType (genWithDict), and only the argument types of fuzzed functions are ever sampled. Since callseq unconditionally inserts an AbiAddressType entry into the additions map (even when no contract was created), any target ABI without an `address`-typed parameter accumulates a never-forced chain of union thunks: one per call sequence per worker, for the campaign lifetime.

On a minimal one-function contract this leaks ~0.4 B/call (~31 kB/s at ~75k calls/s), 100% of live-heap growth: the heap census shows a single monotonically growing THUNK band, info-table profiling points at the Map.unionWith specialization's collision branch, and retainer profiling roots it at callseq's WorkerState.genDict. Note this is distinct from the dictionary's known value growth -- it happens even when no new constants are harvested at all.

Use Data.Map.Strict.unionWith so per-key sets are forced as they are unioned. Measured on the reproducer: live-heap slope drops from ~31,010 B/s to ~3 B/s over 93M calls, with identical coverage and corpus behavior.