### PR TITLE
Fix divide-by-zero distributing corpus with zero workers

### DIFF
--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -89,11 +89,16 @@ ui vm dict initialCorpus cliSelectedContract = do
     perWorkerTestLimit = ceiling
       (fromIntegral conf.campaignConf.testLimit / fromIntegral nFuzzWorkers :: Double)
 
-    (corpusChunkSize, largerCorpusChunks) = length initialCorpus `divMod` nFuzzWorkers
-    corpusChunkSizes =
-      replicate largerCorpusChunks (corpusChunkSize + 1) <>
-      replicate (nFuzzWorkers - largerCorpusChunks) corpusChunkSize
-    corpusChunks = splitPlaces corpusChunkSizes initialCorpus ++ repeat []
+    -- Distribute the replay corpus across the fuzz workers. The symbolic
+    -- worker always replays the full corpus (see spawnWorker), so with no
+    -- fuzz workers there is nothing to distribute.
+    corpusChunks
+      | nFuzzWorkers == 0 = repeat []
+      | otherwise = splitPlaces chunkSizes initialCorpus ++ repeat []
+      where
+        (baseSize, remainder) = length initialCorpus `divMod` nFuzzWorkers
+        chunkSizes = replicate remainder (baseSize + 1)
+                  <> replicate (nFuzzWorkers - remainder) baseSize
 
   corpusSaverStopVar <- spawnListener (saveCorpusEvent env)
 


### PR DESCRIPTION
The corpus distribution introduced in 92b90d4a uses integer divMod by nFuzzWorkers, which throws on workers: 0 (symbolic-only mode, where the sym worker is the only worker and forces the corpus chunks). Guard the nFuzzWorkers == 0 case explicitly: there are no fuzz workers to distribute to, and the symbolic worker replays the full corpus anyway.