### PR TITLE
Reject precompile deployment addresses

### DIFF
--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -72,6 +72,15 @@ instance FromJSON EConfigWithUsage where
           fail $ show k <> ": value does not fit in 256 bits"
         else
           pure $ fromIntegral value
+      rejectPrecompileAddress field addr
+        | addr `Set.member` precompileAddresses =
+          fail $ field <> ": address " <> show addr <> " is reserved for an EVM precompile"
+        | otherwise = pure addr
+      rejectPrecompileDeployments field =
+        traverse $ \(addr, target) -> do
+          addr' <- rejectPrecompileAddress field addr
+          pure (addr', target)
+      precompileAddresses = Set.fromList [1..10]
 
       txConfParser = TxConf
         <$> v ..:? "propMaxGas" ..!= maxGasPerBlock
@@ -120,7 +129,7 @@ instance FromJSON EConfigWithUsage where
           Nothing                -> pure Bitwuzla
 
       solConfParser = SolConf
-        <$> v ..:? "contractAddr"    ..!= defaultContractAddr
+        <$> (v ..:? "contractAddr"    ..!= defaultContractAddr >>= rejectPrecompileAddress "contractAddr")
         <*> v ..:? "deployer"        ..!= defaultDeployerAddr
         <*> v ..:? "sender"          ..!= Set.fromList [0x10000, 0x20000, defaultDeployerAddr]
         <*> v ..:? "balanceAddr"     ..!= 0xffffffff
@@ -132,8 +141,8 @@ instance FromJSON EConfigWithUsage where
         <*> v ..:? "solcArgs"        ..!= ""
         <*> v ..:? "solcLibs"        ..!= []
         <*> v ..:? "quiet"           ..!= False
-        <*> v ..:? "deployContracts" ..!= []
-        <*> v ..:? "deployBytecodes" ..!= []
+        <*> (v ..:? "deployContracts" ..!= [] >>= rejectPrecompileDeployments "deployContracts")
+        <*> (v ..:? "deployBytecodes" ..!= [] >>= rejectPrecompileDeployments "deployBytecodes")
         <*> ((<|>) <$> v ..:? "allContracts"
                    -- TODO: keep compatible with the old name for a while
                    <*> lift (v .:? "multi-abi")) ..!= False

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -13,6 +13,7 @@ import Data.Set qualified as Set
 import Data.Text (isPrefixOf)
 import Data.Yaml qualified as Y
 
+import EVM (isPrecompileAddr')
 import EVM.Solvers (Solver(..))
 import EVM.Types (Addr, VM(..), W256)
 
@@ -73,14 +74,13 @@ instance FromJSON EConfigWithUsage where
         else
           pure $ fromIntegral value
       rejectPrecompileAddress field addr
-        | addr `Set.member` precompileAddresses =
+        | isPrecompileAddr' addr =
           fail $ field <> ": address " <> show addr <> " is reserved for an EVM precompile"
         | otherwise = pure addr
       rejectPrecompileDeployments field =
         traverse $ \(addr, target) -> do
           addr' <- rejectPrecompileAddress field addr
           pure (addr', target)
-      precompileAddresses = Set.fromList [1..10]
 
       txConfParser = TxConf
         <$> v ..:? "propMaxGas" ..!= maxGasPerBlock

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -64,8 +64,9 @@ configTests = testGroup "Configuration tests" $
               Right (_ :: EConfigWithUsage) -> pure ()
               Left e -> assertFailure $ "unexpected decoding error: " <> show e
       shouldReject "contractAddr: \"0x1\""
-      shouldReject "deployContracts: [[\"0x1\", \"A\"]]"
+      shouldReject "contractAddr: \"0x11\""
+      shouldReject "deployContracts: [[\"0x100\", \"A\"]]"
       shouldReject "deployBytecodes: [[\"0xa\", \"00\"]]"
-      shouldAccept "contractAddr: \"0xb\"\ndeployContracts: [[\"0xb\", \"A\"]]\ndeployBytecodes: [[\"0xb\", \"00\"]]"
+      shouldAccept "contractAddr: \"0x12\"\ndeployContracts: [[\"0x12\", \"A\"]]\ndeployBytecodes: [[\"0x101\", \"00\"]]"
   ]
   where files = ["basic/config.yaml", "basic/default.yaml", "basic/coverage-test.yaml", "basic/corpus-fallback-test.yaml"]

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -54,5 +54,18 @@ configTests = testGroup "Configuration tests" $
       case Y.decodeEither' ("maxGasprice: " <> overW256) of
         Right (_ :: EConfigWithUsage) -> assertFailure "should not decode"
         Left _ -> pure ()
+  , testCase "reject precompile deployment addresses" $ do
+      let shouldReject config =
+            case Y.decodeEither' config of
+              Right (_ :: EConfigWithUsage) -> assertFailure "should not decode"
+              Left _ -> pure ()
+          shouldAccept config =
+            case Y.decodeEither' config of
+              Right (_ :: EConfigWithUsage) -> pure ()
+              Left e -> assertFailure $ "unexpected decoding error: " <> show e
+      shouldReject "contractAddr: \"0x1\""
+      shouldReject "deployContracts: [[\"0x1\", \"A\"]]"
+      shouldReject "deployBytecodes: [[\"0xa\", \"00\"]]"
+      shouldAccept "contractAddr: \"0xb\"\ndeployContracts: [[\"0xb\", \"A\"]]\ndeployBytecodes: [[\"0xb\", \"00\"]]"
   ]
   where files = ["basic/config.yaml", "basic/default.yaml", "basic/coverage-test.yaml", "basic/corpus-fallback-test.yaml"]


### PR DESCRIPTION
Part of #1430

## Summary
- reject `contractAddr` values in the EVM precompile range
- reject `deployContracts` and `deployBytecodes` entries targeting precompile addresses
- add config parser coverage for rejected and allowed deployment addresses

## Tests
- `stack test --test-arguments '-p "Configuration tests"'`
- `stack build --test --no-run-tests --ghc-options='-Werror'`
- `hlint lib/Echidna/Config.hs src/test/Tests/Config.hs`
