### PR TITLE
Echidna 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 ## Unreleased
 
+## 2.3.3
+
+* New `excludeViewPure` option to disable testing of view and pure functions in property mode, except those with the test prefix (#1552)
 * The reason a test failed (e.g. revert, returned false) is now shown consistently in the text, JSON and UI outputs, including when no transactions are required to reproduce the failure (#1476)
+* Foundry reproducers are now generated for assertion failures that emit events (#1550)
+* The replay corpus is now distributed evenly across all fuzz workers (#1565), and a divide-by-zero when using `workers: 0` was fixed (#1583)
+* Fixed a desync between the transaction sequence and traces shown for shrunk reproducers (#1554)
+* Fixed two memory leaks, one in the constants dictionary (#1577) and one in the campaign event queue (#1587)
+* ANSI escape codes are now disabled when Echidna's output is not a TTY (#1567)
+* The UI event listener is now started before the workers to avoid missing early events (#1563)
+* Deploying contracts to precompile addresses is now rejected with an error (#1585)
+* Fixed TLS handshake failures when fetching contracts from RPC providers using certificate compression, such as Alchemy, by updating `tls` to 2.2.2 (#1581)
+* Fixed libff header installation with CMake 4.3+ (#1573)
+* Updated hevm to `408bf31` with support for dynamic argument inputs in symbolic mode (#1575, #1580)
 
 ## 2.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Deploying contracts to precompile addresses is now rejected with an error (#1585)
 * Fixed TLS handshake failures when fetching contracts from RPC providers using certificate compression, such as Alchemy, by updating `tls` to 2.2.2 (#1581)
 * Fixed libff header installation with CMake 4.3+ (#1573)
-* Updated hevm to `408bf31` with support for dynamic argument inputs in symbolic mode (#1575, #1580)
+* Updated hevm to `4ca42fd` (0.58.0) with support for dynamic argument inputs in symbolic mode (#1575, #1580)
 
 ## 2.3.2
 

--- a/flake.nix
+++ b/flake.nix
@@ -100,8 +100,8 @@
           (pkgs.haskellPackages.callCabal2nix "hevm" (pkgs.fetchFromGitHub {
             owner = "argotorg";
             repo = "hevm";
-            rev = "408bf3100f1edbfc489b21b5218332e583e503a7";
-            sha256 = "sha256-iJwO0tXuHe5dbPuzIdLHMVW8U4TwAqrC0VKmZcuz9S4=";
+            rev = "4ca42fd5b2dd1344b7596775fe5fe6ac2d03021f";
+            sha256 = "sha256-Gk1hroTuQuS4blEX4M4wJ7tDNg+hnMHSwtdFKpv0Gyc=";
           }) { secp256k1 = pkgs.secp256k1; })
           ([
             pkgs.haskell.lib.compose.dontCheck

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@ name: echidna
 author: Trail of Bits <opensource@trailofbits.com>
 maintainer: Trail of Bits <opensource@trailofbits.com>
 
-version: 2.3.2
+version: 2.3.3
 
 ghc-options:
   - -O2

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@ allow-newer-deps:
 
 extra-deps:
 - git: https://github.com/argotorg/hevm.git
-  commit: 408bf3100f1edbfc489b21b5218332e583e503a7
+  commit: 4ca42fd5b2dd1344b7596775fe5fe6ac2d03021f
 
 # Bump tls to >= 2.2.2 for the fix in https://github.com/haskell-tls/hs-tls/pull/515.
 # tls 2.2.2 needs the crypton-x509 1.8 line, which migrated from asn1-*/pem/hourglass to


### PR DESCRIPTION
Prepare the 2.3.3 release:

* Bump version to 2.3.3
* Update CHANGELOG with all user-facing changes since 2.3.2 (#1476, #1550, #1552, #1554, #1563, #1565, #1567, #1573, #1575, #1577, #1580, #1581, #1583, #1585, #1587)
* Update hevm to `4ca42fd` (0.58.0), which additionally brings a fix for cheatcode string arguments with invalid UTF-8

Verified that the branch builds with the new hevm pin and that the binary reports `Echidna 2.3.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)