### PR TITLE
fix: handle verification and Foundry campaign modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * New `verification` test mode to symbolically verify each function of a contract using a single transaction, instead of configuring the symbolic worker by hand (#1595)
 * Foundry mode now follows Foundry's function naming conventions more closely: `invariant`- and `statefulFuzz`-prefixed functions are stateful invariants, and `testFail`-prefixed tests are expected to revert (#1595)
 * Foundry mode now only calls parameterized `test` functions when `seqLen` is 1, matching Foundry's stateless fuzzing (#1595)
-* `check`- and `prove`-prefixed functions are always verified in verification mode, even when no assertion was found in them (#1595)
+* `check`- and `prove`-prefixed functions are always verified in verification mode, even when no assertion was found in them, and are fuzzed like any other test function in foundry mode (#1595)
 
 ## 2.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+* New `verification` test mode to symbolically verify each function of a contract using a single transaction, instead of configuring the symbolic worker by hand (#1595)
+* Foundry mode now follows Foundry's function naming conventions more closely: `invariant`- and `statefulFuzz`-prefixed functions are stateful invariants, and `testFail`-prefixed tests are expected to revert (#1595)
+* Foundry mode now only calls parameterized `test` functions when `seqLen` is 1, matching Foundry's stateless fuzzing (#1595)
+* `check`- and `prove`-prefixed functions are always verified in verification mode, even when no assertion was found in them (#1595)
+
 ## 2.3.3
 
 * New `excludeViewPure` option to disable testing of view and pure functions in property mode, except those with the test prefix (#1552)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ The example above uses the default **property** mode, but Echidna supports sever
 
 * **`property`** (default): Test `echidna_`-prefixed functions that return `bool`.
 * **`assertion`**: Detect assertion failures from `assert()` and Foundry's `assertX` helpers (`assertTrue`, `assertEq`, etc.).
-* **`foundry`**: Run Foundry-style `test`-prefixed unit tests and `invariant_`-prefixed stateful invariants.
+* **`foundry`**: Run Foundry-style tests, following its naming conventions: `test`-prefixed unit and fuzz tests (`testFail`-prefixed ones are expected to revert) and `invariant`- or `statefulFuzz`-prefixed stateful invariants.
+* **`verification`**: Symbolically verify each function of the contract using a single transaction. `check`- and `prove`-prefixed functions are always used as entry points.
 * **`overflow`**: Detect integer over/underflows (Solidity >= 0.8.0).
 * **`optimization`**: Maximize the return value of `echidna_`-prefixed functions that return `int256` (uses the same configurable prefix as property mode).
 * **`exploration`**: Collect coverage without checking properties.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The example above uses the default **property** mode, but Echidna supports sever
 
 * **`property`** (default): Test `echidna_`-prefixed functions that return `bool`.
 * **`assertion`**: Detect assertion failures from `assert()` and Foundry's `assertX` helpers (`assertTrue`, `assertEq`, etc.).
-* **`foundry`**: Run Foundry-style tests, following its naming conventions: `test`-prefixed unit and fuzz tests (`testFail`-prefixed ones are expected to revert) and `invariant`- or `statefulFuzz`-prefixed stateful invariants.
+* **`foundry`**: Run Foundry-style tests, following its naming conventions: `test`-prefixed unit and fuzz tests (`testFail`-prefixed ones are expected to revert) and `invariant`- or `statefulFuzz`-prefixed stateful invariants. `check`- and `prove`-prefixed functions are symbolic entry points, but since this mode is a fuzzing campaign, they are fuzzed like any other test function.
 * **`verification`**: Symbolically verify each function of the contract using a single transaction. `check`- and `prove`-prefixed functions are always used as entry points.
 * **`overflow`**: Detect integer over/underflows (Solidity >= 0.8.0).
 * **`optimization`**: Maximize the return value of `echidna_`-prefixed functions that return `int256` (uses the same configurable prefix as property mode).

--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -67,7 +67,7 @@ prepareContract cfg solFiles buildOutput selectedContract seed = do
 
   mainContract <- selectMainContract solConf selectedContract contracts
   tests <- mkTests solConf campaignConf mainContract
-  signatureMap <- mkSignatureMap solConf mainContract contracts
+  signatureMap <- mkSignatureMap solConf campaignConf mainContract contracts
 
   -- run processors
   slitherInfo <- runSlither (NE.head solFiles) solConf

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -53,6 +53,7 @@ import Echidna.Types.Corpus (Corpus, corpusSize)
 import Echidna.Types.Coverage (coverageStats)
 import Echidna.Types.Random (rElem)
 import Echidna.Types.Signature (FunctionName)
+import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Test
 import Echidna.Types.Test qualified as Test
 import Echidna.Types.Tx (TxCall(..), Tx(..))
@@ -125,7 +126,7 @@ runSymWorker callback vm dict workerId _ name = do
 
   flip runStateT initialState $
     flip evalRandT (mkStdGen effectiveSeed) $ do -- unused but needed for callseq
-      if (cfg.campaignConf.workers == Just 0) && (cfg.campaignConf.seqLen == 1) then do
+      if isVerificationMode cfg.solConf.testMode then do
         verifyMethods -- No arguments, everything is in this environment
         pure SymbolicVerificationDone
       else do

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -26,9 +26,22 @@ import Echidna.Types.Solidity
 import Echidna.Types.Test (TestConf(..))
 import Echidna.Types.Tx (TxConf(TxConf), maxGasPerBlock, defaultTimeDelay, defaultBlockDelay)
 
+-- | Verification is a stateless symbolic mode: it uses one symbolic worker
+-- and exactly one transaction per sequence.
+adjustForVerificationMode :: EConfig -> EConfig
+adjustForVerificationMode cfg
+  | isVerificationMode cfg.solConf.testMode =
+      cfg { campaignConf = cfg.campaignConf
+              { workers = Just 0
+              , seqLen = 1
+              , symExec = True
+              }
+          }
+  | otherwise = cfg
+
 instance FromJSON EConfig where
   -- retrieve the config from the key usage annotated parse
-  parseJSON x = (.econfig) <$> parseJSON @EConfigWithUsage x
+  parseJSON x = adjustForVerificationMode . (.econfig) <$> parseJSON @EConfigWithUsage x
 
 instance FromJSON EConfigWithUsage where
   -- this runs the parser in a StateT monad which keeps track of the keys

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -27,7 +27,9 @@ import Echidna.Types.Test (TestConf(..))
 import Echidna.Types.Tx (TxConf(TxConf), maxGasPerBlock, defaultTimeDelay, defaultBlockDelay)
 
 -- | Verification is a stateless symbolic mode: it uses one symbolic worker
--- and exactly one transaction per sequence.
+-- and exactly one transaction per sequence. This is applied when parsing a
+-- config file; the CLI applies it again after its own overrides, since the
+-- test mode can also be selected with @--test-mode@.
 adjustForVerificationMode :: EConfig -> EConfig
 adjustForVerificationMode cfg
   | isVerificationMode cfg.solConf.testMode =
@@ -41,7 +43,7 @@ adjustForVerificationMode cfg
 
 instance FromJSON EConfig where
   -- retrieve the config from the key usage annotated parse
-  parseJSON x = adjustForVerificationMode . (.econfig) <$> parseJSON @EConfigWithUsage x
+  parseJSON x = (.econfig) <$> parseJSON @EConfigWithUsage x
 
 instance FromJSON EConfigWithUsage where
   -- this runs the parser in a StateT monad which keeps track of the keys
@@ -55,7 +57,9 @@ instance FromJSON EConfigWithUsage where
                _        -> mempty
     (c, ks) <- runStateT (parser v') $ Set.fromList []
     let found = Set.fromList (keys v')
-    pure $ EConfigWithUsage c (found `Set.difference` ks) (ks `Set.difference` found)
+    pure $ EConfigWithUsage (adjustForVerificationMode c)
+                            (found `Set.difference` ks)
+                            (ks `Set.difference` found)
     -- this parser runs in StateT and comes equipped with the following
     -- equivalent unary operators:
     -- x .:? k (Parser) <==> x ..:? k (StateT)

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -156,11 +156,25 @@ filterMethods contractName (Blacklist ig) ms =
 --   See: https://book.getfoundry.sh/forge/invariant-testing
 -- - Other functions with arguments are kept as callable targets for
 --   invariant test campaigns.
-filterMethodsWithArgs :: NonEmpty SolSignature -> NonEmpty SolSignature
-filterMethodsWithArgs ms =
-  case NE.filter (\(n, xs) -> T.isPrefixOf "test" n || (T.isPrefixOf "invariant_" n || not (null xs))) ms of
+--
+-- The set of callable functions depends on @seqLen@, mirroring how tests are
+-- selected in 'Echidna.Test.createTests':
+-- - In fuzz mode (@seqLen == 1@) each "test" function is itself the fuzz
+--   target and is called directly by the fuzzer. Only "test" functions with
+--   at least one parameter are kept; calling other functions (e.g. handlers
+--   like @mint@) would only waste effort since no test checks them.
+-- - In invariant mode (@seqLen > 1@) test functions, "invariant_" functions,
+--   and parameterized handlers retain the existing callable set, which is
+--   exercised in randomized sequences.
+filterMethodsWithArgs :: Int -> NonEmpty SolSignature -> NonEmpty SolSignature
+filterMethodsWithArgs seqLen ms =
+  case NE.filter keep ms of
     [] -> error "No foundry tests found"
     fs -> NE.fromList fs
+  where
+    keep (n, xs)
+      | seqLen == 1 = T.isPrefixOf "test" n && not (null xs)
+      | otherwise   = T.isPrefixOf "test" n || T.isPrefixOf "invariant_" n || not (null xs)
 
 abiOf :: Text -> SolcContract -> NonEmpty SolSignature
 abiOf pref solcContract =
@@ -270,10 +284,11 @@ selectMainContract solConf name cs = do
 
 mkSignatureMap
   :: SolConf
+  -> CampaignConf
   -> SolcContract
   -> [SolcContract]
   -> IO SignatureMap
-mkSignatureMap solConf mainContract contracts = do
+mkSignatureMap solConf campaignConf mainContract contracts = do
   let
     -- Optionally exclude view/pure functions from the ABI, but never
     -- exclude prefixed functions (e.g. echidna_*) as they may be properties
@@ -285,7 +300,7 @@ mkSignatureMap solConf mainContract contracts = do
       | otherwise = NE.toList sigs
     -- Filter ABI according to the config options
     fabiOfc = if isFoundryMode solConf.testMode
-                then NE.toList $ filterMethodsWithArgs (abiOf solConf.prefix mainContract)
+                then NE.toList $ filterMethodsWithArgs campaignConf.seqLen (abiOf solConf.prefix mainContract)
                 else let base = filterMethods mainContract.contractName solConf.methodFilter $
                                   abiOf solConf.prefix mainContract
                      in case NE.nonEmpty base of

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -44,7 +44,8 @@ import Echidna.Exec (execTx, execTxWithCov, initialVM)
 import Echidna.SourceAnalysis.Slither
 import Echidna.Test
   ( createTests, isAssertionMode, isFoundryInvariantName, isFoundryMode
-  , isFoundryTestName, isOptimizationMode, isPropertyMode )
+  , isFoundrySymbolicName, isFoundryTestName, isOptimizationMode
+  , isPropertyMode )
 import Echidna.Types.Campaign (CampaignConf(..))
 import Echidna.Types.Config (EConfig(..), Env(..))
 import Echidna.Types.Signature
@@ -156,13 +157,16 @@ filterMethods contractName (Blacklist ig) ms =
 -- - Functions prefixed with "invariant" or "statefulFuzz" are invariant tests,
 --   called in randomized sequences to verify properties that must always hold.
 --   See: https://book.getfoundry.sh/forge/invariant-testing
+-- - Functions prefixed with "check" or "prove" are symbolic entry points, only
+--   verified in verification mode. This is a fuzzing campaign, so they are
+--   called and checked like any other test function.
 -- - Other functions with arguments are kept as callable targets for
 --   invariant test campaigns.
 --
 -- @seqLen@ selects between Foundry's two fuzzing modes, mirroring how tests
 -- are selected in 'Echidna.Test.createTests':
--- - Stateless fuzzing (@seqLen == 1@): each "test" function is itself the fuzz
---   target and is called directly by the fuzzer. Only "test" functions with
+-- - Stateless fuzzing (@seqLen == 1@): each test function is itself the fuzz
+--   target and is called directly by the fuzzer. Only test functions with
 --   at least one parameter are kept; calling other functions (e.g. handlers
 --   like @mint@) would only waste effort since no test checks them.
 -- - Stateful (invariant) fuzzing (@seqLen > 1@): test functions, invariant
@@ -175,8 +179,12 @@ filterMethodsWithArgs seqLen ms =
     fs -> NE.fromList fs
   where
     keep (n, xs)
-      | seqLen == 1 = isFoundryTestName n && not (null xs)
-      | otherwise   = isFoundryTestName n || isFoundryInvariantName n || not (null xs)
+      | seqLen == 1 = (isFoundryTestName n || isFoundrySymbolicName n)
+                      && not (null xs)
+      | otherwise   = isFoundryTestName n
+                      || isFoundryInvariantName n
+                      || isFoundrySymbolicName n
+                      || not (null xs)
 
 abiOf :: Text -> SolcContract -> NonEmpty SolSignature
 abiOf pref solcContract =

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -42,7 +42,9 @@ import Echidna.ABI
 import Echidna.Deploy (deployContracts, deployBytecodes)
 import Echidna.Exec (execTx, execTxWithCov, initialVM)
 import Echidna.SourceAnalysis.Slither
-import Echidna.Test (createTests, isAssertionMode, isPropertyMode, isFoundryMode, isOptimizationMode)
+import Echidna.Test
+  ( createTests, isAssertionMode, isFoundryInvariantName, isFoundryMode
+  , isFoundryTestName, isOptimizationMode, isPropertyMode )
 import Echidna.Types.Campaign (CampaignConf(..))
 import Echidna.Types.Config (EConfig(..), Env(..))
 import Echidna.Types.Signature
@@ -151,21 +153,21 @@ filterMethods contractName (Blacklist ig) ms =
 -- - Functions prefixed with "test" are test functions (unit or fuzz).
 --   Fuzz tests are distinguished by having at least one parameter.
 --   See: https://book.getfoundry.sh/forge/fuzz-testing
--- - Functions prefixed with "invariant_" are invariant tests, called in
---   randomized sequences to verify properties that must always hold.
+-- - Functions prefixed with "invariant" or "statefulFuzz" are invariant tests,
+--   called in randomized sequences to verify properties that must always hold.
 --   See: https://book.getfoundry.sh/forge/invariant-testing
 -- - Other functions with arguments are kept as callable targets for
 --   invariant test campaigns.
 --
--- The set of callable functions depends on @seqLen@, mirroring how tests are
--- selected in 'Echidna.Test.createTests':
--- - In fuzz mode (@seqLen == 1@) each "test" function is itself the fuzz
+-- @seqLen@ selects between Foundry's two fuzzing modes, mirroring how tests
+-- are selected in 'Echidna.Test.createTests':
+-- - Stateless fuzzing (@seqLen == 1@): each "test" function is itself the fuzz
 --   target and is called directly by the fuzzer. Only "test" functions with
 --   at least one parameter are kept; calling other functions (e.g. handlers
 --   like @mint@) would only waste effort since no test checks them.
--- - In invariant mode (@seqLen > 1@) test functions, "invariant_" functions,
---   and parameterized handlers retain the existing callable set, which is
---   exercised in randomized sequences.
+-- - Stateful (invariant) fuzzing (@seqLen > 1@): test functions, invariant
+--   functions, and parameterized handlers retain the existing callable set,
+--   which is exercised in randomized sequences.
 filterMethodsWithArgs :: Int -> NonEmpty SolSignature -> NonEmpty SolSignature
 filterMethodsWithArgs seqLen ms =
   case NE.filter keep ms of
@@ -173,8 +175,8 @@ filterMethodsWithArgs seqLen ms =
     fs -> NE.fromList fs
   where
     keep (n, xs)
-      | seqLen == 1 = T.isPrefixOf "test" n && not (null xs)
-      | otherwise   = T.isPrefixOf "test" n || T.isPrefixOf "invariant_" n || not (null xs)
+      | seqLen == 1 = isFoundryTestName n && not (null xs)
+      | otherwise   = isFoundryTestName n || isFoundryInvariantName n || not (null xs)
 
 abiOf :: Text -> SolcContract -> NonEmpty SolSignature
 abiOf pref solcContract =

--- a/lib/Echidna/SymExec/Verification.hs
+++ b/lib/Echidna/SymExec/Verification.hs
@@ -23,6 +23,7 @@ import EVM.Types (VMType(..))
 import qualified EVM.Types (VM(..))
 
 import Echidna.SymExec.Common (rpcFetcher, exploreMethod, suitableForSymExec, TxOrError(..), PartialsLogs)
+import Echidna.Test (isFoundrySymbolicName)
 import Echidna.Types.Campaign (CampaignConf(..), WorkerState)
 import Echidna.Types.Config (Env(..), EConfig(..), OperationMode(..), OutputFormat(..), UIConf(..))
 import Echidna.Types.Solidity (SolConf(..))
@@ -38,10 +39,15 @@ isSuitableToVerifyMethod contract method symExecTargets = do
       (selector, _) = case find (\(_, m) -> m == method) allMethods of
         Nothing -> error $ "Method " ++ show method.name ++ " not found in contract ABI"
         Just x  -> x
+      -- "check" and "prove" functions are explicit symbolic test entry points
+      -- (as in Foundry and Halmos), so they are verified even when the static
+      -- analysis found no assertion in them.
+      isSymbolicEntryPoint = isFoundrySymbolicName method.name
 
   return $
     if null symExecTargets
-    then (null assertSigs || selector `elem` assertSigs) && suitableForSymExec method
+    then (isSymbolicEntryPoint || null assertSigs || selector `elem` assertSigs)
+         && suitableForSymExec method
     else method.name `elem` symExecTargets
 
 

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -52,7 +52,7 @@ createTest m = EchidnaTest Open m v [] Stop Nothing Nothing
 
 validateTestModeError :: String
 validateTestModeError =
-  "Invalid test mode (should be property, assertion, foundry, optimization, overflow or exploration)"
+  "Invalid test mode (should be property, assertion, foundry, optimization, overflow, exploration or verification)"
 
 validateTestMode :: String -> TestMode
 validateTestMode s = case s of
@@ -62,11 +62,16 @@ validateTestMode s = case s of
   "exploration"  -> s
   "overflow"     -> s
   "optimization" -> s
+  "verification" -> s
   _              -> error validateTestModeError
 
 isAssertionMode :: TestMode -> Bool
 isAssertionMode "assertion" = True
 isAssertionMode _           = False
+
+isVerificationMode :: TestMode -> Bool
+isVerificationMode "verification" = True
+isVerificationMode _              = False
 
 isExplorationMode :: TestMode -> Bool
 isExplorationMode "exploration" = True
@@ -104,6 +109,8 @@ createTests m td ts seqLen r ss = case m of
   "assertion" ->
     map (\s -> createTest (AssertionTest False s r))
         (filter (/= fallback) ss) ++ [createTest (CallTest "AssertionFailed(..)" checkAssertionTest)]
+  "verification" ->
+    map (\s -> createTest (AssertionTest False s r)) (filter (/= fallback) ss)
   -- In foundry mode, seqLen distinguishes fuzz tests (seqLen == 1) from
   -- invariant tests (seqLen > 1), which determines how functions are filtered.
   "foundry" ->

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -136,13 +136,18 @@ createTests m td ts seqLen r ss = case m of
     map (\s -> createTest (AssertionTest False s r)) (filter (/= fallback) ss)
   -- In foundry mode, seqLen distinguishes fuzz tests (seqLen == 1) from
   -- invariant tests (seqLen > 1), which determines how functions are filtered.
+  -- "check" and "prove" functions are symbolic entry points, but this is a
+  -- fuzzing campaign, so they are tested as regular fuzz tests here.
   "foundry" ->
     if seqLen == 1 then
       map (\s -> createTest (AssertionTest True s r))
-        (filter (\(n, xs) -> isFoundryTestName n && not (null xs)) ss)
+        (filter (\(n, xs) -> (isFoundryTestName n || isFoundrySymbolicName n)
+                             && not (null xs)) ss)
     else
       map (\s -> createTest (AssertionTest True s r))
-          (filter (\(n, xs) -> isFoundryInvariantName n || not (null xs)) ss)
+          (filter (\(n, xs) -> isFoundryInvariantName n
+                               || isFoundrySymbolicName n
+                               || not (null xs)) ss)
   _ -> error validateTestModeError
   ++ (if td then [sdt, sdat] else [])
   where
@@ -293,7 +298,9 @@ checkFoundryAssertion vm sig addr = do
           -- vm.assume failures should not be treated as test failures
           Just (VMFailure AssumeCheatFailed) -> False
           Just (VMFailure (Revert _)) ->
-            isFoundryTestName name || isFoundryInvariantName name
+            isFoundryTestName name
+              || isFoundryInvariantName name
+              || isFoundrySymbolicName name
           Just (VMFailure _) -> True
           _ -> False
     isCorrectAddr = LitAddr addr == vm.state.codeContract

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -89,6 +89,29 @@ isOptimizationMode :: TestMode -> Bool
 isOptimizationMode "optimization" = True
 isOptimizationMode _               = False
 
+-- The following predicates classify function names following the Foundry
+-- naming conventions, mirroring @TestFunctionKind::classify@:
+-- https://github.com/foundry-rs/foundry/blob/master/crates/common/src/traits.rs
+
+-- | @test*@ functions are tests: unit tests when they take no arguments,
+-- fuzz tests when they do.
+isFoundryTestName :: Text -> Bool
+isFoundryTestName = T.isPrefixOf "test"
+
+-- | @testFail*@ functions are tests that are expected to revert, so their
+-- outcome is inverted with respect to a plain @test*@ function.
+isFoundryTestFailName :: Text -> Bool
+isFoundryTestFailName = T.isPrefixOf "testFail"
+
+-- | @invariant*@ and @statefulFuzz*@ functions are stateful (invariant) tests,
+-- checked after each transaction of a randomized sequence.
+isFoundryInvariantName :: Text -> Bool
+isFoundryInvariantName n = T.isPrefixOf "invariant" n || T.isPrefixOf "statefulFuzz" n
+
+-- | @check*@ and @prove*@ functions are symbolic test entry points.
+isFoundrySymbolicName :: Text -> Bool
+isFoundrySymbolicName n = T.isPrefixOf "check" n || T.isPrefixOf "prove" n
+
 createTests
   :: TestMode
   -> Bool
@@ -116,10 +139,10 @@ createTests m td ts seqLen r ss = case m of
   "foundry" ->
     if seqLen == 1 then
       map (\s -> createTest (AssertionTest True s r))
-        (filter (\(n, xs) -> T.isPrefixOf "test" n && not (null xs)) ss)
+        (filter (\(n, xs) -> isFoundryTestName n && not (null xs)) ss)
     else
       map (\s -> createTest (AssertionTest True s r))
-          (filter (\(n, xs) -> T.isPrefixOf "invariant_" n || not (null xs)) ss)
+          (filter (\(n, xs) -> isFoundryInvariantName n || not (null xs)) ss)
   _ -> error validateTestModeError
   ++ (if td then [sdt, sdat] else [])
   where
@@ -251,19 +274,28 @@ checkFoundryAssertion
   -> m (TestValue, VM Concrete)
 checkFoundryAssertion vm sig addr = do
   let
+    name = fst sig
     -- Whether the last transaction has any value
     hasValue = vm.state.callvalue /= Lit 0
     -- Whether the last transaction called the function `sig`.
     isCorrectFn =
       BS.isPrefixOf (BS.take 4 (abiCalldata (encodeSig sig) mempty))
                     (forceBuf vm.state.calldata)
-    isAssertionFailure = case vm.result of
-      -- vm.assume failures should not be treated as test failures
-      Just (VMFailure AssumeCheatFailed) -> False
-      Just (VMFailure (Revert _)) ->
-        T.isPrefixOf "test" (fst sig) || T.isPrefixOf "invariant_" (fst sig)
-      Just (VMFailure _) -> True
-      _ -> False
+    isAssertionFailure
+      -- "testFail" functions are expected to revert, so the test only fails
+      -- when the call succeeds.
+      | isFoundryTestFailName name = case vm.result of
+          -- vm.assume failures discard the input, they neither pass nor fail
+          Just (VMFailure AssumeCheatFailed) -> False
+          Just (VMSuccess _) -> True
+          _ -> False
+      | otherwise = case vm.result of
+          -- vm.assume failures should not be treated as test failures
+          Just (VMFailure AssumeCheatFailed) -> False
+          Just (VMFailure (Revert _)) ->
+            isFoundryTestName name || isFoundryInvariantName name
+          Just (VMFailure _) -> True
+          _ -> False
     isCorrectAddr = LitAddr addr == vm.state.codeContract
     isCorrectTarget = isCorrectFn && isCorrectAddr
     isFailure = not hasValue && (isCorrectTarget && isAssertionFailure)

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -85,9 +85,12 @@ ui vm dict initialCorpus cliSelectedContract = do
       other -> other
 
     -- Distribute over all workers, could be slightly bigger overall due to
-    -- ceiling but this doesn't matter
-    perWorkerTestLimit = ceiling
-      (fromIntegral conf.campaignConf.testLimit / fromIntegral nFuzzWorkers :: Double)
+    -- ceiling but this doesn't matter. Verification mode has no fuzz workers,
+    -- so avoid dividing by zero in that case.
+    perWorkerTestLimit
+      | nFuzzWorkers == 0 = conf.campaignConf.testLimit
+      | otherwise = ceiling
+          (fromIntegral conf.campaignConf.testLimit / fromIntegral nFuzzWorkers :: Double)
 
     -- Distribute the replay corpus across the fuzz workers. The symbolic
     -- worker always replays the full corpus (see spawnWorker), so with no

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -73,7 +73,8 @@ main = withUtf8 $ withCP65001 $ withStrippedExceptions $ do
   opts@Options{..} <- execParser optsParser
   EConfigWithUsage loadedCfg ks _ <-
     maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig cliConfigFilepath
-  cfg <- overrideConfig loadedCfg opts
+  cfg' <- overrideConfig loadedCfg opts
+  let cfg = adjustForVerificationMode cfg'
 
   printProjectName cfg.projectName
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -73,8 +73,7 @@ main = withUtf8 $ withCP65001 $ withStrippedExceptions $ do
   opts@Options{..} <- execParser optsParser
   EConfigWithUsage loadedCfg ks _ <-
     maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig cliConfigFilepath
-  cfg' <- overrideConfig loadedCfg opts
-  let cfg = adjustForVerificationMode cfg'
+  cfg <- overrideConfig loadedCfg opts
 
   printProjectName cfg.projectName
 
@@ -292,6 +291,8 @@ overrideConfig config Options{..} = do
            , disableOnchainSources = cliDisableOnchainSources || config.disableOnchainSources
            }
            & overrideFormat
+           -- re-apply, as --test-mode may have selected the verification mode
+           & adjustForVerificationMode
   where
     overrideUiConf uiConf = uiConf
       { maxTime = cliTimeout <|> uiConf.maxTime

--- a/src/test/Tests/Config.hs
+++ b/src/test/Tests/Config.hs
@@ -68,5 +68,15 @@ configTests = testGroup "Configuration tests" $
       shouldReject "deployContracts: [[\"0x100\", \"A\"]]"
       shouldReject "deployBytecodes: [[\"0xa\", \"00\"]]"
       shouldAccept "contractAddr: \"0x12\"\ndeployContracts: [[\"0x12\", \"A\"]]\ndeployBytecodes: [[\"0x101\", \"00\"]]"
+  , testCase "verification mode configures symbolic execution" $
+      case Y.decodeEither' "testMode: verification" of
+        Right (config :: EConfig) -> do
+          assertBool "verification mode should use no fuzz workers" $
+            config.campaignConf.workers == Just 0
+          assertBool "verification mode should use one transaction" $
+            config.campaignConf.seqLen == 1
+          assertBool "verification mode should enable symbolic execution" $
+            config.campaignConf.symExec
+        Left e -> assertFailure $ "unexpected decoding error: " <> show e
   ]
   where files = ["basic/config.yaml", "basic/default.yaml", "basic/coverage-test.yaml", "basic/corpus-fallback-test.yaml"]

--- a/src/test/Tests/Foundry.hs
+++ b/src/test/Tests/Foundry.hs
@@ -1,13 +1,30 @@
 module Tests.Foundry (foundryTests) where
 
+import Data.List.NonEmpty (NonEmpty((:|)))
+import Data.List.NonEmpty qualified as NE
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import EVM.ABI (AbiType(AbiUIntType))
 
 import Common (testContract', solcV, solved, passed)
+import Echidna.Solidity (filterMethodsWithArgs)
+import Echidna.Types.Signature (SolSignature)
 import Echidna.Types.Worker (WorkerType(..))
 
 foundryTests :: TestTree
 foundryTests = testGroup "Foundry Integration Testing"
-  [ testContract' "foundry-basic/basic.sol" (Just "GreeterTest") (Just (\v -> v >= solcV (0,7,5))) (Just "foundry-basic/config.yaml") False FuzzWorker
+  [ testGroup "ABI filtering"
+      [ testCase "stateless fuzzing only calls parameterized test functions" $
+          assertEqual "filtered signatures"
+            ["testFuzz"]
+            (fst <$> NE.toList (filterMethodsWithArgs 1 foundrySignatures))
+      , testCase "invariant fuzzing retains the callable function set" $
+          assertEqual "filtered signatures"
+            ["testUnit", "testFuzz", "handler", "invariant_total"]
+            (fst <$> NE.toList (filterMethodsWithArgs 100 foundrySignatures))
+      ]
+  , testContract' "foundry-basic/basic.sol" (Just "GreeterTest") (Just (\v -> v >= solcV (0,7,5))) (Just "foundry-basic/config.yaml") False FuzzWorker
      [
         ("testShrinking passed", solved "testShrinking"),
         ("testFuzzFixedArray passed", solved "testFuzzFixedArray"),
@@ -20,3 +37,13 @@ foundryTests = testGroup "Foundry Integration Testing"
         ("testAssume failed", passed "testFuzzAssume")
       ]
   ]
+
+foundrySignatures :: NonEmpty SolSignature
+foundrySignatures =
+  ("", []) :|
+    [ ("setUp", [])
+    , ("testUnit", [])
+    , ("testFuzz", [AbiUIntType 256])
+    , ("handler", [AbiUIntType 256])
+    , ("invariant_total", [])
+    ]

--- a/src/test/Tests/Foundry.hs
+++ b/src/test/Tests/Foundry.hs
@@ -19,12 +19,13 @@ foundryTests = testGroup "Foundry Integration Testing"
   [ testGroup "ABI filtering"
       [ testCase "stateless fuzzing only calls parameterized test functions" $
           assertEqual "filtered signatures"
-            ["testFuzz", "testFailFuzz"]
+            ["testFuzz", "testFailFuzz", "check_value"]
             (fst <$> NE.toList (filterMethodsWithArgs 1 foundrySignatures))
       , testCase "invariant fuzzing retains the callable function set" $
           assertEqual "filtered signatures"
             [ "testUnit", "testFuzz", "testFailFuzz", "handler"
-            , "invariant_total", "invariantTotal", "statefulFuzzTotal" ]
+            , "invariant_total", "invariantTotal", "statefulFuzzTotal"
+            , "check_value", "prove_total" ]
             (fst <$> NE.toList (filterMethodsWithArgs 100 foundrySignatures))
       ]
   , testGroup "function name classification"
@@ -71,4 +72,6 @@ foundrySignatures =
     , ("invariant_total", [])
     , ("invariantTotal", [])
     , ("statefulFuzzTotal", [])
+    , ("check_value", [AbiUIntType 256])
+    , ("prove_total", [])
     ]

--- a/src/test/Tests/Foundry.hs
+++ b/src/test/Tests/Foundry.hs
@@ -9,6 +9,8 @@ import EVM.ABI (AbiType(AbiUIntType))
 
 import Common (testContract', solcV, solved, passed)
 import Echidna.Solidity (filterMethodsWithArgs)
+import Echidna.Test
+  (isFoundryInvariantName, isFoundrySymbolicName, isFoundryTestFailName, isFoundryTestName)
 import Echidna.Types.Signature (SolSignature)
 import Echidna.Types.Worker (WorkerType(..))
 
@@ -17,12 +19,32 @@ foundryTests = testGroup "Foundry Integration Testing"
   [ testGroup "ABI filtering"
       [ testCase "stateless fuzzing only calls parameterized test functions" $
           assertEqual "filtered signatures"
-            ["testFuzz"]
+            ["testFuzz", "testFailFuzz"]
             (fst <$> NE.toList (filterMethodsWithArgs 1 foundrySignatures))
       , testCase "invariant fuzzing retains the callable function set" $
           assertEqual "filtered signatures"
-            ["testUnit", "testFuzz", "handler", "invariant_total"]
+            [ "testUnit", "testFuzz", "testFailFuzz", "handler"
+            , "invariant_total", "invariantTotal", "statefulFuzzTotal" ]
             (fst <$> NE.toList (filterMethodsWithArgs 100 foundrySignatures))
+      ]
+  , testGroup "function name classification"
+      [ testCase "test functions" $
+          assertEqual "classified names"
+            [True, True, False, False]
+            (map isFoundryTestName ["testFuzz", "testFailFuzz", "invariantTotal", "handler"])
+      , testCase "testFail functions" $
+          assertEqual "classified names"
+            [True, False, False]
+            (map isFoundryTestFailName ["testFailFuzz", "testFuzz", "handler"])
+      , testCase "invariant functions" $
+          assertEqual "classified names"
+            [True, True, True, False]
+            (map isFoundryInvariantName
+                 ["invariant_total", "invariantTotal", "statefulFuzzTotal", "testFuzz"])
+      , testCase "symbolic entry points" $
+          assertEqual "classified names"
+            [True, True, False]
+            (map isFoundrySymbolicName ["checkValue", "prove_value", "testFuzz"])
       ]
   , testContract' "foundry-basic/basic.sol" (Just "GreeterTest") (Just (\v -> v >= solcV (0,7,5))) (Just "foundry-basic/config.yaml") False FuzzWorker
      [
@@ -44,6 +66,9 @@ foundrySignatures =
     [ ("setUp", [])
     , ("testUnit", [])
     , ("testFuzz", [AbiUIntType 256])
+    , ("testFailFuzz", [AbiUIntType 256])
     , ("handler", [AbiUIntType 256])
     , ("invariant_total", [])
+    , ("invariantTotal", [])
+    , ("statefulFuzzTotal", [])
     ]

--- a/src/test/Tests/FoundryTestGen.hs
+++ b/src/test/Tests/FoundryTestGen.hs
@@ -166,6 +166,10 @@ foundryTestGenTests = testGroup "Foundry test generation"
           [ ("a reverting testFail should pass", passed "testFail_always_reverts")
           , ("a non reverting testFail should be detected", solved "testFail_sometimes_reverts")
           ]
+      , testContract "foundry/CheckProve.sol" (Just "foundry/CheckProve.yaml")
+          [ ("check functions should be fuzzed without symbolic execution", solved "check_small")
+          , ("prove functions should be fuzzed without symbolic execution", solved "prove_small")
+          ]
       , testContract "foundry/PropertyRepro.sol" (Just "foundry/PropertyRepro.yaml")
           [ ("property test should be detected", solved "echidna_counter_is_zero")
           ]

--- a/src/test/Tests/FoundryTestGen.hs
+++ b/src/test/Tests/FoundryTestGen.hs
@@ -162,6 +162,10 @@ foundryTestGenTests = testGroup "Foundry test generation"
           FuzzWorker
           [ ("vm.assume should not be treated as test failure", passed "test_assume_filters")
           ]
+      , testContract "foundry/TestFail.sol" (Just "foundry/TestFail.yaml")
+          [ ("a reverting testFail should pass", passed "testFail_always_reverts")
+          , ("a non reverting testFail should be detected", solved "testFail_sometimes_reverts")
+          ]
       , testContract "foundry/PropertyRepro.sol" (Just "foundry/PropertyRepro.yaml")
           [ ("property test should be detected", solved "echidna_counter_is_zero")
           ]

--- a/src/test/Tests/FoundryTestGen.hs
+++ b/src/test/Tests/FoundryTestGen.hs
@@ -166,9 +166,20 @@ foundryTestGenTests = testGroup "Foundry test generation"
           [ ("a reverting testFail should pass", passed "testFail_always_reverts")
           , ("a non reverting testFail should be detected", solved "testFail_sometimes_reverts")
           ]
-      , testContract "foundry/CheckProve.sol" (Just "foundry/CheckProve.yaml")
+      , testContractNamed "foundry/CheckProve.sol (stateless)"
+          "foundry/CheckProve.sol"
+          (Just "CheckProveTest") Nothing (Just "foundry/CheckProve.yaml")
+          True FuzzWorker
           [ ("check functions should be fuzzed without symbolic execution", solved "check_small")
           , ("prove functions should be fuzzed without symbolic execution", solved "prove_small")
+          , ("a revert in a check function should be a failure", solved "check_revert")
+          ]
+      , testContractNamed "foundry/CheckProve.sol (stateful)"
+          "foundry/CheckProve.sol"
+          (Just "CheckProveStatefulTest") Nothing (Just "foundry/CheckProveStateful.yaml")
+          True FuzzWorker
+          [ ("check functions should be checked in sequences", solved "check_counter")
+          , ("prove functions should be checked in sequences", solved "prove_counter")
           ]
       , testContract "foundry/PropertyRepro.sol" (Just "foundry/PropertyRepro.yaml")
           [ ("property test should be detected", solved "echidna_counter_is_zero")

--- a/tests/solidity/foundry/CheckProve.sol
+++ b/tests/solidity/foundry/CheckProve.sol
@@ -15,4 +15,33 @@ contract CheckProveTest {
     function prove_small(uint256 x) public pure {
         assert(x < 10);
     }
+
+    // reverts are failures for test functions, and these are test functions too
+    function check_revert(uint256 x) public pure {
+        if (x >= 10) {
+            revert("too large");
+        }
+    }
+}
+
+// In a stateful campaign, parameterless "check" and "prove" functions are
+// checked after each transaction, like "invariant" functions
+contract CheckProveStatefulTest {
+    uint256 public counter;
+
+    function IS_TEST() public pure returns (bool) {
+        return true;
+    }
+
+    function increase(uint8 x) public {
+        counter += x;
+    }
+
+    function check_counter() public view {
+        assert(counter <= 5);
+    }
+
+    function prove_counter() public view {
+        assert(counter <= 5);
+    }
 }

--- a/tests/solidity/foundry/CheckProve.sol
+++ b/tests/solidity/foundry/CheckProve.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+// "check" and "prove" functions are symbolic entry points, but they are also
+// valid fuzzing targets: when symbolic execution is disabled, they are fuzzed
+// like any other Foundry test function.
+contract CheckProveTest {
+    function IS_TEST() public pure returns (bool) {
+        return true;
+    }
+
+    function check_small(uint256 x) public pure {
+        assert(x < 10);
+    }
+
+    function prove_small(uint256 x) public pure {
+        assert(x < 10);
+    }
+}

--- a/tests/solidity/foundry/CheckProve.yaml
+++ b/tests/solidity/foundry/CheckProve.yaml
@@ -1,0 +1,4 @@
+testMode: foundry
+seed: 1234
+seqLen: 1
+disableSlither: true

--- a/tests/solidity/foundry/CheckProveStateful.yaml
+++ b/tests/solidity/foundry/CheckProveStateful.yaml
@@ -1,0 +1,4 @@
+testMode: foundry
+seed: 1234
+seqLen: 10
+disableSlither: true

--- a/tests/solidity/foundry/FoundryAssertsSymbolic.yaml
+++ b/tests/solidity/foundry/FoundryAssertsSymbolic.yaml
@@ -1,8 +1,5 @@
-testMode: foundry
+testMode: verification
 seed: 1234
 cryticArgs: ["--solc-remaps", "forge-std/=foundry/forge-std/src/"]
-symExec: true
 symExecSMTSolver: bitwuzla
-workers: 0
-seqLen: 1
 disableSlither: true

--- a/tests/solidity/foundry/TestFail.sol
+++ b/tests/solidity/foundry/TestFail.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+// Foundry "testFail" functions are expected to revert, so their outcome is
+// inverted: they fail when the call succeeds. No forge-std needed here, the
+// convention is purely about the function name.
+contract TestFailTest {
+    function IS_TEST() public pure returns (bool) {
+        return true;
+    }
+
+    // Always reverts, so this test passes
+    function testFail_always_reverts(uint256) public pure {
+        revert("expected revert");
+    }
+
+    // Succeeds for any input above 100, breaking the expectation that a
+    // "testFail" function always reverts
+    function testFail_sometimes_reverts(uint256 x) public pure {
+        require(x > 100, "expected revert");
+    }
+}

--- a/tests/solidity/foundry/TestFail.yaml
+++ b/tests/solidity/foundry/TestFail.yaml
@@ -1,0 +1,3 @@
+testMode: foundry
+seed: 1234
+disableSlither: true

--- a/tests/solidity/symbolic/verify.bitwuzla.yaml
+++ b/tests/solidity/symbolic/verify.bitwuzla.yaml
@@ -1,5 +1,4 @@
-testMode: assertion
-symExec: true
+testMode: verification
 symExecSMTSolver: bitwuzla
 workers: 0
 seqLen: 1

--- a/tests/solidity/symbolic/verify.bitwuzla.yaml
+++ b/tests/solidity/symbolic/verify.bitwuzla.yaml
@@ -1,6 +1,4 @@
 testMode: verification
 symExecSMTSolver: bitwuzla
-workers: 0
-seqLen: 1
 
 disableSlither: true # TODO: re-enable when slither fixes https://github.com/crytic/slither/issues/2770

--- a/tests/solidity/symbolic/verify.yaml
+++ b/tests/solidity/symbolic/verify.yaml
@@ -1,5 +1,4 @@
-testMode: assertion
-symExec: true
+testMode: verification
 symExecSMTSolver: z3
 workers: 0
 seqLen: 1

--- a/tests/solidity/symbolic/verify.yaml
+++ b/tests/solidity/symbolic/verify.yaml
@@ -1,6 +1,4 @@
 testMode: verification
 symExecSMTSolver: z3
-workers: 0
-seqLen: 1
 
 disableSlither: true # TODO: re-enable when slither fixes https://github.com/crytic/slither/issues/2770


### PR DESCRIPTION
## Summary

- add an explicit `verification` test mode and enforce its stateless symbolic campaign settings
- avoid zero-worker UI division and dispatch symbolic verification by mode
- make Foundry ABI filtering sequence-length-aware so stateless fuzzing only calls parameterized `test*` functions
- add regression coverage for verification configuration and both Foundry filtering paths

These are kept together because both are small, prerequisite campaign-mode correctness fixes. They remain split into two commits for review.

## Testing

- `stack test echidna:test:echidna-testsuite --fast --test-arguments='--pattern "Configuration tests" --hide-successes --color never'` (16 passed)
- `stack test echidna:test:echidna-testsuite --fast --test-arguments='--pattern "Foundry Integration Testing" --hide-successes --color never'` (3 passed)
- `stack test echidna:test:echidna-testsuite --fast --test-arguments='--pattern "Symbolic tests" --hide-successes --color never'` (3 passed)
