### PR TITLE
Small standalone fixes: coverage attribution, generic log events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ crytic-export/
 echidna.cabal
 *.swp
 profiles/
+
+# Python helper scripts and test suites
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/

--- a/lib/Echidna/Server.hs
+++ b/lib/Echidna/Server.hs
@@ -36,6 +36,10 @@ instance ToJSON SSE where
     object [ "timestamp" .= time
            , "filename" .= filename
            ]
+  toJSON (SSE (time, ServerLog msg)) =
+    object [ "timestamp" .= time
+           , "data" .= msg
+           ]
 
 runSSEServer :: MVar () -> Env -> Word16 -> Int -> IO ()
 runSSEServer serverStopVar env port nworkers = do
@@ -53,11 +57,13 @@ runSSEServer serverStopVar env port nworkers = do
               NewCoverage {} -> "new_coverage"
               SymExecLog _ -> "sym_exec_log"
               SymExecError _ -> "sym_exec_error"
+              Log _ -> "log"
               TxSequenceReplayed {} -> "tx_sequence_replayed"
               TxSequenceReplayFailed {} -> "tx_sequence_replay_failed"
               WorkerStopped _ -> "worker_stopped"
           Failure _err -> "failure"
           ReproducerSaved _ -> "saved_reproducer"
+          ServerLog _ -> "server_log"
 
     let serverEvent = ServerEvent
           { eventName = Just (eventName campaignEvent)

--- a/lib/Echidna/Types/Worker.hs
+++ b/lib/Echidna/Types/Worker.hs
@@ -11,6 +11,7 @@ data CampaignEvent
   = WorkerEvent WorkerId WorkerType WorkerEvent
   | Failure String
   | ReproducerSaved String -- filename
+  | ServerLog String
 
 data WorkerEvent
   = TestFalsified !EchidnaTest
@@ -18,6 +19,7 @@ data WorkerEvent
   | NewCoverage { points :: !Int, numCodehashes :: !Int, corpusSize :: !Int, transactions :: [Tx] }
   | SymExecError !String
   | SymExecLog !String
+  | Log !String
   | TxSequenceReplayed FilePath !Int !Int
   | TxSequenceReplayFailed FilePath Tx
   | WorkerStopped WorkerStopReason

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -34,6 +34,8 @@ ppLogLine vm (time, event@(WorkerEvent workerId FuzzWorker _)) =
   ((timePrefix time <> "[Worker " <> show workerId <> "] ") <>) <$> ppCampaignEventLog vm event
 ppLogLine vm (time, event@(WorkerEvent workerId SymbolicWorker _)) =
   ((timePrefix time <> "[Worker " <> show workerId <> ", symbolic] ") <>) <$> ppCampaignEventLog vm event
+ppLogLine vm (time, event@(ServerLog _)) =
+  ((timePrefix time <> "[Server] ") <>) <$> ppCampaignEventLog vm event
 ppLogLine vm (time, event) =
   ((timePrefix time <> " ") <>) <$> ppCampaignEventLog vm event
 

--- a/lib/Echidna/Worker.hs
+++ b/lib/Echidna/Worker.hs
@@ -31,6 +31,7 @@ instance ToJSON WorkerEvent where
       object [ "coverage" .= points, "contracts" .= numCodehashes, "corpus_size" .= corpusSize]
     SymExecError msg -> object [ "msg" .= msg ]
     SymExecLog msg -> object [ "msg" .= msg ]
+    Log msg -> object [ "msg" .= msg ]
     TxSequenceReplayed file current total ->
       object [ "file" .= file, "current" .= current, "total" .= total ]
     TxSequenceReplayFailed file tx ->
@@ -98,6 +99,7 @@ ppCampaignEvent = \case
   WorkerEvent _ _ e -> ppWorkerEvent e
   Failure err -> err
   ReproducerSaved f -> "Saved reproducer to " <> f
+  ServerLog msg -> msg
 
 ppWorkerEvent :: WorkerEvent -> String
 ppWorkerEvent = \case
@@ -122,6 +124,8 @@ ppWorkerEvent = \case
     "Symbolic execution failed: " <> err
   SymExecLog msg ->
     "Symbolic execution log: " <> msg
+  Log msg ->
+    msg
   TxSequenceReplayed file current total ->
     "Sequence replayed from corpus file " <> file <> " (" <> show current <> "/" <> show total <> ")"
   TxSequenceReplayFailed file tx ->

--- a/lib/Echidna/Worker.hs
+++ b/lib/Echidna/Worker.hs
@@ -12,6 +12,7 @@ import Echidna.ABI (encodeSig)
 import Echidna.Types.Campaign
 import Echidna.Types.Config (Env(..), EConfig(..))
 import Echidna.Types.Test
+import Echidna.Types.Tx (Tx(..), TxCall(..))
 import Echidna.Types.Worker
 import Echidna.Utility (getTimestamp)
 
@@ -105,10 +106,18 @@ ppWorkerEvent = \case
   TestOptimized test ->
     let name = case test.testType of OptimizationTest n _ -> n; _ -> error "fixme"
     in "New maximum value of " <> unpack name <> ": " <> show test.value
-  NewCoverage { points, numCodehashes, corpusSize } ->
-    "New coverage: " <> show points <> " instr, "
+  NewCoverage { points, numCodehashes, corpusSize, transactions } ->
+    let -- the coverage is credited to the last transaction of the sequence
+        culprit = case transactions of
+          [] -> "init"
+          txs -> case (last txs).call of
+            SolCall (name, _) -> unpack name
+            SolCreate _ -> "constructor"
+            SolCalldata _ -> "fallback"
+            NoCall -> "no call"
+    in "New coverage: " <> show points <> " instr, "
       <> show numCodehashes <> " contracts, "
-      <> show corpusSize <> " seqs in corpus"
+      <> show corpusSize <> " seqs in corpus (" <> culprit <> ")"
   SymExecError err ->
     "Symbolic execution failed: " <> err
   SymExecLog msg ->

--- a/lib/Echidna/Worker.hs
+++ b/lib/Echidna/Worker.hs
@@ -112,7 +112,7 @@ ppWorkerEvent = \case
     let -- the coverage is credited to the last transaction of the sequence
         culprit = case transactions of
           [] -> "init"
-          txs -> case (last txs).call of
+          txs -> let tx = last txs in case tx.call of
             SolCall (name, _) -> unpack name
             SolCreate _ -> "constructor"
             SolCalldata _ -> "fallback"

--- a/tests/solidity/basic/flags.sol
+++ b/tests/solidity/basic/flags.sol
@@ -5,13 +5,15 @@ contract Test {
   bool private flag1 = true;
 
   function set0(int val) public returns (bool){
-    if (val % 100 == 0) 
+    if (val % 100 == 0)
       flag0 = false;
+    return flag0;
   }
 
   function set1(int val) public returns (bool){
-    if (val % 10 == 0 && !flag0) 
+    if (val % 10 == 0 && !flag0)
       flag1 = false;
+    return flag1;
   }
 
   function echidna_alwaystrue() public returns (bool){


### PR DESCRIPTION
  Stacked on #1596 — base branch is `refactor/campaign-decomposition`, please merge that first.

  Four independent changes carved out of the `dev-agents-2` work, each its own commit. They need no new infrastructure and stand on their own, so they're here together rather than
  as four micro-PRs.

  ### `New coverage:` lines name the function that found it

  `ppWorkerEvent` already receives the transaction sequence behind a `NewCoverage` event but only printed the aggregate counters. The last transaction of the sequence is the one
  credited with the coverage, so append its call:

  ```
  [Worker 3] New coverage: 427 instr, 1 contracts, 1 seqs in corpus (set1)
  ```

  Non-`SolCall` sequences report `constructor` / `fallback` / `no call`, and an empty sequence reports `init` (`transactions` can be empty, so the `last` is guarded).

  ### Generic log events

  - `WorkerEvent`: `Log !String` — free-form worker messages.
  - `CampaignEvent`: `ServerLog String` — messages not attributable to any worker.

  `ServerLog` renders with a `[Server]` prefix in the text UI and as a `server_log` SSE event. All four exhaustive matches over these types — the two `ToJSON` instances,
  `ppCampaignEvent`/`ppWorkerEvent`, and the SSE event names — land in one commit so the build never breaks mid-series.

  ### `flags.sol` `set0`/`set1` return their flag

  Both are declared `returns (bool)` but fall off the end, so solc warns and they silently return `false`. Two lines. Test fixture only.

  ### `.gitignore` Python artifacts

  `__pycache__/`, `*.py[cod]`, `.pytest_cache/`, `.venv/`. The repo has no Python today; this is groundwork for the pytest-based MCP suite later in the series.

  ### Verification

  - `cabal build` — clean, no warnings.
  - `cabal run tests` — all 165 pass.
  - Ran the binary against `basic/flags.sol` and confirmed the function-name suffix appears in real output (sample above).