### PR TITLE
refactor: replace runWorker dispatch with an Agent sum type

### DIFF
--- a/lib/Echidna/Agent.hs
+++ b/lib/Echidna/Agent.hs
@@ -1,0 +1,41 @@
+module Echidna.Agent (runAgent) where
+
+import Control.Monad.Reader (runReaderT)
+import Control.Monad.State.Strict (get)
+import Control.Monad.Trans (liftIO)
+import Data.IORef (writeIORef)
+
+import Echidna.Types.Agent
+import Echidna.Types.Config (Env)
+import Echidna.Types.Worker (CampaignEvent(..), WorkerEvent(..), WorkerStopReason)
+import Echidna.Worker (pushCampaignEvent)
+import Echidna.Worker.Fuzz (runFuzzWorker)
+import Echidna.Worker.Symbolic (runSymWorker)
+
+-- | Run an agent to completion and report why it stopped.
+--
+-- The reason is returned rather than pushed as a 'WorkerStopped' event: an
+-- agent killed by the campaign timeout never reaches its own last line, so only
+-- the caller knows the real reason and it must emit that event itself, exactly
+-- once per worker. Listeners count 'WorkerStopped' events to decide when the
+-- campaign is over, so a second one retires a worker that is still running.
+runAgent :: Agent -> Env -> IO WorkerStopReason
+runAgent agent env = do
+  let workerId = workerIdOf agent
+      stateRef = stateRefOf agent
+      -- Publish the worker state so the UI can read it
+      callback = get >>= liftIO . writeIORef stateRef
+
+  pushCampaignEvent env $ WorkerEvent workerId (workerTypeOf agent)
+    (Log ("Starting " ++ agentName agent ++ " " ++ show workerId))
+
+  (reason, finalState) <- flip runReaderT env $ case agent of
+    FuzzerAgent{initialVm, initialDict, initialCorpus, testLimit} ->
+      runFuzzWorker callback initialVm initialDict workerId initialCorpus testLimit
+    SymbolicAgent{initialVm, initialDict, initialCorpus, contractName} ->
+      runSymWorker callback initialVm initialDict workerId initialCorpus contractName
+
+  -- The callback publishes as the worker goes, but not from every exit path
+  -- (verification mode never runs it), so publish the final state here too.
+  writeIORef stateRef finalState
+  pure reason

--- a/lib/Echidna/Agent.hs
+++ b/lib/Echidna/Agent.hs
@@ -32,8 +32,8 @@ runAgent agent env = do
   (reason, finalState) <- flip runReaderT env $ case agent of
     FuzzerAgent{initialVm, initialDict, initialCorpus, testLimit} ->
       runFuzzWorker callback initialVm initialDict workerId initialCorpus testLimit
-    SymbolicAgent{initialVm, initialDict, initialCorpus, contractName} ->
-      runSymWorker callback initialVm initialDict workerId initialCorpus contractName
+    SymbolicAgent{initialVm, initialDict, contractName} ->
+      runSymWorker callback initialVm initialDict workerId contractName
 
   -- The callback publishes as the worker goes, but not from every exit path
   -- (verification mode never runs it), so publish the final state here too.

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -1,9 +1,0 @@
-module Echidna.Campaign (isSuccessful) where
-
-import Echidna.Types.Test
-
--- | Given a 'Campaign', check if the test results should be reported as a
--- success or a failure.
-isSuccessful :: [EchidnaTest] -> Bool
-isSuccessful =
-  all (\case { Passed -> True; Open -> True; _ -> False; } . (.state))

--- a/lib/Echidna/Campaign.hs
+++ b/lib/Echidna/Campaign.hs
@@ -1,45 +1,9 @@
-module Echidna.Campaign
-  ( isSuccessful
-  , runWorker
-  ) where
+module Echidna.Campaign (isSuccessful) where
 
-import Control.Monad.Catch (MonadThrow)
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Reader (MonadReader)
-import Control.Monad.State.Strict (StateT)
-import Data.Text (Text)
-
-import EVM.Types hiding (Env)
-
-import Echidna.ABI (GenDict)
-import Echidna.Types.Campaign (WorkerState)
-import Echidna.Types.Config
 import Echidna.Types.Test
-import Echidna.Types.Tx (Tx)
-import Echidna.Types.Worker
-import Echidna.Worker.Fuzz (runFuzzWorker)
-import Echidna.Worker.Symbolic (runSymWorker)
 
 -- | Given a 'Campaign', check if the test results should be reported as a
 -- success or a failure.
 isSuccessful :: [EchidnaTest] -> Bool
 isSuccessful =
   all (\case { Passed -> True; Open -> True; _ -> False; } . (.state))
-
-runWorker
-  :: (MonadIO m, MonadThrow m, MonadReader Env m)
-  => WorkerType
-  -> StateT WorkerState m ()
-  -- ^ Callback to run after each state update (for instrumentation)
-  -> VM Concrete -- ^ Initial VM state
-  -> GenDict -- ^ Generation dictionary
-  -> Int     -- ^ Worker id starting from 0
-  -> [(FilePath, [Tx])]
-  -- ^ Initial corpus of transactions
-  -> Int     -- ^ Test limit for this worker
-  -> Maybe Text -- ^ Specified contract name
-  -> m (WorkerStopReason, WorkerState)
-runWorker SymbolicWorker callback vm dict workerId initialCorpus _ name =
-  runSymWorker callback vm dict workerId initialCorpus name
-runWorker FuzzWorker callback vm dict workerId initialCorpus testLimit _ =
-  runFuzzWorker callback vm dict workerId initialCorpus testLimit

--- a/lib/Echidna/Types/Agent.hs
+++ b/lib/Echidna/Types/Agent.hs
@@ -1,0 +1,19 @@
+module Echidna.Types.Agent where
+
+import Echidna.Types.Config (Env)
+import Echidna.Types.Worker (WorkerStopReason)
+
+-- | Something that can be spawned as a campaign worker.
+--
+-- Each instance bundles everything its worker needs to run, so the campaign
+-- can start one without knowing which kind of worker it is.
+class Agent a where
+  -- | Run the agent to completion and report why it stopped.
+  --
+  -- The reason is returned rather than pushed as a 'WorkerStopped' event: an
+  -- agent killed by the campaign timeout never reaches its own last line, so
+  -- only the caller knows the real reason and it must emit that event itself,
+  -- exactly once per worker. Listeners count 'WorkerStopped' events to decide
+  -- when the campaign is over, so a second one retires a worker that is still
+  -- running.
+  runAgent :: a -> Env -> IO WorkerStopReason

--- a/lib/Echidna/Types/Agent.hs
+++ b/lib/Echidna/Types/Agent.hs
@@ -1,19 +1,53 @@
 module Echidna.Types.Agent where
 
-import Echidna.Types.Config (Env)
-import Echidna.Types.Worker (WorkerStopReason)
+import Data.IORef (IORef)
+import Data.Text (Text)
 
--- | Something that can be spawned as a campaign worker.
+import EVM.Types (VM, VMType(Concrete))
+
+import Echidna.ABI (GenDict)
+import Echidna.Types.Campaign (WorkerState)
+import Echidna.Types.Tx (Tx)
+import Echidna.Types.Worker (WorkerId, WorkerType(..))
+
+-- | A worker the campaign can spawn, bundled with everything it needs to run.
 --
--- Each instance bundles everything its worker needs to run, so the campaign
--- can start one without knowing which kind of worker it is.
-class Agent a where
-  -- | Run the agent to completion and report why it stopped.
-  --
-  -- The reason is returned rather than pushed as a 'WorkerStopped' event: an
-  -- agent killed by the campaign timeout never reaches its own last line, so
-  -- only the caller knows the real reason and it must emit that event itself,
-  -- exactly once per worker. Listeners count 'WorkerStopped' events to decide
-  -- when the campaign is over, so a second one retires a worker that is still
-  -- running.
-  runAgent :: a -> Env -> IO WorkerStopReason
+-- Each constructor carries only its own worker's parameters, so a caller never
+-- has to supply arguments the other kind of worker discards.
+data Agent
+  = FuzzerAgent
+      { fuzzerId :: Int
+      , initialVm :: VM Concrete
+      , initialDict :: GenDict
+      , initialCorpus :: [(FilePath, [Tx])]
+      , testLimit :: Int
+      , stateRef :: IORef WorkerState
+      }
+  | SymbolicAgent
+      { initialVm :: VM Concrete
+      , initialDict :: GenDict
+      , initialCorpus :: [(FilePath, [Tx])]
+      , contractName :: Maybe Text
+      , stateRef :: IORef WorkerState
+      }
+
+-- | The worker id this agent runs as. There is at most one symbolic worker and
+-- it is always worker 0.
+workerIdOf :: Agent -> WorkerId
+workerIdOf FuzzerAgent{fuzzerId} = fuzzerId
+workerIdOf SymbolicAgent{} = 0
+
+-- | The kind of worker this agent is, for tagging campaign events.
+workerTypeOf :: Agent -> WorkerType
+workerTypeOf FuzzerAgent{} = FuzzWorker
+workerTypeOf SymbolicAgent{} = SymbolicWorker
+
+-- | The ref the agent publishes its 'WorkerState' through.
+stateRefOf :: Agent -> IORef WorkerState
+stateRefOf FuzzerAgent{stateRef} = stateRef
+stateRefOf SymbolicAgent{stateRef} = stateRef
+
+-- | Name used to announce the agent when it starts.
+agentName :: Agent -> String
+agentName FuzzerAgent{} = "FuzzerAgent"
+agentName SymbolicAgent{} = "SymbolicAgent"

--- a/lib/Echidna/Types/Agent.hs
+++ b/lib/Echidna/Types/Agent.hs
@@ -23,10 +23,10 @@ data Agent
       , testLimit :: Int
       , stateRef :: IORef WorkerState
       }
+  -- | The symbolic worker does not replay the corpus, so it carries none.
   | SymbolicAgent
       { initialVm :: VM Concrete
       , initialDict :: GenDict
-      , initialCorpus :: [(FilePath, [Tx])]
       , contractName :: Maybe Text
       , stateRef :: IORef WorkerState
       }

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -174,9 +174,11 @@ isVerified t = case t.state of
 
 -- | Whether a whole test set should be reported as a success or a failure.
 -- This is what decides Echidna's exit code.
+--
+-- 'Unsolvable' counts as a success: it is the state verification mode sets on
+-- a test it has formally proven cannot be falsified.
 isSuccessful :: [EchidnaTest] -> Bool
-isSuccessful =
-  all (\case { Passed -> True; Open -> True; _ -> False; } . (.state))
+isSuccessful = all (\t -> isOpen t || isPassed t || isVerified t)
 
 instance ToJSON TestState where
   toJSON s =

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -172,6 +172,12 @@ isVerified t = case t.state of
   Unsolvable -> True
   _          -> False
 
+-- | Whether a whole test set should be reported as a success or a failure.
+-- This is what decides Echidna's exit code.
+isSuccessful :: [EchidnaTest] -> Bool
+isSuccessful =
+  all (\case { Passed -> True; Open -> True; _ -> False; } . (.state))
+
 instance ToJSON TestState where
   toJSON s =
     object $ ("passed", toJSON passed) : maybeToList desc

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -15,7 +15,7 @@ import Control.Monad.State.Strict hiding (state)
 import Data.ByteString.Lazy qualified as BS
 import Data.List.Split (splitPlaces)
 import Data.Map (Map)
-import Data.Maybe (isJust, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Sequence ((|>))
 import Data.Text (Text)
 import Data.Time
@@ -33,11 +33,11 @@ import EVM.Fetch qualified
 import EVM.Types (Addr, Contract, VM, VMType(Concrete), W256)
 
 import Echidna.ABI
-import Echidna.Campaign (runWorker)
 import Echidna.Output.Corpus (saveCorpusEvent)
 import Echidna.Output.JSON qualified
 import Echidna.Server (runSSEServer)
 import Echidna.SourceAnalysis.Slither (isEmptySlitherInfo)
+import Echidna.Types.Agent (runAgent)
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Corpus qualified as Corpus
@@ -49,6 +49,8 @@ import Echidna.UI.Report
 import Echidna.UI.Widgets
 import Echidna.Utility (timePrefix, getTimestamp)
 import Echidna.Worker (getNWorkers, spawnListener, workerIDToType)
+import Echidna.Worker.Fuzz (FuzzerAgent(..))
+import Echidna.Worker.Symbolic (SymbolicAgent(..))
 
 data UIEvent =
   CampaignUpdated LocalTime [EchidnaTest] [WorkerState]
@@ -106,7 +108,7 @@ ui vm dict initialCorpus cliSelectedContract = do
   corpusSaverStopVar <- spawnListener (saveCorpusEvent env)
 
   let spawnWorkers =
-        forM (zip corpusChunks [0..(nworkers-1)]) $
+        liftIO $ forM (zip corpusChunks [0..(nworkers-1)]) $
           uncurry (spawnWorker env perWorkerTestLimit)
 
   case effectiveMode of
@@ -248,6 +250,15 @@ ui vm dict initialCorpus cliSelectedContract = do
   spawnWorker env testLimit corpusChunk workerId = do
     stateRef <- newIORef initialWorkerState
 
+    let fuzzerAgent corpus limit =
+          FuzzerAgent { fuzzerId = workerId
+                      , initialVm = vm
+                      , initialDict = dict
+                      , initialCorpus = corpus
+                      , testLimit = limit
+                      , stateRef
+                      }
+
     threadId <- forkIO $ do
       -- TODO: maybe figure this out with forkFinally?
       let workerType = workerIDToType env.cfg.campaignConf workerId
@@ -255,12 +266,16 @@ ui vm dict initialCorpus cliSelectedContract = do
           let
             timeoutUsecs = maybe (-1) (*1_000_000) env.cfg.uiConf.maxTime
             corpus = if workerType == SymbolicWorker then initialCorpus else corpusChunk
-          maybeResult <- timeout timeoutUsecs $
-            runWorker workerType (get >>= writeIORef stateRef)
-                      vm dict workerId corpus testLimit cliSelectedContract
-          pure $ case maybeResult of
-            Just (stopReason, _finalState) -> stopReason
-            Nothing -> TimeLimitReached
+          maybeResult <- timeout timeoutUsecs $ case workerType of
+            FuzzWorker -> runAgent (fuzzerAgent corpus testLimit) env
+            SymbolicWorker -> runAgent
+              SymbolicAgent { initialVm = vm
+                            , initialDict = dict
+                            , initialCorpus = corpus
+                            , contractName = cliSelectedContract
+                            , stateRef
+                            } env
+          pure $ fromMaybe TimeLimitReached maybeResult
         )
         [ Handler $ \(e :: AsyncException) -> pure $ Killed (show e)
         , Handler $ \(e :: SomeException)  -> pure $ Crashed (show e)
@@ -268,14 +283,13 @@ ui vm dict initialCorpus cliSelectedContract = do
 
       -- When a fuzz worker is interrupted by timeout, tests may not have
       -- finished shrinking. Run a shrink-only pass outside the timeout using
-      -- the same worker loop (testLimit=0 means no fuzzing, only shrink).
+      -- the same agent (testLimit=0 means no fuzzing, only shrink).
       -- (See github.com/crytic/echidna/issues/839)
       case stopReason of
         TimeLimitReached | workerType == FuzzWorker -> do
           tests <- traverse readIORef env.testRefs
           when (any needsShrinking tests) $ void $
-            runReaderT (runWorker FuzzWorker (get >>= writeIORef stateRef)
-                        vm dict workerId [] 0 cliSelectedContract) env
+            runAgent (fuzzerAgent [] 0) env
         _ -> pure ()
 
       time <- liftIO getTimestamp

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -94,8 +94,8 @@ ui vm dict initialCorpus cliSelectedContract = do
           (fromIntegral conf.campaignConf.testLimit / fromIntegral nFuzzWorkers :: Double)
 
     -- Distribute the replay corpus across the fuzz workers. The symbolic
-    -- worker always replays the full corpus (see spawnWorker), so with no
-    -- fuzz workers there is nothing to distribute.
+    -- worker does not replay it, so with no fuzz workers there is nothing to
+    -- distribute.
     corpusChunks
       | nFuzzWorkers == 0 = repeat []
       | otherwise = splitPlaces chunkSizes initialCorpus ++ repeat []
@@ -258,14 +258,11 @@ ui vm dict initialCorpus cliSelectedContract = do
                       , stateRef
                       }
 
-        -- Fuzz workers each replay their own chunk of the corpus; the symbolic
-        -- worker replays all of it.
         agent = case workerIDToType env.cfg.campaignConf workerId of
           FuzzWorker -> fuzzerAgent corpusChunk testLimit
           SymbolicWorker ->
             SymbolicAgent { initialVm = vm
                           , initialDict = dict
-                          , initialCorpus = initialCorpus
                           , contractName = cliSelectedContract
                           , stateRef
                           }

--- a/lib/Echidna/UI.hs
+++ b/lib/Echidna/UI.hs
@@ -33,11 +33,12 @@ import EVM.Fetch qualified
 import EVM.Types (Addr, Contract, VM, VMType(Concrete), W256)
 
 import Echidna.ABI
+import Echidna.Agent (runAgent)
 import Echidna.Output.Corpus (saveCorpusEvent)
 import Echidna.Output.JSON qualified
 import Echidna.Server (runSSEServer)
 import Echidna.SourceAnalysis.Slither (isEmptySlitherInfo)
-import Echidna.Types.Agent (runAgent)
+import Echidna.Types.Agent (Agent(..), workerTypeOf)
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Corpus qualified as Corpus
@@ -49,8 +50,6 @@ import Echidna.UI.Report
 import Echidna.UI.Widgets
 import Echidna.Utility (timePrefix, getTimestamp)
 import Echidna.Worker (getNWorkers, spawnListener, workerIDToType)
-import Echidna.Worker.Fuzz (FuzzerAgent(..))
-import Echidna.Worker.Symbolic (SymbolicAgent(..))
 
 data UIEvent =
   CampaignUpdated LocalTime [EchidnaTest] [WorkerState]
@@ -259,23 +258,25 @@ ui vm dict initialCorpus cliSelectedContract = do
                       , stateRef
                       }
 
+        -- Fuzz workers each replay their own chunk of the corpus; the symbolic
+        -- worker replays all of it.
+        agent = case workerIDToType env.cfg.campaignConf workerId of
+          FuzzWorker -> fuzzerAgent corpusChunk testLimit
+          SymbolicWorker ->
+            SymbolicAgent { initialVm = vm
+                          , initialDict = dict
+                          , initialCorpus = initialCorpus
+                          , contractName = cliSelectedContract
+                          , stateRef
+                          }
+
+        workerType = workerTypeOf agent
+
     threadId <- forkIO $ do
       -- TODO: maybe figure this out with forkFinally?
-      let workerType = workerIDToType env.cfg.campaignConf workerId
       stopReason <- catches (do
-          let
-            timeoutUsecs = maybe (-1) (*1_000_000) env.cfg.uiConf.maxTime
-            corpus = if workerType == SymbolicWorker then initialCorpus else corpusChunk
-          maybeResult <- timeout timeoutUsecs $ case workerType of
-            FuzzWorker -> runAgent (fuzzerAgent corpus testLimit) env
-            SymbolicWorker -> runAgent
-              SymbolicAgent { initialVm = vm
-                            , initialDict = dict
-                            , initialCorpus = corpus
-                            , contractName = cliSelectedContract
-                            , stateRef
-                            } env
-          pure $ fromMaybe TimeLimitReached maybeResult
+          let timeoutUsecs = maybe (-1) (*1_000_000) env.cfg.uiConf.maxTime
+          fromMaybe TimeLimitReached <$> timeout timeoutUsecs (runAgent agent env)
         )
         [ Handler $ \(e :: AsyncException) -> pure $ Killed (show e)
         , Handler $ \(e :: SomeException)  -> pure $ Crashed (show e)

--- a/lib/Echidna/Worker/Fuzz.hs
+++ b/lib/Echidna/Worker/Fuzz.hs
@@ -1,62 +1,32 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 
-module Echidna.Worker.Fuzz (FuzzerAgent(..), runFuzzWorker) where
+module Echidna.Worker.Fuzz (runFuzzWorker) where
 
 import Control.Monad (forM_, replicateM, void)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Random.Strict (MonadRandom, evalRandT)
-import Control.Monad.Reader (MonadReader, ask, asks, liftIO, runReaderT)
-import Control.Monad.State.Strict (MonadIO, MonadState, StateT, get, gets, runStateT)
+import Control.Monad.Reader (MonadReader, ask, asks, liftIO)
+import Control.Monad.State.Strict (MonadIO, MonadState, StateT, gets, runStateT)
 import Control.Monad.Trans (lift)
-import Data.IORef (IORef, atomicModifyIORef', readIORef, writeIORef)
+import Data.IORef (atomicModifyIORef', readIORef)
 import Data.Map (Map)
 import System.Random (mkStdGen)
 
-import EVM.Types hiding (Env, Frame(state), Gas, Log)
+import EVM.Types hiding (Env, Frame(state), Gas)
 
 import Echidna.ABI
 import Echidna.Mutator.Corpus
 import Echidna.Orphans.Rand ()
 import Echidna.Shrink (isShrinkable, shrinkWorkerTests)
 import Echidna.Transaction
-import Echidna.Types.Agent
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Test
 import Echidna.Types.Test qualified as Test
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.Worker
-import Echidna.Worker (pushCampaignEvent)
 import Echidna.Worker.Sequence (callseq, replayCorpus)
-
--- | A fuzzing worker. A campaign runs one per fuzz worker id.
-data FuzzerAgent = FuzzerAgent
-  { fuzzerId :: Int
-  , initialVm :: VM Concrete
-  , initialDict :: GenDict
-  , initialCorpus :: [(FilePath, [Tx])]
-  , testLimit :: Int
-  , stateRef :: IORef WorkerState
-  }
-
-instance Agent FuzzerAgent where
-  runAgent agent env = do
-    let workerId = agent.fuzzerId
-        -- Publish the worker state so the UI can read it
-        callback = get >>= liftIO . writeIORef agent.stateRef
-
-    pushCampaignEvent env $ WorkerEvent workerId FuzzWorker
-      (Log ("Starting FuzzerAgent " ++ show workerId))
-
-    (reason, finalState) <- flip runReaderT env $
-      runFuzzWorker callback agent.initialVm agent.initialDict workerId
-                    agent.initialCorpus agent.testLimit
-
-    -- The callback publishes as the worker goes, but not from every exit path,
-    -- so publish the final state here as well.
-    writeIORef agent.stateRef finalState
-    pure reason
 
 -- | Run a fuzzing campaign given an initial universe state, some tests, and an
 -- optional dictionary to generate calls with. Return the 'Campaign' state once

--- a/lib/Echidna/Worker/Fuzz.hs
+++ b/lib/Echidna/Worker/Fuzz.hs
@@ -1,32 +1,62 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 
-module Echidna.Worker.Fuzz (runFuzzWorker) where
+module Echidna.Worker.Fuzz (FuzzerAgent(..), runFuzzWorker) where
 
 import Control.Monad (forM_, replicateM, void)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Random.Strict (MonadRandom, evalRandT)
-import Control.Monad.Reader (MonadReader, ask, asks, liftIO)
-import Control.Monad.State.Strict (MonadIO, MonadState, StateT, gets, runStateT)
+import Control.Monad.Reader (MonadReader, ask, asks, liftIO, runReaderT)
+import Control.Monad.State.Strict (MonadIO, MonadState, StateT, get, gets, runStateT)
 import Control.Monad.Trans (lift)
-import Data.IORef (atomicModifyIORef', readIORef)
+import Data.IORef (IORef, atomicModifyIORef', readIORef, writeIORef)
 import Data.Map (Map)
 import System.Random (mkStdGen)
 
-import EVM.Types hiding (Env, Frame(state), Gas)
+import EVM.Types hiding (Env, Frame(state), Gas, Log)
 
 import Echidna.ABI
 import Echidna.Mutator.Corpus
 import Echidna.Orphans.Rand ()
 import Echidna.Shrink (isShrinkable, shrinkWorkerTests)
 import Echidna.Transaction
+import Echidna.Types.Agent
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Test
 import Echidna.Types.Test qualified as Test
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.Worker
+import Echidna.Worker (pushCampaignEvent)
 import Echidna.Worker.Sequence (callseq, replayCorpus)
+
+-- | A fuzzing worker. A campaign runs one per fuzz worker id.
+data FuzzerAgent = FuzzerAgent
+  { fuzzerId :: Int
+  , initialVm :: VM Concrete
+  , initialDict :: GenDict
+  , initialCorpus :: [(FilePath, [Tx])]
+  , testLimit :: Int
+  , stateRef :: IORef WorkerState
+  }
+
+instance Agent FuzzerAgent where
+  runAgent agent env = do
+    let workerId = agent.fuzzerId
+        -- Publish the worker state so the UI can read it
+        callback = get >>= liftIO . writeIORef agent.stateRef
+
+    pushCampaignEvent env $ WorkerEvent workerId FuzzWorker
+      (Log ("Starting FuzzerAgent " ++ show workerId))
+
+    (reason, finalState) <- flip runReaderT env $
+      runFuzzWorker callback agent.initialVm agent.initialDict workerId
+                    agent.initialCorpus agent.testLimit
+
+    -- The callback publishes as the worker goes, but not from every exit path,
+    -- so publish the final state here as well.
+    writeIORef agent.stateRef finalState
+    pure reason
 
 -- | Run a fuzzing campaign given an initial universe state, some tests, and an
 -- optional dictionary to generate calls with. Return the 'Campaign' state once

--- a/lib/Echidna/Worker/Symbolic.hs
+++ b/lib/Echidna/Worker/Symbolic.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 
-module Echidna.Worker.Symbolic (SymbolicAgent(..), runSymWorker) where
+module Echidna.Worker.Symbolic (runSymWorker) where
 
 import Control.Concurrent (dupChan, takeMVar)
 import Control.Monad (forM_, unless, void, when)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Random.Strict (evalRandT)
-import Control.Monad.Reader (MonadReader, asks, liftIO, runReaderT)
-import Control.Monad.State.Strict (MonadIO, StateT, get, modify', runStateT)
+import Control.Monad.Reader (MonadReader, asks, liftIO)
+import Control.Monad.State.Strict (MonadIO, StateT, modify', runStateT)
 import Control.Monad.Trans (lift)
 import Data.Foldable (foldlM)
-import Data.IORef (IORef, readIORef, writeIORef)
+import Data.IORef (readIORef)
 import Data.List.NonEmpty qualified as NEList
 import Data.Map qualified as Map
 import Data.Maybe (fromJust)
@@ -20,7 +20,7 @@ import System.Random (mkStdGen)
 
 import EVM.Dapp (DappInfo(..))
 import EVM.Solidity (Method(..), SolcContract(..))
-import EVM.Types hiding (Env, Frame(state), Gas, Log)
+import EVM.Types hiding (Env, Frame(state), Gas)
 
 import Echidna.ABI
 import Echidna.Exec (execTx)
@@ -32,7 +32,6 @@ import Echidna.SymExec.Exploration (exploreContract, getRandomTargetMethod, getT
 import Echidna.SymExec.Verification (isSuitableToVerifyMethod, verifyMethod)
 import Echidna.Test
 import Echidna.Test.State (findFailedTests, setAssertionTestState)
-import Echidna.Types.Agent
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Random (rElem)
@@ -40,35 +39,8 @@ import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Test
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.Worker
-import Echidna.Worker (listenerLoop, pushCampaignEvent, pushWorkerEvent)
+import Echidna.Worker (listenerLoop, pushWorkerEvent)
 import Echidna.Worker.Sequence (callseq)
-
--- | The symbolic worker. There is at most one, and it is always worker 0.
-data SymbolicAgent = SymbolicAgent
-  { initialVm :: VM Concrete
-  , initialDict :: GenDict
-  , initialCorpus :: [(FilePath, [Tx])]
-  , contractName :: Maybe Text
-  , stateRef :: IORef WorkerState
-  }
-
-instance Agent SymbolicAgent where
-  runAgent agent env = do
-    let workerId = 0
-        -- Publish the worker state so the UI can read it
-        callback = get >>= liftIO . writeIORef agent.stateRef
-
-    pushCampaignEvent env $ WorkerEvent workerId SymbolicWorker
-      (Log ("Starting SymbolicAgent " ++ show workerId))
-
-    (reason, finalState) <- flip runReaderT env $
-      runSymWorker callback agent.initialVm agent.initialDict workerId
-                   agent.initialCorpus agent.contractName
-
-    -- The callback publishes as the worker goes, but not from every exit path
-    -- (verification mode never runs it), so publish the final state here too.
-    writeIORef agent.stateRef finalState
-    pure reason
 
 runSymWorker
   :: (MonadIO m, MonadThrow m, MonadReader Env m)

--- a/lib/Echidna/Worker/Symbolic.hs
+++ b/lib/Echidna/Worker/Symbolic.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 
-module Echidna.Worker.Symbolic (runSymWorker) where
+module Echidna.Worker.Symbolic (SymbolicAgent(..), runSymWorker) where
 
 import Control.Concurrent (dupChan, takeMVar)
 import Control.Monad (forM_, unless, void, when)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Random.Strict (evalRandT)
-import Control.Monad.Reader (MonadReader, asks, liftIO)
-import Control.Monad.State.Strict (MonadIO, StateT, modify', runStateT)
+import Control.Monad.Reader (MonadReader, asks, liftIO, runReaderT)
+import Control.Monad.State.Strict (MonadIO, StateT, get, modify', runStateT)
 import Control.Monad.Trans (lift)
 import Data.Foldable (foldlM)
-import Data.IORef (readIORef)
+import Data.IORef (IORef, readIORef, writeIORef)
 import Data.List.NonEmpty qualified as NEList
 import Data.Map qualified as Map
 import Data.Maybe (fromJust)
@@ -20,7 +20,7 @@ import System.Random (mkStdGen)
 
 import EVM.Dapp (DappInfo(..))
 import EVM.Solidity (Method(..), SolcContract(..))
-import EVM.Types hiding (Env, Frame(state), Gas)
+import EVM.Types hiding (Env, Frame(state), Gas, Log)
 
 import Echidna.ABI
 import Echidna.Exec (execTx)
@@ -32,6 +32,7 @@ import Echidna.SymExec.Exploration (exploreContract, getRandomTargetMethod, getT
 import Echidna.SymExec.Verification (isSuitableToVerifyMethod, verifyMethod)
 import Echidna.Test
 import Echidna.Test.State (findFailedTests, setAssertionTestState)
+import Echidna.Types.Agent
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Random (rElem)
@@ -39,8 +40,35 @@ import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Test
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.Worker
-import Echidna.Worker (listenerLoop, pushWorkerEvent)
+import Echidna.Worker (listenerLoop, pushCampaignEvent, pushWorkerEvent)
 import Echidna.Worker.Sequence (callseq)
+
+-- | The symbolic worker. There is at most one, and it is always worker 0.
+data SymbolicAgent = SymbolicAgent
+  { initialVm :: VM Concrete
+  , initialDict :: GenDict
+  , initialCorpus :: [(FilePath, [Tx])]
+  , contractName :: Maybe Text
+  , stateRef :: IORef WorkerState
+  }
+
+instance Agent SymbolicAgent where
+  runAgent agent env = do
+    let workerId = 0
+        -- Publish the worker state so the UI can read it
+        callback = get >>= liftIO . writeIORef agent.stateRef
+
+    pushCampaignEvent env $ WorkerEvent workerId SymbolicWorker
+      (Log ("Starting SymbolicAgent " ++ show workerId))
+
+    (reason, finalState) <- flip runReaderT env $
+      runSymWorker callback agent.initialVm agent.initialDict workerId
+                   agent.initialCorpus agent.contractName
+
+    -- The callback publishes as the worker goes, but not from every exit path
+    -- (verification mode never runs it), so publish the final state here too.
+    writeIORef agent.stateRef finalState
+    pure reason
 
 runSymWorker
   :: (MonadIO m, MonadThrow m, MonadReader Env m)

--- a/lib/Echidna/Worker/Symbolic.hs
+++ b/lib/Echidna/Worker/Symbolic.hs
@@ -37,7 +37,6 @@ import Echidna.Types.Config
 import Echidna.Types.Random (rElem)
 import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Test
-import Echidna.Types.Tx (Tx)
 import Echidna.Types.Worker
 import Echidna.Worker (listenerLoop, pushWorkerEvent)
 import Echidna.Worker.Sequence (callseq)
@@ -49,11 +48,9 @@ runSymWorker
   -> VM Concrete -- ^ Initial VM state
   -> GenDict -- ^ Generation dictionary
   -> Int     -- ^ Worker id starting from 0
-  -> [(FilePath, [Tx])]
-  -- ^ Initial corpus of transactions
   -> Maybe Text -- ^ Specified contract name
   -> m (WorkerStopReason, WorkerState)
-runSymWorker callback vm dict workerId _ name = do
+runSymWorker callback vm dict workerId name = do
   cfg <- asks (.cfg)
   let nworkers = getNFuzzWorkers cfg.campaignConf -- getNFuzzWorkers, NOT getNWorkers
   eventQueue <- asks (.eventQueue)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -37,7 +37,6 @@ import EVM.Solidity (BuildOutput(..))
 import EVM.Types (Addr)
 
 import Echidna
-import Echidna.Campaign (isSuccessful)
 import Echidna.Config
 import Echidna.Onchain qualified as Onchain
 import Echidna.Output.Corpus
@@ -48,7 +47,7 @@ import Echidna.Test (validateTestMode)
 import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Solidity
-import Echidna.Types.Test (TestMode, EchidnaTest(..), TestConf(..), TestType(..), TestState(..))
+import Echidna.Types.Test (TestMode, EchidnaTest(..), TestConf(..), TestType(..), TestState(..), isSuccessful)
 import Echidna.UI
 import Echidna.Utility (measureIO)
 

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -112,7 +112,6 @@ runContract f selectedContract cfg workerType = do
         SymbolicWorker ->
           SymbolicAgent { initialVm = vm
                         , initialDict = dict
-                        , initialCorpus = []
                         , contractName = selectedContract
                         , stateRef
                         }

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -25,7 +25,7 @@ module Common
   , gasConsumedGt
   ) where
 
-import Control.Monad (forM_)
+import Control.Monad (forM_, void)
 import Control.Monad.Random (getRandomR)
 import Control.Monad.Reader (runReaderT)
 import Data.DoubleWord (Int256)
@@ -45,10 +45,10 @@ import EVM.Solidity (Contracts(..), BuildOutput(..), SolcContract(..))
 import EVM.Types hiding (Env, Gas)
 
 import Echidna (mkEnv, prepareContract)
-import Echidna.Campaign (runWorker)
 import Echidna.Config (parseConfig, defaultConfig)
 import Echidna.Solidity (selectMainContract, mkTests, loadSpecified, compileContracts)
 import Echidna.Test (checkETest)
+import Echidna.Types.Agent (runAgent)
 import Echidna.Types.Campaign
 import Echidna.Types.Config (Env(..), EConfig(..), EConfigWithUsage(..))
 import Echidna.Types.Signature (ContractName)
@@ -57,6 +57,8 @@ import Echidna.Types.Test
 import Echidna.Types.Tx (Tx(..), TxCall(..))
 import Echidna.Types.Worker (WorkerType(..))
 import Echidna.Types.World (World(..))
+import Echidna.Worker.Fuzz (FuzzerAgent(..))
+import Echidna.Worker.Symbolic (SymbolicAgent(..))
 
 testConfig :: EConfig
 testConfig = defaultConfig & overrideQuiet
@@ -98,8 +100,24 @@ runContract f selectedContract cfg workerType = do
 
   (vm, env, dict) <- prepareContract cfg (f :| []) buildOutput selectedContract seed
 
-  (_stopReason, finalState) <- flip runReaderT env $
-    runWorker workerType (pure ()) vm dict 0 [] cfg.campaignConf.testLimit selectedContract
+  stateRef <- newIORef initialWorkerState
+  void $ case workerType of
+    FuzzWorker -> runAgent
+      FuzzerAgent { fuzzerId = 0
+                  , initialVm = vm
+                  , initialDict = dict
+                  , initialCorpus = []
+                  , testLimit = cfg.campaignConf.testLimit
+                  , stateRef
+                  } env
+    SymbolicWorker -> runAgent
+      SymbolicAgent { initialVm = vm
+                    , initialDict = dict
+                    , initialCorpus = []
+                    , contractName = selectedContract
+                    , stateRef
+                    } env
+  finalState <- readIORef stateRef
 
   -- TODO: consider snapshotting the state so checking functions don't need to
   -- be IO

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -45,10 +45,11 @@ import EVM.Solidity (Contracts(..), BuildOutput(..), SolcContract(..))
 import EVM.Types hiding (Env, Gas)
 
 import Echidna (mkEnv, prepareContract)
+import Echidna.Agent (runAgent)
 import Echidna.Config (parseConfig, defaultConfig)
 import Echidna.Solidity (selectMainContract, mkTests, loadSpecified, compileContracts)
 import Echidna.Test (checkETest)
-import Echidna.Types.Agent (runAgent)
+import Echidna.Types.Agent (Agent(..))
 import Echidna.Types.Campaign
 import Echidna.Types.Config (Env(..), EConfig(..), EConfigWithUsage(..))
 import Echidna.Types.Signature (ContractName)
@@ -57,8 +58,6 @@ import Echidna.Types.Test
 import Echidna.Types.Tx (Tx(..), TxCall(..))
 import Echidna.Types.Worker (WorkerType(..))
 import Echidna.Types.World (World(..))
-import Echidna.Worker.Fuzz (FuzzerAgent(..))
-import Echidna.Worker.Symbolic (SymbolicAgent(..))
 
 testConfig :: EConfig
 testConfig = defaultConfig & overrideQuiet
@@ -101,22 +100,23 @@ runContract f selectedContract cfg workerType = do
   (vm, env, dict) <- prepareContract cfg (f :| []) buildOutput selectedContract seed
 
   stateRef <- newIORef initialWorkerState
-  void $ case workerType of
-    FuzzWorker -> runAgent
-      FuzzerAgent { fuzzerId = 0
-                  , initialVm = vm
-                  , initialDict = dict
-                  , initialCorpus = []
-                  , testLimit = cfg.campaignConf.testLimit
-                  , stateRef
-                  } env
-    SymbolicWorker -> runAgent
-      SymbolicAgent { initialVm = vm
-                    , initialDict = dict
-                    , initialCorpus = []
-                    , contractName = selectedContract
-                    , stateRef
-                    } env
+  let agent = case workerType of
+        FuzzWorker ->
+          FuzzerAgent { fuzzerId = 0
+                      , initialVm = vm
+                      , initialDict = dict
+                      , initialCorpus = []
+                      , testLimit = cfg.campaignConf.testLimit
+                      , stateRef
+                      }
+        SymbolicWorker ->
+          SymbolicAgent { initialVm = vm
+                        , initialDict = dict
+                        , initialCorpus = []
+                        , contractName = selectedContract
+                        , stateRef
+                        }
+  void $ runAgent agent env
   finalState <- readIORef stateRef
 
   -- TODO: consider snapshotting the state so checking functions don't need to


### PR DESCRIPTION
## Summary

- add `Echidna.Types.Agent`: one `Agent` sum type with a constructor per worker, carrying only that worker's parameters
- add `Echidna.Agent.runAgent :: Agent -> Env -> IO WorkerStopReason`, sitting above both worker modules exactly where `runWorker` used to
- retire `Echidna.Campaign`: with `runWorker` gone it held a single pure predicate, so `isSuccessful` moves to `Echidna.Types.Test` next to `isOpen`/`isPassed`/`isVerified`
- fix the exit code in verification mode, which reported failure on a fully verified run (#1602)
- stop threading a corpus into the symbolic worker, which has discarded it since #1394

`runWorker` dispatched on `WorkerType` and took a tag plus the union of both
workers' parameters, so every caller had to supply arguments the other worker
discards: `testLimit` for the symbolic worker, the selected contract name for
the fuzzer. A sum of records, one constructor per worker, is that signature's
actual shape.

Behaviour-preserving apart from the exit-code fix, which is its own commit and
described below.

## Why a sum type and not a typeclass

The first cut of this used `class Agent a` with two instances, following
`dev-agents-2`. Worth recording why it isn't that any more: nothing ever
abstracts over the class. There is no `Agent a =>` constraint, existential, or
heterogeneous collection anywhere in this repo, on any branch, including
`dev-agents-2` in its final state. Both call sites matched on `WorkerType` and
then named a concrete instance, so the class bought a shared method name and no
polymorphism.

A closed set of two worker kinds with per-kind behaviour at several sites is
what a sum type is for, and it buys two things the class did not:

- **`WorkerType` becomes derived rather than carried.** `spawnWorker` picks a
  constructor once and `workerTypeOf` supplies the rest, so the corpus
  conditional (`if workerType == SymbolicWorker then initialCorpus else
  corpusChunk`) disappears — each constructor is simply built with the corpus
  its worker wants.
- **Adding a third worker kind becomes a compile error** at every site that has
  to care. With the class you would add an instance and silently miss both
  dispatch sites.

## Deviations from `dev-agents-2`

`runAgent` takes no `Bus` parameter. `dev-agents-2` passes the bus explicitly
*and* stores it in `Env` (`Types/Config.hs`, plus `let bus = env.bus` in
`UI.hs`), so it is threaded twice. Reading it from `Env` — which `runFuzzWorker`
can already do, being `MonadReader Env m` — keeps this signature stable for the
rest of the stack. The agent records in `dev-agents-2` are otherwise identical
to these, and PRs after this one add no fields to them.

## Fixed while extracting

`runAgent` publishes the worker's final state to `stateRef` before returning.
The callback publishes as the worker goes but not from every exit path —
verification mode never runs it — and `src/test/Common.hs` now reads the state
back from that ref instead of from `runWorker`'s return value, so the ref has to
be authoritative.

## Exit code in verification mode (#1602)

Separate commit, and the one behaviour change here.

`isSuccessful` accepted only `Passed` and `Open`. `Unsolvable` — the state
symbolic execution sets once it proves an assertion cannot be reached — fell
through to `False`, so a run where *every* test verified still exited 1. The
better verification did, the more likely the run was to "fail": a test that
could not be verified stays `Open` and counted as a success, while one that was
verified did not.

Every other consumer already treats `Unsolvable` as a success — `ppTS` prints
`verified ✅`, `tsWidget` shows `VERIFIED!`, the JSON encoder maps it to
`Verified`. Only the exit code disagreed, which made it useless for gating CI on
a verification run.

Moving `isSuccessful` next to its sibling predicates is what surfaced this; the
move and the fix are separate commits.

## The symbolic worker's corpus (#1394 fallout)

`runSymWorker` has bound its `initialCorpus` parameter to `_` since c2671049,
which removed the `replayCorpus` call but left the parameter and every caller
feeding it. `replayCorpus` now has exactly one caller, in `Worker/Fuzz.hs`.

So the argument was threaded from `UI.hs` through the agent into a function that
dropped it, `UI.hs` had a branch specifically to hand the symbolic worker the
*whole* corpus rather than a chunk, and a comment claimed "the symbolic worker
always replays the full corpus" — untrue for about a year. All removed. The
value was already being discarded, so behaviour cannot change.

## Stacking

Stacked on `refactor/log-events`, which adds the generic `Log` event the agents
use to announce themselves. Retarget to `master` once that lands; the diff does
not change.

Because this targets a non-default branch, `Fixes #1602` on the commit will not
auto-close the issue on merge.

## Testing

- `cabal build all` — clean, no warnings (`-Wunused-packages` and `-Wall` are on)
- `cabal run tests` — 165 passed, re-run after each commit
- exit codes checked in four directions: all-verified `1 → 0`; verification with
  real failures still `1`; passing fuzz run `0`; falsified fuzz run `1`
- `--format text` with 3 workers: workers start, log, stop, and reproducers
  shrink as before; startup log lines are byte-identical to before the refactor
- `--timeout` path: the post-timeout shrink-only pass still re-enters the agent
  with `testLimit = 0` and shrinks the reproducer

Not covered: the interactive TUI, which needs a real terminal — worth an eyeball
before merge.