### PR TITLE
Inter-worker message bus and per-function call sampling

### DIFF
--- a/lib/Echidna.hs
+++ b/lib/Echidna.hs
@@ -1,6 +1,7 @@
 module Echidna where
 
 import Control.Concurrent (forkIO, newChan, readChan)
+import Control.Concurrent.STM (newBroadcastTChanIO)
 import Control.Exception (SomeException, handle)
 import Control.Monad (forever, void)
 import Control.Monad.Catch (MonadThrow(..))
@@ -132,6 +133,10 @@ mkEnv cfg buildOutput tests world slitherInfo = do
   -- it from a dedicated thread so the GC can reclaim delivered events.
   void $ forkIO $ handle (\(_ :: SomeException) -> pure ()) $
     forever $ void $ readChan eventQueue
+  -- A broadcast channel has no read end of its own, so nothing accumulates
+  -- until an agent duplicates it, and messages written while nobody is
+  -- listening are dropped.
+  bus <- newBroadcastTChanIO
   coverageRefInit <- newIORef mempty
   coverageRefRuntime <- newIORef mempty
   corpusRef <- newIORef mempty
@@ -142,6 +147,6 @@ mkEnv cfg buildOutput tests world slitherInfo = do
   -- TODO put in real path
   let dapp = dappInfo "/" buildOutput
   pure $ Env { cfg, dapp, codehashMap, fetchSession, contractNameCache
-             , chainId, eventQueue, coverageRefInit, coverageRefRuntime, corpusRef, testRefs, world
+             , chainId, eventQueue, bus, coverageRefInit, coverageRefRuntime, corpusRef, testRefs, world
              , slitherInfo, useColor
              }

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -1,15 +1,120 @@
 module Echidna.Types.Campaign where
 
 import Control.Concurrent (ThreadId)
+import Data.Map (Map)
+import Data.Map qualified as Map
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Word (Word8, Word16)
 import GHC.Conc (numCapabilities)
 
+import EVM.ABI (AbiValue(..))
 import EVM.Solvers (Solver(..))
 
 import Echidna.ABI (GenDict, emptyDict)
 import Echidna.Types
 import Echidna.Types.Coverage (CoverageFileType, CoverageMap)
+import Echidna.Types.Tx (TxResult(..))
+
+-- | Maximum number of functions a single worker samples at once.
+maxSampledFunctions :: Int
+maxSampledFunctions = 10
+
+-- | Maximum number of recent revert summaries kept per sampled function.
+maxRecentReverts :: Int
+maxRecentReverts = 5
+
+-- | Per-function sampling state.
+--
+-- Sampling is opt-in, but once a function is sampled its stats are updated
+-- once per call, on the fuzzing hot path, and only read when someone asks for
+-- them. Every field is therefore kept forced: a lazy field here would retain
+-- the whole call history as a chain of unevaluated updates.
+data SampleStats = SampleStats
+  { sampleCalls         :: !Int
+    -- ^ Total calls observed.
+  , sampleReverts       :: !Int
+    -- ^ Total calls that did not return successfully.
+  , sampleReturnRange   :: !(Maybe (AbiValue, AbiValue))
+    -- ^ Min/max of the decoded return value. Only tracked for functions whose
+    -- return type is known via 'Echidna.ABI.GenDict.rTypes' and orderable
+    -- according to 'abiCompare'.
+  , sampleRecentReverts :: ![Text]
+    -- ^ Last 'maxRecentReverts' revert summaries, newest first.
+  } deriving Show
+
+emptySampleStats :: SampleStats
+emptySampleStats = SampleStats 0 0 Nothing []
+
+-- | Comparison for the subset of 'AbiValue' kinds that have a natural
+-- ordering. 'Nothing' for anything else (bytes, strings, tuples, arrays), and
+-- for values of different kinds.
+abiCompare :: AbiValue -> AbiValue -> Maybe Ordering
+abiCompare (AbiUInt _ a)  (AbiUInt _ b)  = Just (compare a b)
+abiCompare (AbiInt  _ a)  (AbiInt  _ b)  = Just (compare a b)
+abiCompare (AbiAddress a) (AbiAddress b) = Just (compare a b)
+abiCompare (AbiBool a)    (AbiBool b)    = Just (compare a b)
+abiCompare _ _ = Nothing
+
+-- | Fold one observed call into a function's 'SampleStats'. Pure, so it can be
+-- unit tested without building 'EVM.Types.VMResult' values.
+applySampleEvent
+  :: TxResult       -- ^ Result kind, from 'Echidna.Types.Tx.getResult'.
+  -> Maybe AbiValue -- ^ Decoded return value, if available and of a known type.
+  -> Text           -- ^ Function name, used in the revert summary.
+  -> [AbiValue]     -- ^ Call arguments, used in the revert summary.
+  -> SampleStats
+  -> SampleStats
+applySampleEvent result decoded fname args stats
+  | result `elem` [ReturnTrue, ReturnFalse, Stop] =
+      stats { sampleCalls       = stats.sampleCalls + 1
+            , sampleReturnRange = maybe range (`widen` range) decoded
+            }
+  | otherwise =
+      stats { sampleCalls         = stats.sampleCalls + 1
+            , sampleReverts       = stats.sampleReverts + 1
+            , sampleRecentReverts =
+                takeStrict maxRecentReverts (summary : stats.sampleRecentReverts)
+            }
+  where
+    range = stats.sampleReturnRange
+
+    summary =
+      let argStr = T.intercalate "," (map (T.pack . show) args)
+      in fname <> "(" <> argStr <> "): " <> T.pack (show result)
+
+    widen v Nothing = Just (v, v)
+    widen v (Just (lo, hi)) =
+      let !lo' = if abiCompare v lo == Just LT then v else lo
+          !hi' = if abiCompare v hi == Just GT then v else hi
+      in Just (lo', hi')
+
+-- | Combine two per-function 'SampleStats', typically from different workers.
+-- Counts are summed, ranges widened, recent reverts concatenated and capped.
+mergeSampleStats :: SampleStats -> SampleStats -> SampleStats
+mergeSampleStats a b = SampleStats
+  { sampleCalls         = a.sampleCalls + b.sampleCalls
+  , sampleReverts       = a.sampleReverts + b.sampleReverts
+  , sampleReturnRange   = mergeRange a.sampleReturnRange b.sampleReturnRange
+  , sampleRecentReverts =
+      takeStrict maxRecentReverts (a.sampleRecentReverts ++ b.sampleRecentReverts)
+  }
+  where
+    mergeRange Nothing x = x
+    mergeRange x Nothing = x
+    mergeRange (Just (loA, hiA)) (Just (loB, hiB)) =
+      let !lo = if abiCompare loA loB == Just GT then loB else loA
+          !hi = if abiCompare hiA hiB == Just LT then hiB else hiA
+      in Just (lo, hi)
+
+-- | 'take' that forces the spine and the elements it keeps. Plain 'take' would
+-- leave the kept list holding on to the entire input through an unevaluated
+-- tail, which for 'sampleRecentReverts' means the whole revert history.
+takeStrict :: Int -> [a] -> [a]
+takeStrict n _ | n <= 0 = []
+takeStrict _ []         = []
+takeStrict n (x:xs)     = x `seq` rest `seq` (x : rest)
+  where rest = takeStrict (n - 1) xs
 
 -- | Configuration for running an Echidna 'Campaign'.
 data CampaignConf = CampaignConf
@@ -86,6 +191,10 @@ data WorkerState = WorkerState
   , runningThreads :: [ThreadId]
     -- ^ Extra threads currently being run,
     --   aside from the main worker thread
+  , sampledFunctions :: !(Map Text SampleStats)
+    -- ^ Functions whose calls are sampled for return-value range and revert
+    --   history, keyed by canonical signature (e.g. @"totalSupply()"@). Empty
+    --   unless sampling was explicitly enabled for this worker.
   }
 
 initialWorkerState :: WorkerState
@@ -97,6 +206,7 @@ initialWorkerState =
               , ncalls = 0
               , totalGas = 0
               , runningThreads = []
+              , sampledFunctions = Map.empty
               }
 
 defaultTestLimit :: Int

--- a/lib/Echidna/Types/Config.hs
+++ b/lib/Echidna/Types/Config.hs
@@ -18,6 +18,7 @@ import Echidna.Types.Cache
 import Echidna.Types.Campaign (CampaignConf)
 import Echidna.Types.Corpus (Corpus)
 import Echidna.Types.Coverage (CoverageMap)
+import Echidna.Types.InterWorker (Bus)
 import Echidna.Types.Solidity (SolConf)
 import Echidna.Types.Test (TestConf, EchidnaTest)
 import Echidna.Types.Tx (TxConf)
@@ -79,6 +80,11 @@ data Env = Env
   -- | Shared between all workers. Events are fairly rare so contention is
   -- minimal.
   , eventQueue :: Chan (LocalTime, CampaignEvent)
+
+  -- | Shared between all agents. Broadcast channel: readers take their own
+  -- 'Control.Concurrent.STM.dupTChan' of it, so every reader sees every
+  -- message.
+  , bus :: Bus
 
   , testRefs :: [IORef EchidnaTest]
   , coverageRefInit :: IORef CoverageMap

--- a/lib/Echidna/Types/InterWorker.hs
+++ b/lib/Echidna/Types/InterWorker.hs
@@ -1,0 +1,54 @@
+-- | The protocol agents use to talk to each other during a campaign.
+--
+-- Everything travels over a single 'Bus' shared through 'Echidna.Types.Config.Env'.
+-- The bus is a broadcast channel, so a message is delivered to every reader
+-- rather than raced for: readers call 'Control.Concurrent.STM.dupTChan' to get
+-- their own view of it, and filter for what concerns them.
+module Echidna.Types.InterWorker
+  ( AgentId(..)
+  , BroadcastMsg(..)
+  , Bus
+  , FuzzerCmd(..)
+  , Message(..)
+  , WrappedMessage(..)
+  ) where
+
+import Control.Concurrent.STM (TChan)
+import Data.Text (Text)
+
+import Echidna.Types.Tx (Tx)
+import Echidna.Types.Worker (WorkerId)
+
+-- | Who sent a message.
+data AgentId = FuzzerId WorkerId | SymbolicId
+  deriving (Show, Eq, Ord)
+
+-- | A command addressed to a single fuzzing worker.
+data FuzzerCmd
+  = EnableSampling Text
+    -- ^ Start sampling the given function, named by its canonical signature.
+    --   Capped per worker by 'Echidna.Types.Campaign.maxSampledFunctions'.
+  | ClearSampling
+    -- ^ Forget every sampled function and its statistics.
+  deriving Show
+
+-- | A message every agent gets to see.
+data BroadcastMsg
+  = NewCoverageInfo Int [Tx] Bool
+    -- ^ Coverage points reached, the sequence that reached them, and whether
+    --   it came from replaying the corpus rather than from fuzzing.
+  deriving Show
+
+data Message
+  = Broadcast BroadcastMsg
+  | ToFuzzer WorkerId FuzzerCmd
+  deriving Show
+
+-- | A message together with its sender.
+data WrappedMessage = WrappedMessage
+  { from :: AgentId
+  , content :: Message
+  } deriving Show
+
+-- | The shared communication bus.
+type Bus = TChan WrappedMessage

--- a/lib/Echidna/Worker/Command.hs
+++ b/lib/Echidna/Worker/Command.hs
@@ -1,0 +1,45 @@
+-- | Commands a fuzzing worker accepts over the inter-worker bus.
+module Echidna.Worker.Command (checkMessages) where
+
+import Control.Concurrent.STM (TChan, atomically, tryReadTChan)
+import Control.Monad.State.Strict (MonadIO, MonadState, gets, liftIO, modify')
+import Data.Map qualified as Map
+
+import Echidna.Types.Campaign
+import Echidna.Types.InterWorker (FuzzerCmd(..), Message(..), WrappedMessage(..))
+
+-- | Run every command addressed to this worker that is currently waiting on
+-- the bus, then return.
+--
+-- The queue is drained rather than sampled one message at a time: every
+-- broadcast is delivered to every worker's duplicate, so leaving messages
+-- behind would let a worker's view of the bus grow without bound while a burst
+-- of coverage is being found. Commands only ever originate outside the
+-- campaign, at the pace of whoever is driving it, so draining cannot starve
+-- fuzzing.
+checkMessages
+  :: (MonadIO m, MonadState WorkerState m)
+  => TChan WrappedMessage
+  -> m ()
+checkMessages chan = do
+  workerId <- gets (.workerId)
+  let loop = liftIO (atomically (tryReadTChan chan)) >>= \case
+        Nothing -> pure ()
+        Just (WrappedMessage _ (ToFuzzer tid cmd)) | tid == workerId ->
+          handleCmd cmd >> loop
+        Just _ -> loop
+  loop
+
+handleCmd :: MonadState WorkerState m => FuzzerCmd -> m ()
+handleCmd (EnableSampling sig) =
+  modify' $ \workerState ->
+    if Map.size workerState.sampledFunctions >= maxSampledFunctions
+       || Map.member sig workerState.sampledFunctions
+    then workerState
+    else workerState
+      { sampledFunctions =
+          Map.insert sig emptySampleStats workerState.sampledFunctions
+      }
+
+handleCmd ClearSampling =
+  modify' $ \workerState -> workerState { sampledFunctions = Map.empty }

--- a/lib/Echidna/Worker/Fuzz.hs
+++ b/lib/Echidna/Worker/Fuzz.hs
@@ -3,6 +3,7 @@
 
 module Echidna.Worker.Fuzz (runFuzzWorker) where
 
+import Control.Concurrent.STM (atomically, dupTChan)
 import Control.Monad (forM_, replicateM, void)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Random.Strict (MonadRandom, evalRandT)
@@ -26,6 +27,7 @@ import Echidna.Types.Test
 import Echidna.Types.Test qualified as Test
 import Echidna.Types.Tx (Tx)
 import Echidna.Types.Worker
+import Echidna.Worker.Command (checkMessages)
 import Echidna.Worker.Sequence (callseq, replayCorpus)
 
 -- | Run a fuzzing campaign given an initial universe state, some tests, and an
@@ -43,6 +45,7 @@ runFuzzWorker
   -> Int     -- ^ Test limit for this worker
   -> m (WorkerStopReason, WorkerState)
 runFuzzWorker callback vm dict workerId initialCorpus testLimit = do
+  bus <- asks (.bus)
   let
     effectiveSeed = dict.defSeed + workerId
     initialState =
@@ -54,10 +57,15 @@ runFuzzWorker callback vm dict workerId initialCorpus testLimit = do
     flip evalRandT (mkStdGen effectiveSeed) $ do
       lift callback
       void $ replayCorpus vm initialCorpus
-      run
+      -- Each worker reads the bus through its own duplicate, so a message
+      -- reaches every worker instead of being raced for by whoever gets there
+      -- first.
+      chan <- liftIO $ atomically $ dupTChan bus
+      run chan
 
   where
-  run = do
+  run chan = do
+    checkMessages chan
     testRefs <- asks (.testRefs)
     tests <- liftIO $ traverse readIORef testRefs
     CampaignConf{stopOnFail, shrinkLimit} <- asks (.cfg.campaignConf)
@@ -77,24 +85,24 @@ runFuzzWorker callback vm dict workerId initialCorpus testLimit = do
 
        -- we shrink first before going back to fuzzing
        | any (isShrinkable shrinkLimit workerId) tests ->
-         shrink >> lift callback >> run
+         shrink >> lift callback >> run chan
 
        -- no shrinking work, fuzz
        | (null tests || any isOpen tests) && ncalls < testLimit ->
-         fuzz >> lift callback >> run
+         fuzz >> lift callback >> run chan
 
        -- Test limit reached. Close any open optimization tests so they
        -- enter the shrink loop above, same as other test types.
        | ncalls >= testLimit && any (\t -> isOpen t && isOptimizationTest t) tests -> do
          liftIO $ forM_ testRefs $ \testRef ->
             atomicModifyIORef' testRef (\test -> (closeOptimizationTest test, ()))
-         lift callback >> run
+         lift callback >> run chan
 
        -- no more work to do, exit
        | otherwise ->
          lift callback >> pure TestLimitReached
 
-  fuzz = randseq vm.env.contracts >>= fmap fst . callseq vm
+  fuzz = randseq vm.env.contracts >>= \txs -> fst <$> callseq vm txs False
 
   -- TODO: Shrinking only this worker's tests makes some workers run longer as
   -- they work less on their test limit portion during shrinking. We should move

--- a/lib/Echidna/Worker/Sequence.hs
+++ b/lib/Echidna/Worker/Sequence.hs
@@ -13,7 +13,7 @@ module Echidna.Worker.Sequence
   ) where
 
 import Control.DeepSeq (force)
-import Control.Monad (forM_, when)
+import Control.Monad (forM_, unless, when)
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Random.Strict (MonadRandom)
 import Control.Monad.Reader (MonadReader, ask, liftIO)
@@ -29,6 +29,7 @@ import Data.Map.Strict qualified as MapStrict
 import Data.Maybe (isJust, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Text (Text)
 import Data.Vector qualified as V
 
 import EVM (cheatCode)
@@ -48,7 +49,7 @@ import Echidna.Types.Coverage (coverageStats)
 import Echidna.Types.Signature (FunctionName)
 import Echidna.Types.Test
 import Echidna.Types.Test qualified as Test
-import Echidna.Types.Tx (TxCall(..), Tx(..))
+import Echidna.Types.Tx (TxCall(..), Tx(..), getResult)
 import Echidna.Types.Worker
 import Echidna.Worker (pushWorkerEvent)
 
@@ -94,6 +95,14 @@ callseq vm txSeq = do
   -- Run each call sequentially. This gives us the result of each call
   -- and the new state
   (results, vm') <- evalSeq vm execFunc txSeq
+
+  -- Update the stats of any sampled function. Nothing is sampled unless a
+  -- client asked for it, so the hot path only pays for the emptiness check.
+  sampled <- gets (.sampledFunctions)
+  unless (Map.null sampled) $ do
+    rTypes <- gets (.genDict.rTypes)
+    modify' $ \workerState ->
+      workerState { sampledFunctions = updateSampleStats rTypes sampled results }
 
   -- If there is new coverage, add the transaction list to the corpus
   newCoverage <- gets (.newCoverage)
@@ -190,6 +199,35 @@ callseq vm txSeq = do
   addToCorpus n res corpus =
     if null rtxs then corpus else Set.insert (n, rtxs) corpus
     where rtxs = fst <$> res
+
+-- | Fold a sequence of transaction results into the sampling map, updating
+-- call counts, revert summaries and return-value range for each sampled
+-- function. Calls to functions that are not sampled are ignored. The
+-- per-event algebra lives in 'applySampleEvent', which is unit tested.
+updateSampleStats
+  :: (FunctionName -> Maybe AbiType)
+  -- ^ Return-type lookup, i.e. @workerState.genDict.rTypes@.
+  -> Map Text SampleStats
+  -> [(Tx, VMResult Concrete)]
+  -> Map Text SampleStats
+updateSampleStats returnTypeOf = List.foldl' applyOne
+  where
+    applyOne acc (tx, vmResult) = case tx.call of
+      SolCall (fname, args) ->
+        let sig = encodeSig (fname, map abiValueType args) in
+        case Map.lookup sig acc of
+          Nothing -> acc
+          Just stats ->
+            let decoded = case (vmResult, returnTypeOf fname) of
+                  (VMSuccess (ConcreteBuf buf), Just type') ->
+                    case runGetOrFail (getAbi type') (LBS.fromStrict buf) of
+                      Right (_, _, abiValue) -> Just abiValue
+                      _ -> Nothing
+                  _ -> Nothing
+            in MapStrict.insert sig
+                 (applySampleEvent (getResult vmResult) decoded fname args stats)
+                 acc
+      _ -> acc
 
 -- | Execute a transaction, capturing the PC and codehash of each instruction
 -- executed, saving the transaction if it finds new coverage.

--- a/lib/Echidna/Worker/Sequence.hs
+++ b/lib/Echidna/Worker/Sequence.hs
@@ -12,6 +12,7 @@ module Echidna.Worker.Sequence
   , callseq
   ) where
 
+import Control.Concurrent.STM (atomically, writeTChan)
 import Control.DeepSeq (force)
 import Control.Monad (forM_, unless, when)
 import Control.Monad.Catch (MonadThrow)
@@ -46,12 +47,14 @@ import Echidna.Types.Campaign
 import Echidna.Types.Config
 import Echidna.Types.Corpus (Corpus, corpusSize)
 import Echidna.Types.Coverage (coverageStats)
+import Echidna.Types.InterWorker
+  (AgentId(..), BroadcastMsg(..), Message(..), WrappedMessage(..))
 import Echidna.Types.Signature (FunctionName)
 import Echidna.Types.Test
 import Echidna.Types.Test qualified as Test
 import Echidna.Types.Tx (TxCall(..), Tx(..), getResult)
 import Echidna.Types.Worker
-import Echidna.Worker (pushWorkerEvent)
+import Echidna.Worker (pushWorkerEvent, workerIDToType)
 
 -- | Run all the transaction sequences from the corpus and accumulate campaign
 -- state. Can be used to minimize corpus as the final campaign state will
@@ -68,7 +71,7 @@ replayCorpus vm txSeqs =
             List.filter (\case Tx { call = NoCall } -> False; _ -> True) txSeq
     case maybeFaultyTx of
       Nothing -> do
-        _ <- callseq vm txSeq
+        _ <- callseq vm txSeq True
         pushWorkerEvent (TxSequenceReplayed file i (length txSeqs))
       Just faultyTx ->
         pushWorkerEvent (TxSequenceReplayFailed file faultyTx)
@@ -82,8 +85,9 @@ callseq
   :: (MonadIO m, MonadThrow m, MonadRandom m, MonadReader Env m, MonadState WorkerState m)
   => VM Concrete
   -> [Tx]
+  -> Bool -- ^ Whether this sequence comes from replaying the corpus
   -> m (VM Concrete, Bool)
-callseq vm txSeq = do
+callseq vm txSeq isReplaying = do
   env <- ask
   -- First, we figure out whether we need to execute with or without coverage
   -- optimization and gas info, and pick our execution function appropriately
@@ -121,6 +125,15 @@ callseq vm txSeq = do
                                 , corpusSize = newSize
                                 , transactions = fst <$> results
                                 }
+
+    -- Tell the other agents about it too
+    workerId <- gets (.workerId)
+    let sender = case workerIDToType env.cfg.campaignConf workerId of
+          FuzzWorker -> FuzzerId workerId
+          SymbolicWorker -> SymbolicId
+    liftIO $ atomically $ writeTChan env.bus $
+      WrappedMessage sender
+        (Broadcast (NewCoverageInfo points (fst <$> results) isReplaying))
 
   modify' $ \workerState ->
 

--- a/lib/Echidna/Worker/Symbolic.hs
+++ b/lib/Echidna/Worker/Symbolic.hs
@@ -78,7 +78,7 @@ runSymWorker callback vm dict workerId name = do
   -- but it may be useful to symexec on top of symexec results to produce multi-transaction
   -- chains where each transaction results in new coverage.
   listenerFunc (_, WorkerEvent _ _ (NewCoverage {transactions})) = do
-    void $ callseq vm transactions
+    void $ callseq vm transactions False
     symexecTxs False transactions
     shrinkAndRandomlyExplore transactions (10 :: Int)
   listenerFunc _ = pure ()
@@ -169,7 +169,7 @@ runSymWorker callback vm dict workerId name = do
     unless (null partials) $ mapM_ ((pushWorkerEvent . SymExecError) . (\e -> "Partial explored path(s) during symbolic exploration: " <> unpack e)) partials
 
     -- We can't do callseq vm' [symTx] because callseq might post the full call sequence as an event
-    newCoverage <- or <$> mapM (\symTx -> snd <$> callseq vm (txsBase <> [symTx])) txs
+    newCoverage <- or <$> mapM (\symTx -> snd <$> callseq vm (txsBase <> [symTx]) False) txs
 
     when (not newCoverage && null errors && not (null txs)) (
       pushWorkerEvent $ SymExecError "No errors but symbolic execution found valid txs breaking assertions. Something is wrong.")
@@ -202,7 +202,7 @@ runSymWorker callback vm dict workerId name = do
     modify' (\ws -> ws { runningThreads = [] })
     lift callback
     -- We can't do callseq vm' [symTx] because callseq might post the full call sequence as an event
-    newCoverage <- or <$> mapM (\symTx -> snd <$> callseq vm [symTx]) txs
+    newCoverage <- or <$> mapM (\symTx -> snd <$> callseq vm [symTx] False) txs
     let methodSignature = unpack method.methodSignature
     unless newCoverage $ do
       unless (null txs) $ error "No new coverage but symbolic execution found valid txs. Something is wrong."

--- a/package.yaml
+++ b/package.yaml
@@ -68,6 +68,7 @@ library:
     - semver
     - signal
     - split
+    - stm
     - strip-ansi-escape
     - time
     - unliftio

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -13,6 +13,7 @@ import Tests.Integration (integrationTests)
 import Tests.Optimization (optimizationTests)
 import Tests.Overflow (overflowTests)
 import Tests.Research (researchTests)
+import Tests.Sample (sampleTests)
 import Tests.Seed (seedTests)
 import Tests.Symbolic (symbolicTests)
 import Tests.Values (valuesTests)
@@ -33,6 +34,7 @@ main = withCurrentDirectory "./tests/solidity" . defaultMain $
            , researchTests
            , foundryTests
            , encodingJSONTests
+           , sampleTests
            , foundryTestGenTests
            , cheatTests
            , symbolicTests

--- a/src/test/Tests/Sample.hs
+++ b/src/test/Tests/Sample.hs
@@ -1,0 +1,159 @@
+module Tests.Sample (sampleTests) where
+
+import Data.Text qualified as T
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
+
+import EVM.ABI (AbiValue(..))
+
+import Echidna.Types.Campaign
+  ( SampleStats(..)
+  , abiCompare
+  , applySampleEvent
+  , emptySampleStats
+  , maxRecentReverts
+  , mergeSampleStats
+  )
+import Echidna.Types.Tx (TxResult(..))
+
+uint :: Integer -> AbiValue
+uint = AbiUInt 256 . fromInteger
+
+int :: Integer -> AbiValue
+int = AbiInt 256 . fromInteger
+
+addr :: Integer -> AbiValue
+addr = AbiAddress . fromInteger
+
+sampleTests :: TestTree
+sampleTests = testGroup "Sample stats"
+  [ abiCompareTests
+  , applySampleEventTests
+  , mergeSampleStatsTests
+  ]
+
+abiCompareTests :: TestTree
+abiCompareTests = testGroup "abiCompare"
+  [ testCase "uint equal"   $ abiCompare (uint 5)  (uint 5)  @?= Just EQ
+  , testCase "uint less"    $ abiCompare (uint 1)  (uint 5)  @?= Just LT
+  , testCase "uint greater" $ abiCompare (uint 10) (uint 5)  @?= Just GT
+  , testCase "int negative compared" $
+      abiCompare (int (-1)) (int 1) @?= Just LT
+  , testCase "address ordering" $
+      abiCompare (addr 0x1) (addr 0x10) @?= Just LT
+  , testCase "bool False < True" $
+      abiCompare (AbiBool False) (AbiBool True) @?= Just LT
+  , testCase "mismatched kinds (uint vs bool) is incomparable" $
+      abiCompare (uint 1) (AbiBool True) @?= Nothing
+  , testCase "string is incomparable (unsupported kind)" $
+      abiCompare (AbiString "a") (AbiString "b") @?= Nothing
+  ]
+
+applySampleEventTests :: TestTree
+applySampleEventTests = testGroup "applySampleEvent"
+  [ testCase "success bumps calls only" $ do
+      let s = applySampleEvent ReturnTrue Nothing "foo" [] emptySampleStats
+      s.sampleCalls         @?= 1
+      s.sampleReverts       @?= 0
+      s.sampleRecentReverts @?= []
+      s.sampleReturnRange   @?= Nothing
+
+  , testCase "revert bumps reverts and pushes summary" $ do
+      let s = applySampleEvent ErrorRevert Nothing "transfer" [uint 100] emptySampleStats
+      s.sampleCalls   @?= 1
+      s.sampleReverts @?= 1
+      case s.sampleRecentReverts of
+        [summary] -> do
+          assertBool "summary mentions function" (T.isPrefixOf "transfer(" summary)
+          assertBool "summary mentions result kind" (T.isSuffixOf "ErrorRevert" summary)
+        _ -> assertBool "expected exactly one revert summary" False
+
+  , testCase "ReturnFalse counts as success (not a revert)" $ do
+      let s = applySampleEvent ReturnFalse Nothing "ok" [] emptySampleStats
+      s.sampleReverts @?= 0
+      s.sampleCalls   @?= 1
+
+  , testCase "Stop counts as success" $ do
+      let s = applySampleEvent Stop Nothing "ok" [] emptySampleStats
+      s.sampleReverts @?= 0
+      s.sampleCalls   @?= 1
+
+  , testCase "return value seeds the range on first success" $ do
+      let s = applySampleEvent ReturnTrue (Just (uint 42)) "totalSupply" [] emptySampleStats
+      s.sampleReturnRange @?= Just (uint 42, uint 42)
+
+  , testCase "return value widens range (smaller value)" $ do
+      let s0 = emptySampleStats { sampleReturnRange = Just (uint 10, uint 20) }
+          s1 = applySampleEvent ReturnTrue (Just (uint 5)) "x" [] s0
+      s1.sampleReturnRange @?= Just (uint 5, uint 20)
+
+  , testCase "return value widens range (larger value)" $ do
+      let s0 = emptySampleStats { sampleReturnRange = Just (uint 10, uint 20) }
+          s1 = applySampleEvent ReturnTrue (Just (uint 100)) "x" [] s0
+      s1.sampleReturnRange @?= Just (uint 10, uint 100)
+
+  , testCase "return value inside range leaves range unchanged" $ do
+      let s0 = emptySampleStats { sampleReturnRange = Just (uint 10, uint 20) }
+          s1 = applySampleEvent ReturnTrue (Just (uint 15)) "x" [] s0
+      s1.sampleReturnRange @?= Just (uint 10, uint 20)
+
+  , testCase "incomparable return value leaves range unchanged" $ do
+      let s0 = emptySampleStats { sampleReturnRange = Just (uint 10, uint 20) }
+          s1 = applySampleEvent ReturnTrue (Just (AbiString "nope")) "x" [] s0
+      s1.sampleReturnRange @?= Just (uint 10, uint 20)
+
+  , testCase "return value not provided keeps existing range" $ do
+      let s0 = emptySampleStats { sampleReturnRange = Just (uint 1, uint 2) }
+          s1 = applySampleEvent ReturnTrue Nothing "x" [] s0
+      s1.sampleReturnRange @?= Just (uint 1, uint 2)
+
+  , testCase "reverts do not update the range" $ do
+      let s0 = emptySampleStats { sampleReturnRange = Just (uint 10, uint 20) }
+          s1 = applySampleEvent ErrorRevert (Just (uint 5)) "x" [] s0
+      s1.sampleReturnRange @?= Just (uint 10, uint 20)
+
+  , testCase "recent reverts capped at maxRecentReverts (newest first)" $ do
+      let go i = applySampleEvent ErrorRevert Nothing ("fn" <> T.pack (show i)) []
+          final = foldr go emptySampleStats [1 .. maxRecentReverts + 5 :: Int]
+      length final.sampleRecentReverts @?= maxRecentReverts
+      case final.sampleRecentReverts of
+        (newest:_) -> assertBool "newest revert summary is at head" (T.isPrefixOf "fn1(" newest)
+        []         -> assertBool "expected non-empty" False
+  ]
+
+mergeSampleStatsTests :: TestTree
+mergeSampleStatsTests = testGroup "mergeSampleStats"
+  [ testCase "counts sum" $ do
+      let a = emptySampleStats { sampleCalls = 3, sampleReverts = 1 }
+          b = emptySampleStats { sampleCalls = 5, sampleReverts = 2 }
+          m = mergeSampleStats a b
+      m.sampleCalls   @?= 8
+      m.sampleReverts @?= 3
+
+  , testCase "range widens to envelope" $ do
+      let a = emptySampleStats { sampleReturnRange = Just (uint 10, uint 50) }
+          b = emptySampleStats { sampleReturnRange = Just (uint 5,  uint 30) }
+          m = mergeSampleStats a b
+      m.sampleReturnRange @?= Just (uint 5, uint 50)
+
+  , testCase "range preserved when one side has no range" $ do
+      let a = emptySampleStats { sampleReturnRange = Just (uint 1, uint 2) }
+          m = mergeSampleStats a emptySampleStats
+      m.sampleReturnRange @?= Just (uint 1, uint 2)
+
+  , testCase "both sides without a range stay empty" $ do
+      let m = mergeSampleStats emptySampleStats emptySampleStats
+      m.sampleReturnRange @?= Nothing
+
+  , testCase "recent reverts concatenated and capped" $ do
+      let aList = map (\i -> "a" <> T.pack (show i)) [1 .. maxRecentReverts :: Int]
+          bList = map (\i -> "b" <> T.pack (show i)) [1 .. maxRecentReverts :: Int]
+          a = emptySampleStats { sampleRecentReverts = aList }
+          b = emptySampleStats { sampleRecentReverts = bList }
+          m = mergeSampleStats a b
+      length m.sampleRecentReverts @?= maxRecentReverts
+      -- the 'a' side comes first, since the merge concatenates a ++ b
+      case m.sampleRecentReverts of
+        (first:_) -> assertBool "first entry from the 'a' side" (T.isPrefixOf "a" first)
+        []        -> assertBool "expected non-empty" False
+  ]


### PR DESCRIPTION
  ## Why

  Workers can currently communicate in exactly one direction: each pushes events
  onto the campaign's event queue, which the UI and the listener read. Nothing can
  talk back to a running worker, and no worker can tell another one what it just
  learned. Every remaining piece of #1502 needs that channel, so it lands here
  together with the first thing that uses it.

  ## What

  **`feat: sample per-function call statistics`**

  A worker can be asked to watch a handful of functions and keep, for each, how
  often it was called, how often the call did not return successfully, the range
  its return value spanned, and a short tail of revert summaries — what an outside
  observer needs to answer "is this function reachable, and what does it do when
  it is" without reading the corpus.

  The state hangs off `WorkerState.sampledFunctions`, keyed by canonical
  signature. The per-event algebra is factored out of the worker into
  `Types/Campaign.hs` (`applySampleEvent`, `abiCompare`, `mergeSampleStats`) so it
  is pure and unit-testable; `updateSampleStats` in `Worker/Sequence.hs` is left
  with just decode-and-dispatch. `Tests.Sample` covers all three, 25 cases.

  **`feat: add an inter-worker message bus`**

  `Env` gains a broadcast STM channel alongside the event queue. Readers take
  their own `dupTChan`, so a message reaches every reader instead of being raced
  for by whoever gets there first. `Echidna.Types.InterWorker` holds the protocol.

  Two users: `callseq` broadcasts `NewCoverageInfo` when a sequence finds
  coverage, carrying the sequence and whether it came from replaying the corpus
  (the new argument threaded through `callseq`'s callers); and a fuzzing worker
  checks the bus once per loop iteration for commands addressed to it, which is
  how sampling is turned on and off.

  ## Notes for review

  - **Nothing enables sampling yet, and nothing listens for `NewCoverageInfo`
    yet.** Both clients are the MCP server, two rungs up. `Tests.Sample` is the
    entry point for the sampling algebra in the meantime. The two commands land
    here rather than with their sender because they are what makes the bus worth
    having.
  - **The rest of the upstream protocol is left out.** Symbolic commands,
    request/response, and the other broadcasts have neither a sender nor a reader
    on `dev-agents-3`; each comes back with the code that uses it. (`WorkerStopped`
    also collided with `Types.Worker.WorkerEvent`'s constructor of the same name.)
  - **`checkMessages` drains its queue rather than handling one message per
    iteration.** Every broadcast is copied into every worker's duplicate, so with
    N workers a worker receives roughly N messages per iteration; consuming one
    would let the queue grow without bound during the early phase of a campaign,
    when almost every sequence finds new coverage. Commands originate outside the
    campaign at human pace, so draining cannot starve fuzzing.
  - **The broadcast's sender is resolved through `workerIDToType`**, the same way
    `pushWorkerEvent` decides which worker type to attribute an event to. The
    symbolic worker calls `callseq` too, and it is not a fuzzer.
  - **The strictness in `SampleStats` is load-bearing and was not free.** These
    fields are updated on the fuzzing hot path and only read when a client asks,
    so `take n (new : old)` would keep `old` alive through its unevaluated tail
    and `old` its predecessor — the list capped at five entries would have
    retained the entire revert history. Hence `takeStrict`, and the forced tuple
    components in the range update.
  - The command handler lives in its own module rather than another `where`-block
    inside `runFuzzWorker`, matching what the preceding decomposition was aiming
    for and giving the handlers in later rungs a home.

  ## Verification

  - `cabal build all` and `cabal build tests` clean under `-Wall -Wunused-packages`
  - `cabal run tests` — all 190 pass, symbolic tests included, so both a normal
    fuzzing run and a symbolic run still terminate
  - `hlint lib src` — clean (one pre-existing hint in `SourceMapping.hs`, untouched
    here)
  - Driven end-to-end with a throwaway probe standing in for the MCP client: a
    `ToFuzzer 0 (EnableSampling "bump(uint256)")` written by any worker reached
    worker 0 through its duplicate, workers 1–3 correctly ignored it, and worker 0
    reported `sampleCalls = 2526, sampleReverts = 1603` with a widened return
    range and exactly `maxRecentReverts` summaries retained.