### PR TITLE
test(coverage): make boolean corpus count deterministic

### DIFF
--- a/tests/solidity/coverage/boolean.yaml
+++ b/tests/solidity/coverage/boolean.yaml
@@ -1,3 +1,5 @@
 coverage: true
 seqLen: 10
 testLimit: 5000
+seed: 0
+workers: 1


### PR DESCRIPTION
## Summary

Make the `coverage/boolean.sol` integration test deterministic by pinning the fuzzing seed and worker count.

The test currently asserts an exact corpus size of one, but its configuration leaves both the random seed and worker count implicit. This can make the corpus cardinality sensitive to platform scheduling and execution configuration, as observed in the Windows `solc 0.8.25` CI job.

## Changes

- Set `seed: 0` in `tests/solidity/coverage/boolean.yaml`.
- - Set `workers: 1` so the exact corpus-count assertion has a stable execution model.
## Validation

- The focused coverage test passed 10 consecutive times in an isolated baseline worktree.
- - The change is limited to test configuration; no production code or assertions were weakened.
This is intentionally separate from the worker-state fix in #1609.