### PR TITLE
fix: deflake values/rconstants.sol test

### DIFF
--- a/tests/solidity/values/rconstants.sol
+++ b/tests/solidity/values/rconstants.sol
@@ -1,7 +1,12 @@
 contract Constants {
   bool found = false;
+  uint dummy;
 
   function seed() public returns (int) {
+    // dummy state write so Slither doesn't report seed() as a constant
+    // function, which would make Echidna call it too rarely to reliably
+    // pick up its return value
+    dummy = 1;
     int mystery = 13337;
     return (1337 + mystery);
   }


### PR DESCRIPTION
Slither classifies seed() as a constant function (no state reads or writes), so Echidna demotes it to the low-priority signature map, which genTx samples with probability 1/1001. The test can only be solved by harvesting seed()'s return value (1337 + 13337) into the dictionary and then generating find(14674), so a campaign capped at 10000 transactions failed whenever the RNG drew seed() too late or never (~0.8% of runs).

Add a dummy state write to seed() so it stays in the high-priority map and is sampled like any other function. The value 14674 still exists only as a runtime return value, so the test still exercises return value harvesting. Modeled failure rate drops from ~1/120 to ~1/90000.

Same workaround precedent: values/contract.sol ("writes state to make it non-pure and more likely for echidna to call").