### PR TITLE
perf: size RTS capabilities to the worker count and cache the coverage lookup per step

### DIFF
--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -11,18 +11,19 @@ import Control.Monad.ST (ST, stToIO, RealWorld)
 import Control.Monad.State.Strict (MonadState(get, put), execState, runStateT, MonadIO(liftIO), gets, modify', execStateT)
 import Data.Bits
 import Data.ByteString qualified as BS
-import Data.IORef (readIORef, newIORef, writeIORef, modifyIORef')
+import Data.IORef (readIORef, newIORef, writeIORef)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, fromJust)
 import Data.Text qualified as T
 import Data.Vector qualified as V
+import Data.Vector.Storable qualified as VS
 import Data.Vector.Unboxed.Mutable qualified as VMut
 import Optics.Core
 import Optics.State.Operators
 import System.Environment (lookupEnv, getEnvironment)
 import System.Process qualified as P
 
-import EVM (bytecode, replaceCodeOfSelf, loadContract, exec1, vmOpIx, clearTStorages)
+import EVM (bytecode, replaceCodeOfSelf, loadContract, exec1, clearTStorages)
 import EVM.ABI
 import EVM.Dapp (DappInfo)
 import EVM.Effects (defaultConfig)
@@ -226,6 +227,22 @@ execTx vm tx = runStateT (execTxWith (fromEVM (exec defaultConfig)) tx) vm
 -- | A type alias for the context we carry while executing instructions
 type CoverageContext = (Bool, Maybe (VMut.IOVector CoverageInfo, Int))
 
+-- | The coverage vector of the code being executed, looked up once per
+-- contract switch rather than once per instruction. The executing code only
+-- changes at call boundaries, so nearly every step reuses it.
+data CoverageCache = CoverageCache
+  { code    :: ContractCode
+    -- ^ the key: the code executing at the previous step. Coverage is keyed
+    -- by codehash, so equal code means the same vector whatever the address.
+    -- The 'Eq' short-circuits to a pointer comparison of the underlying
+    -- 'BS.ByteString' when it is the same object, which the loop maintains
+    -- by storing the current step's code on every hit.
+  , opIxMap :: VS.Vector Int
+    -- ^ byte index to op index map of that code
+  , covVec  :: Maybe (VMut.IOVector CoverageInfo)
+    -- ^ its coverage vector, if it has any code at all
+  }
+
 -- | Execute a transaction, logging coverage at every step.
 execTxWithCov
   :: (MonadIO m, MonadState (VM Concrete) m, MonadReader Env m, MonadThrow m)
@@ -256,27 +273,70 @@ execTxWithCov tx = do
     -- the same as EVM.exec but collects coverage, will stop on a query
     execCov env covContextRef = do
       vm <- get
-      (r, vm') <- liftIO $ loop vm
+      -- The context survives across calls: execution resumes here after
+      -- answering a query, and the last location must span the whole tx.
+      ctx <- liftIO $ readIORef covContextRef
+      (r, vm', ctx') <- liftIO $ loop Nothing ctx vm
+      liftIO $ writeIORef covContextRef ctx'
       put vm'
       pure r
       where
       -- | Repeatedly exec a step and add coverage until we have an end result
-      loop :: VM Concrete -> IO (VMResult Concrete, VM Concrete)
-      loop !vm = case vm.result of
+      loop
+        :: Maybe CoverageCache -> CoverageContext -> VM Concrete
+        -> IO (VMResult Concrete, VM Concrete, CoverageContext)
+      loop cache !ctx !vm = case vm.result of
         Nothing -> do
-          addCoverage vm
-          stepVM vm >>= loop
-        Just r -> pure (r, vm)
+          (cache', ctx') <- addCoverage cache ctx vm
+          vm' <- stepVM vm
+          loop (Just cache') ctx' vm'
+        Just r -> pure (r, vm, ctx)
 
       -- | Execute one instruction on the EVM
       stepVM :: VM Concrete -> IO (VM Concrete)
       stepVM = stToIO . execStateT (exec1 defaultConfig)
 
       -- | Add current location to the CoverageMap
-      addCoverage :: VM Concrete -> IO ()
-      addCoverage !vm = do
-        let (pc, opIx, depth) = currentCovLoc vm
-            contract = currentContract vm
+      addCoverage
+        :: Maybe CoverageCache -> CoverageContext -> VM Concrete
+        -> IO (CoverageCache, CoverageContext)
+      addCoverage cache ctx@(grew, _) !vm = do
+        cache'@CoverageCache{opIxMap, covVec} <- case cache of
+          -- Hit: keep this step's code object so the next comparison is a
+          -- pointer check even if we just switched to a contract whose code is
+          -- equal but not the same object (a clone).
+          Just c | c.code == vm.state.code ->
+            pure CoverageCache { code = vm.state.code
+                               , opIxMap = c.opIxMap
+                               , covVec = c.covVec
+                               }
+          _ -> lookupCoverage vm
+
+        ctx' <- case covVec of
+          Nothing -> pure ctx
+          Just vec -> do
+            let pc = vm.state.pc
+                depth = length vm.frames
+            -- TODO: no-op when pc is out-of-bounds. This shouldn't happen but
+            -- we observed this in some real-world scenarios. This is likely a
+            -- bug in another place, investigate.
+            -- ... this should be fixed now, since we use `codeContract` instead
+            -- of `contract` for everything; it may be safe to remove this check.
+            if pc >= VMut.length vec then pure ctx else
+              VMut.read vec pc >>= \case
+                (_, depths, results) | depth < 64 && not (depths `testBit` depth) -> do
+                  let opIx = fromMaybe 0 $ opIxMap VS.!? pc
+                  VMut.write vec pc (opIx, depths `setBit` depth, results `setBit` fromEnum Stop)
+                  pure (True, Just (vec, pc))
+                _ ->
+                  pure (grew, Just (vec, pc))
+
+        pure (cache', ctx')
+
+      -- | Find (or create) the coverage vector of the contract being executed
+      lookupCoverage :: VM Concrete -> IO CoverageCache
+      lookupCoverage vm = do
+        let contract = currentContract vm
             covRef = case contract.code of
               InitCode _ _ -> env.coverageRefInit
               _ -> env.coverageRefRuntime
@@ -293,24 +353,10 @@ execTxWithCov tx = do
             forM_ [0..size-1] $ \i -> VMut.write vec i (-1, 0, 0)
             pure $ Just vec
 
-        case maybeCovVec of
-          Nothing -> pure ()
-          Just vec -> do
-            -- TODO: no-op when pc is out-of-bounds. This shouldn't happen but
-            -- we observed this in some real-world scenarios. This is likely a
-            -- bug in another place, investigate.
-            -- ... this should be fixed now, since we use `codeContract` instead
-            -- of `contract` for everything; it may be safe to remove this check.
-            when (pc < VMut.length vec) $
-              VMut.read vec pc >>= \case
-                (_, depths, results) | depth < 64 && not (depths `testBit` depth) -> do
-                  VMut.write vec pc (opIx, depths `setBit` depth, results `setBit` fromEnum Stop)
-                  writeIORef covContextRef (True, Just (vec, pc))
-                _ ->
-                  modifyIORef' covContextRef $ \(new, _) -> (new, Just (vec, pc))
-
-      -- | Get the VM's current execution location
-      currentCovLoc vm = (vm.state.pc, fromMaybe 0 $ vmOpIx vm, length vm.frames)
+        pure CoverageCache { code = vm.state.code
+                           , opIxMap = contract.opIxMap
+                           , covVec = maybeCovVec
+                           }
 
       -- | Get the current contract being executed
       currentContract vm = fromMaybe (error "no contract information on coverage") $

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -23,7 +23,7 @@ import Optics.State.Operators
 import System.Environment (lookupEnv, getEnvironment)
 import System.Process qualified as P
 
-import EVM (bytecode, replaceCodeOfSelf, loadContract, exec1, clearTStorages)
+import EVM (bytecode, replaceCodeOfSelf, loadContract, exec1, clearTStorages, currentContract)
 import EVM.ABI
 import EVM.Dapp (DappInfo)
 import EVM.Effects (defaultConfig)
@@ -287,7 +287,7 @@ execTxWithCov tx = do
         -> IO (VMResult Concrete, VM Concrete, CoverageContext)
       loop cache !ctx !vm = case vm.result of
         Nothing -> do
-          (cache', ctx') <- addCoverage cache ctx vm
+          (cache', ctx') <- addCoverage env cache ctx vm
           vm' <- stepVM vm
           loop (Just cache') ctx' vm'
         Just r -> pure (r, vm, ctx)
@@ -296,71 +296,67 @@ execTxWithCov tx = do
       stepVM :: VM Concrete -> IO (VM Concrete)
       stepVM = stToIO . execStateT (exec1 defaultConfig)
 
-      -- | Add current location to the CoverageMap
-      addCoverage
-        :: Maybe CoverageCache -> CoverageContext -> VM Concrete
-        -> IO (CoverageCache, CoverageContext)
-      addCoverage cache ctx@(grew, _) !vm = do
-        cache'@CoverageCache{opIxMap, covVec} <- case cache of
-          -- Hit: keep this step's code object so the next comparison is a
-          -- pointer check even if we just switched to a contract whose code is
-          -- equal but not the same object (a clone).
-          Just c | c.code == vm.state.code ->
-            pure CoverageCache { code = vm.state.code
-                               , opIxMap = c.opIxMap
-                               , covVec = c.covVec
-                               }
-          _ -> lookupCoverage vm
+-- | Add current location to the CoverageMap
+addCoverage
+  :: Env -> Maybe CoverageCache -> CoverageContext -> VM Concrete
+  -> IO (CoverageCache, CoverageContext)
+addCoverage env cache ctx@(grew, _) !vm = do
+  cache'@CoverageCache{opIxMap, covVec} <- case cache of
+    -- Hit: keep this step's code object so the next comparison is a
+    -- pointer check even if we just switched to a contract whose code is
+    -- equal but not the same object (a clone).
+    Just c | c.code == vm.state.code ->
+      pure CoverageCache { code = vm.state.code
+                         , opIxMap = c.opIxMap
+                         , covVec = c.covVec
+                         }
+    _ -> lookupCoverage env vm
 
-        ctx' <- case covVec of
-          Nothing -> pure ctx
-          Just vec -> do
-            let pc = vm.state.pc
-                depth = length vm.frames
-            -- TODO: no-op when pc is out-of-bounds. This shouldn't happen but
-            -- we observed this in some real-world scenarios. This is likely a
-            -- bug in another place, investigate.
-            -- ... this should be fixed now, since we use `codeContract` instead
-            -- of `contract` for everything; it may be safe to remove this check.
-            if pc >= VMut.length vec then pure ctx else
-              VMut.read vec pc >>= \case
-                (_, depths, results) | depth < 64 && not (depths `testBit` depth) -> do
-                  let opIx = fromMaybe 0 $ opIxMap VS.!? pc
-                  VMut.write vec pc (opIx, depths `setBit` depth, results `setBit` fromEnum Stop)
-                  pure (True, Just (vec, pc))
-                _ ->
-                  pure (grew, Just (vec, pc))
+  ctx' <- case covVec of
+    Nothing -> pure ctx
+    Just vec -> do
+      let pc = vm.state.pc
+          depth = length vm.frames
+      -- TODO: no-op when pc is out-of-bounds. This shouldn't happen but
+      -- we observed this in some real-world scenarios. This is likely a
+      -- bug in another place, investigate.
+      -- ... this should be fixed now, since we use `codeContract` instead
+      -- of `contract` for everything; it may be safe to remove this check.
+      if pc >= VMut.length vec then pure ctx else
+        VMut.read vec pc >>= \case
+          (_, depths, results) | depth < 64 && not (depths `testBit` depth) -> do
+            let opIx = fromMaybe 0 $ opIxMap VS.!? pc
+            VMut.write vec pc (opIx, depths `setBit` depth, results `setBit` fromEnum Stop)
+            pure (True, Just (vec, pc))
+          _ ->
+            pure (grew, Just (vec, pc))
 
-        pure (cache', ctx')
+  pure (cache', ctx')
 
-      -- | Find (or create) the coverage vector of the contract being executed
-      lookupCoverage :: VM Concrete -> IO CoverageCache
-      lookupCoverage vm = do
-        let contract = currentContract vm
-            covRef = case contract.code of
-              InitCode _ _ -> env.coverageRefInit
-              _ -> env.coverageRefRuntime
+-- | Find (or create) the coverage vector of the contract being executed
+lookupCoverage :: Env -> VM Concrete -> IO CoverageCache
+lookupCoverage env vm = do
+  let contract = fromMaybe (error "no contract information on coverage") $ currentContract vm
+      covRef = case contract.code of
+        InitCode _ _ -> env.coverageRefInit
+        _ -> env.coverageRefRuntime
 
-        maybeCovVec <- lookupUsingCodehashOrInsert env.codehashMap contract env.dapp covRef $ do
-          let
-            size = case contract.code of
-              InitCode b _ -> BS.length b
-              _ -> BS.length . forceBuf . fromJust . view bytecode $ contract
-          if size == 0 then pure Nothing else do
-            -- IO for making a new vec
-            vec <- VMut.new size
-            -- We use -1 for opIx to indicate that the location was not covered
-            forM_ [0..size-1] $ \i -> VMut.write vec i (-1, 0, 0)
-            pure $ Just vec
+  maybeCovVec <- lookupUsingCodehashOrInsert env.codehashMap contract env.dapp covRef $ do
+    let
+      size = case contract.code of
+        InitCode b _ -> BS.length b
+        _ -> BS.length . forceBuf . fromJust . view bytecode $ contract
+    if size == 0 then pure Nothing else do
+      -- IO for making a new vec
+      vec <- VMut.new size
+      -- We use -1 for opIx to indicate that the location was not covered
+      forM_ [0..size-1] $ \i -> VMut.write vec i (-1, 0, 0)
+      pure $ Just vec
 
-        pure CoverageCache { code = vm.state.code
-                           , opIxMap = contract.opIxMap
-                           , covVec = maybeCovVec
-                           }
-
-      -- | Get the current contract being executed
-      currentContract vm = fromMaybe (error "no contract information on coverage") $
-        vm ^? #env % #contracts % at vm.state.codeContract % _Just
+  pure CoverageCache { code = vm.state.code
+                     , opIxMap = contract.opIxMap
+                     , covVec = maybeCovVec
+                     }
 
 initialVM :: Bool -> ST RealWorld (VM Concrete)
 initialVM ffi = do

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -2,7 +2,12 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE GADTs #-}
 
-module Echidna.Exec where
+module Echidna.Exec
+  ( execTx
+  , execTxWithCov
+  , initialVM
+  , pattern Reversion
+  ) where
 
 import Control.Monad (when, forM_)
 import Control.Monad.Catch (MonadThrow(..))

--- a/lib/Echidna/Types/Campaign.hs
+++ b/lib/Echidna/Types/Campaign.hs
@@ -243,7 +243,9 @@ defaultSymExecAskSMTIters = 1
 
 -- | Get number of fuzzing workers (doesn't include sym exec worker)
 -- Defaults to `N` if set to Nothing, where `N` is Haskell's -N value,
--- usually the number of cores, clamped between 1 and 4.
+-- clamped between 1 and 4. The echidna executable always fills in `workers`
+-- (from the processor count, see `Main.overrideConfig`), since it starts the
+-- RTS with a single capability; this fallback serves other entry points.
 getNFuzzWorkers :: CampaignConf -> Int
 getNFuzzWorkers conf = maybe defaultN fromIntegral conf.workers
   where

--- a/package.yaml
+++ b/package.yaml
@@ -101,7 +101,10 @@ executables:
     ghc-options:
       - -threaded
       - -rtsopts
-      - '"-with-rtsopts=-A64m -N"'
+      # No -N: Main sizes the capabilities to the number of workers. Every
+      # capability gets its own 64 MiB nursery (-A64m), so -N alone would
+      # reserve cores × 64 MiB regardless of how many workers run.
+      - '"-with-rtsopts=-A64m"'
     when:
       - condition: (os(linux) || os(windows)) && flag(static)
         ghc-options:

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,6 +2,7 @@
 
 module Main where
 
+import Control.Concurrent (getNumCapabilities, setNumCapabilities)
 import Control.Exception (SomeException, displayException, handle, throwIO, fromException)
 import Control.Monad (unless, when, forM_)
 import Control.Monad.Random (getRandomR)
@@ -22,6 +23,7 @@ import Data.Text.Lazy qualified as TL
 import Data.Time.Clock.System (getSystemTime, systemSeconds)
 import Data.Version (showVersion)
 import Data.Word (Word8, Word16, Word64)
+import GHC.Conc (getNumProcessors)
 import Main.Utf8 (withUtf8)
 import Options.Applicative
 import Paths_echidna (version)
@@ -50,6 +52,7 @@ import Echidna.Types.Solidity
 import Echidna.Types.Test (TestMode, EchidnaTest(..), TestConf(..), TestType(..), TestState(..), isSuccessful)
 import Echidna.UI
 import Echidna.Utility (measureIO)
+import Echidna.Worker (getNWorkers)
 
 -- | Strip ANSI escape codes from any uncaught exception's display text when
 -- stderr doesn't support them (e.g., redirected to a file). Covers the
@@ -73,6 +76,17 @@ main = withUtf8 $ withCP65001 $ withStrippedExceptions $ do
   EConfigWithUsage loadedCfg ks _ <-
     maybe (pure (EConfigWithUsage defaultConfig mempty mempty)) parseConfig cliConfigFilepath
   cfg <- overrideConfig loadedCfg opts
+
+  -- Size the RTS to the campaign: one capability per worker plus one for the
+  -- UI, but never more than there are cores (what -N used to give). The RTS
+  -- starts with a single capability (no -N in -with-rtsopts) and each one added
+  -- here brings its own 64 MiB nursery, so this is what bounds the process'
+  -- baseline memory. An explicit +RTS -N asking for more wins.
+  capabilities <- getNumCapabilities
+  processors <- max 1 <$> getNumProcessors
+  let neededCapabilities = min processors (getNWorkers cfg.campaignConf + 1)
+  when (capabilities < neededCapabilities) $
+    setNumCapabilities neededCapabilities
 
   printProjectName cfg.projectName
 
@@ -280,9 +294,13 @@ overrideConfig config Options{..} = do
   envRpcUrl <- Onchain.rpcUrlEnv
   envRpcBlock <- Onchain.rpcBlockEnv
   envEtherscanApiKey <- Onchain.etherscanApiKey
+  -- Default worker count: one per core, capped at 4. Resolved here rather than
+  -- left to 'getNFuzzWorkers' because the RTS starts with a single capability
+  -- (see 'main'), so the capability count no longer reflects the machine.
+  defaultWorkers <- fromIntegral . min 4 . max 1 <$> getNumProcessors
   pure $
     config { solConf = overrideSolConf config.solConf
-           , campaignConf = overrideCampaignConf config.campaignConf
+           , campaignConf = overrideCampaignConf defaultWorkers config.campaignConf
            , uiConf = overrideUiConf config.uiConf
            , rpcUrl = cliRpcUrl <|> envRpcUrl <|> config.rpcUrl
            , rpcBlock = cliRpcBlock <|> envRpcBlock <|> config.rpcBlock
@@ -305,14 +323,14 @@ overrideConfig config Options{..} = do
                               , solConf = cfg.solConf { quiet = True }
                               }
 
-    overrideCampaignConf campaignConf = campaignConf
+    overrideCampaignConf defaultWorkers campaignConf = campaignConf
       { corpusDir = cliCorpusDir <|> campaignConf.corpusDir
       , coverageDir = cliCoverageDir <|> campaignConf.coverageDir
       , testLimit = fromMaybe campaignConf.testLimit cliTestLimit
       , shrinkLimit = fromMaybe campaignConf.shrinkLimit cliShrinkLimit
       , seqLen = fromMaybe campaignConf.seqLen cliSeqLen
       , seed = cliSeed <|> campaignConf.seed
-      , workers = cliWorkers <|> campaignConf.workers
+      , workers = cliWorkers <|> campaignConf.workers <|> Just defaultWorkers
       , serverPort = cliServerPort <|> campaignConf.serverPort
       , symExec = fromMaybe campaignConf.symExec cliSymExec
       , symExecTargets = if null cliSymExecTargets then campaignConf.symExecTargets else cliSymExecTargets


### PR DESCRIPTION
Two independent performance fixes found while profiling a property campaign
(`+RTS -s -hT` and a late-cost-centre profiling build). Same seed, same
workload, identical campaign results before and after.

## `perf(rts)`: size the RTS capabilities to the campaign's worker count

The executable was linked with `-with-rtsopts=-A64m -N`, so the RTS created one
capability per core, each with its own 64 MiB nursery, regardless of how many
workers actually run. With nursery chunking (`-A >= 16m`) a single busy worker
churns through all of them, so a **one-worker campaign on a 16-core machine sat
at 1.2 GiB of RTS memory while its live heap was ~13 MB**.

Now the RTS starts with one capability and `main` grows it to
`min cores (workers + 1)` once the config is resolved: one per fuzz/symexec
worker plus one for the UI, and never more than the old `-N` default created.
An explicit `+RTS -N` asking for more is still honoured.

Because the default worker count used to be derived from the capability count
(`getNFuzzWorkers`), it is now resolved in `overrideConfig` from
`getNumProcessors` — same value (cores clamped to 1..4). `getNFuzzWorkers`
keeps its fallback for other entry points.

| `--workers` | capabilities | memory in use |
|---|---|---|
| 1 | `-N2` | 158 MiB |
| 3 | `-N4` | 306 MiB |
| 40 (16-core box) | `-N16` | 1216 MiB — same as the old default |
| 1, `+RTS -N8` | `-N8` | 602 MiB — override honoured |

## `perf(exec)`: cache the coverage vector lookup across EVM steps

The per-instruction coverage hook did two `Map.lookup`s on `env.contracts`, a
`readIORef` plus a codehash `Map` lookup, and a `modifyIORef'` allocating a new
context tuple on **every EVM step** (~380 steps per call on this workload).

The step loop now carries a small `CoverageCache` keyed on the executing code
and only redoes the lookup when the code changes. Coverage is keyed by
codehash, so equal code always means the same vector; the `ByteString` `Eq`
short-circuits to a pointer compare when it is the same object, which the loop
maintains by storing the current step's code on every hit (clones stay on the
fast path). The coverage context is threaded as a value and written back to its
`IORef` once per `execCov` call, so it still spans query interruptions.

Recorded coverage is unchanged: same opIx, same handling of out-of-bounds pcs,
depth ≥ 64 and already-covered locations.

## Numbers

Benchmark: 3-property contract, `seqLen: 100`, 1 worker, fixed seed,
`--test-limit 400000`, 16-core machine.

| | `master` | this PR | Δ |
|---|---|---|---|
| Elapsed | 51.5 s | 45.0 s | **−13 %** |
| Bytes allocated | 252 GB | 232.5 GB | −7.7 % |
| Total memory in use | 1212 MiB | **189 MiB** | **−84 %** |
| Max RSS | 1.32 GB | 247 MB | −81 % |
| Campaign result | corpus 21, 4263 instrs | identical | |

The two effects are independent: `master` forced to `+RTS -N2` gets all of the
memory drop (194 MiB) at the same speed (51.5 s); this PR forced to `-N16` gets
all of the speedup (44.5 s) at the old memory (1225 MiB). Alternating A/B runs
at equal `-N` reproduce the gap (51.8–52.2 s vs 45.3–45.6 s, noise ≈ 0.4 s).