### PR TITLE
perf: stop re-encoding signatures and rendering events in assertion checks

### DIFF
--- a/lib/Echidna/Events.hs
+++ b/lib/Echidna/Events.hs
@@ -79,14 +79,8 @@ extractEvents decodeErrors dappInfo vm =
       _ -> Nothing
 
 -- | Whether the last transaction emitted an event with the given name, under
--- any overload.
---
--- This is the answer @any (isPrefixOf (name <> "(")) . extractEvents@ gives:
--- 'showValues' always parenthesises the arguments, so a rendered event starts
--- with @name <> "("@ exactly when the event has that name, and nothing else
--- 'extractEvents' produces (revert reasons, raw topics, error traces) can start
--- that way. Rendering the arguments of every event is what made that check
--- expensive, and none of it is needed to know the name.
+-- any overload. Checks the name via the event map instead of rendering the
+-- events, which is expensive.
 hasEventNamed :: Text -> DappInfo -> VM Concrete -> Bool
 hasEventNamed name dappInfo vm = any (any isNamed) (traceForest vm)
   where

--- a/lib/Echidna/Events.hs
+++ b/lib/Echidna/Events.hs
@@ -78,6 +78,25 @@ extractEvents decodeErrors dappInfo vm =
         Just $ humanPanic $ decodePanic d
       _ -> Nothing
 
+-- | Whether the last transaction emitted an event with the given name, under
+-- any overload.
+--
+-- This is the answer @any (isPrefixOf (name <> "(")) . extractEvents@ gives:
+-- 'showValues' always parenthesises the arguments, so a rendered event starts
+-- with @name <> "("@ exactly when the event has that name, and nothing else
+-- 'extractEvents' produces (revert reasons, raw topics, error traces) can start
+-- that way. Rendering the arguments of every event is what made that check
+-- expensive, and none of it is needed to know the name.
+hasEventNamed :: Text -> DappInfo -> VM Concrete -> Bool
+hasEventNamed name dappInfo vm = any (any isNamed) (traceForest vm)
+  where
+  isNamed trace = case trace.tracedata of
+    EventTrace _ _ (topic:_) ->
+      case Map.lookup (forceWord topic) dappInfo.eventMap of
+        Just (Event name' _ _) -> name' == name
+        Nothing -> False
+    _ -> False
+
 -- | Extract all non‑indexed event values emitted between two VM states.
 extractEventValues :: DappInfo -> VM Concrete -> VM Concrete -> Map AbiType (Set AbiValue)
 extractEventValues dappInfo vm vm' =

--- a/lib/Echidna/Output/Foundry.hs
+++ b/lib/Echidna/Output/Foundry.hs
@@ -39,7 +39,7 @@ foundryTest mContractName psender test =
       in fromStrict $ substituteValue template (toMustache testData)
     CallTest name _ | "AssertionFailed" `isPrefixOf` unpack name ->
       -- Echidna detects assertion failures via events named AssertionFailed
-      -- with any argument types (see checkAssertionEvent in Echidna.Test).
+      -- with any argument types (see checkAssertionTest in Echidna.Test).
       -- We check all overloads defined in crytic's fuzzlib (LibLog.sol):
       --   AssertionFailed()
       --   AssertionFailed(string)

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -330,10 +330,9 @@ checkAnySelfDestructed _ vm =
 checkPanicEvent :: T.Text -> Events -> Bool
 checkPanicEvent n = any (T.isPrefixOf ("Panic(" <> n <> ")"))
 
--- | Whether the last transaction is reported with @Panic(n)@ by 'extractEvents',
--- i.e. it reverted with that panic code. Only the revert reason can render that
--- way, so the events themselves are not rendered -- unless the contract
--- declares an event named Panic, which 'checkPanicEvent' would match too.
+-- | Whether the last transaction reverted with @Panic(n)@. Only renders the
+-- events if the contract declares a Panic event of its own, which
+-- 'checkPanicEvent' would match too.
 hasPanic :: T.Text -> DappInfo -> VM Concrete -> Bool
 hasPanic n dappInfo vm = checkPanicEvent n events
   where

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -21,7 +21,7 @@ import Echidna.Events (Events, decodeRevert, extractEvents, hasEventNamed)
 import Echidna.Exec
 import Echidna.SymExec.Symbolic (forceBuf)
 import Echidna.Types.Config
-import Echidna.Types.Signature (SolSignature)
+import Echidna.Types.Signature (FunctionName, SolSignature)
 import Echidna.Types.Test
 import Echidna.Types.Tx (Tx, TxConf(..), basicTx, TxResult(..), getResult)
 
@@ -190,8 +190,9 @@ checkETest test vm = case test.testType of
   Exploration -> pure (BoolValue True, vm) -- These values are never used
   PropertyTest n a -> checkProperty vm n a
   OptimizationTest n a -> checkOptimization vm n a
-  AssertionTest dt n a sel -> if dt then checkFoundryAssertion vm n sel a
-                                    else checkStatefulAssertion vm sel a
+  AssertionTest{foundry, sig, addr, sel} ->
+    if foundry then checkFoundryAssertion vm (fst sig) sel addr
+               else checkStatefulAssertion vm sel addr
   CallTest _ f -> checkCall vm f
 
 -- | Given a property test, evaluate it and see if it currently passes.
@@ -272,16 +273,15 @@ checkStatefulAssertion vm sel addr = do
 checkFoundryAssertion
   :: (MonadReader Env m, MonadThrow m)
   => VM Concrete
-  -> SolSignature
+  -> FunctionName -- ^ name of the function under test
   -> BS.ByteString -- ^ selector of the function under test
   -> Addr
   -> m (TestValue, VM Concrete)
-checkFoundryAssertion vm sig sel addr = do
+checkFoundryAssertion vm name sel addr = do
   let
-    name = fst sig
     -- Whether the last transaction has any value
     hasValue = vm.state.callvalue /= Lit 0
-    -- Whether the last transaction called the function `sig`.
+    -- Whether the last transaction called the function under test.
     isCorrectFn = BS.isPrefixOf sel (forceBuf vm.state.calldata)
     isAssertionFailure
       -- "testFail" functions are expected to revert, so the test only fails

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -7,6 +7,7 @@ import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader.Class (MonadReader, asks)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
+import Data.Maybe (maybeToList)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Prelude hiding (Word)
@@ -16,7 +17,7 @@ import EVM.Dapp (DappInfo)
 import EVM.Types hiding (Env)
 
 import Echidna.ABI
-import Echidna.Events (Events, extractEvents)
+import Echidna.Events (Events, decodeRevert, extractEvents, hasEventNamed)
 import Echidna.Exec
 import Echidna.SymExec.Symbolic (forceBuf)
 import Echidna.Types.Config
@@ -264,8 +265,7 @@ checkStatefulAssertion vm sel addr = do
     txtOffset = 4+32+32 -- selector + offset + length
     -- Test always passes if it doesn't target the last executed contract and function.
     -- Otherwise it passes if it doesn't cause an assertion failure.
-    events = extractEvents False dappInfo vm
-    eventFailure = not (null events) && (checkAssertionEvent events || checkPanicEvent "1" events)
+    eventFailure = hasEventNamed "AssertionFailed" dappInfo vm || hasPanic "1" dappInfo vm
     isFailure = isCorrectTarget && (eventFailure || isAssertionFailure)
   pure (BoolValue (not isFailure), vm)
 
@@ -316,11 +316,7 @@ checkCall vm f = do
 
 checkAssertionTest :: DappInfo -> VM Concrete -> TestValue
 checkAssertionTest dappInfo vm =
-  let events = extractEvents False dappInfo vm
-  in BoolValue $ null events || not (checkAssertionEvent events)
-
-checkAssertionEvent :: Events -> Bool
-checkAssertionEvent = any (T.isPrefixOf "AssertionFailed(")
+  BoolValue $ not (hasEventNamed "AssertionFailed" dappInfo vm)
 
 checkSelfDestructedTarget :: Addr -> DappInfo -> VM Concrete -> TestValue
 checkSelfDestructedTarget addr _ vm =
@@ -334,10 +330,20 @@ checkAnySelfDestructed _ vm =
 checkPanicEvent :: T.Text -> Events -> Bool
 checkPanicEvent n = any (T.isPrefixOf ("Panic(" <> n <> ")"))
 
+-- | Whether the last transaction is reported with @Panic(n)@ by 'extractEvents',
+-- i.e. it reverted with that panic code. Only the revert reason can render that
+-- way, so the events themselves are not rendered -- unless the contract
+-- declares an event named Panic, which 'checkPanicEvent' would match too.
+hasPanic :: T.Text -> DappInfo -> VM Concrete -> Bool
+hasPanic n dappInfo vm = checkPanicEvent n events
+  where
+  events
+    | hasEventNamed "Panic" dappInfo vm = extractEvents False dappInfo vm
+    | otherwise = maybeToList (decodeRevert False vm)
+
 checkOverflowTest :: DappInfo -> VM Concrete-> TestValue
 checkOverflowTest dappInfo vm =
-  let es = extractEvents False dappInfo vm
-  in BoolValue $ null es || not (checkPanicEvent "17" es)
+  BoolValue $ not (hasPanic "17" dappInfo vm)
 
 -- | Reproduce a test saving VM snapshot after every transaction
 reproduceTest

--- a/lib/Echidna/Test.hs
+++ b/lib/Echidna/Test.hs
@@ -130,21 +130,21 @@ createTests m td ts seqLen r ss = case m of
   "optimization" ->
     map (\t -> createTest (OptimizationTest t r)) ts
   "assertion" ->
-    map (\s -> createTest (AssertionTest False s r))
+    map (\s -> createTest (assertionTest False s r))
         (filter (/= fallback) ss) ++ [createTest (CallTest "AssertionFailed(..)" checkAssertionTest)]
   "verification" ->
-    map (\s -> createTest (AssertionTest False s r)) (filter (/= fallback) ss)
+    map (\s -> createTest (assertionTest False s r)) (filter (/= fallback) ss)
   -- In foundry mode, seqLen distinguishes fuzz tests (seqLen == 1) from
   -- invariant tests (seqLen > 1), which determines how functions are filtered.
   -- "check" and "prove" functions are symbolic entry points, but this is a
   -- fuzzing campaign, so they are tested as regular fuzz tests here.
   "foundry" ->
     if seqLen == 1 then
-      map (\s -> createTest (AssertionTest True s r))
+      map (\s -> createTest (assertionTest True s r))
         (filter (\(n, xs) -> (isFoundryTestName n || isFoundrySymbolicName n)
                              && not (null xs)) ss)
     else
-      map (\s -> createTest (AssertionTest True s r))
+      map (\s -> createTest (assertionTest True s r))
           (filter (\(n, xs) -> isFoundryInvariantName n
                                || isFoundrySymbolicName n
                                || not (null xs)) ss)
@@ -189,8 +189,8 @@ checkETest test vm = case test.testType of
   Exploration -> pure (BoolValue True, vm) -- These values are never used
   PropertyTest n a -> checkProperty vm n a
   OptimizationTest n a -> checkOptimization vm n a
-  AssertionTest dt n a -> if dt then checkFoundryAssertion vm n a
-                                else checkStatefulAssertion vm n a
+  AssertionTest dt n a sel -> if dt then checkFoundryAssertion vm n sel a
+                                    else checkStatefulAssertion vm sel a
   CallTest _ f -> checkCall vm f
 
 -- | Given a property test, evaluate it and see if it currently passes.
@@ -245,16 +245,14 @@ checkOptimization vm f a = do
 checkStatefulAssertion
   :: (MonadReader Env m, MonadThrow m)
   => VM Concrete
-  -> SolSignature
+  -> BS.ByteString -- ^ selector of the function under test
   -> Addr
   -> m (TestValue, VM Concrete)
-checkStatefulAssertion vm sig addr = do
+checkStatefulAssertion vm sel addr = do
   dappInfo <- asks (.dapp)
   let
-    -- Whether the last transaction called the function `sig`.
-    isCorrectFn =
-      BS.isPrefixOf (BS.take 4 (abiCalldata (encodeSig sig) mempty))
-                    (forceBuf vm.state.calldata)
+    -- Whether the last transaction called the function under test.
+    isCorrectFn = BS.isPrefixOf sel (forceBuf vm.state.calldata)
     -- Whether the last transaction executed a function on the contract `addr`.
     isCorrectAddr = LitAddr addr == vm.state.codeContract
     isCorrectTarget = isCorrectFn && isCorrectAddr
@@ -275,17 +273,16 @@ checkFoundryAssertion
   :: (MonadReader Env m, MonadThrow m)
   => VM Concrete
   -> SolSignature
+  -> BS.ByteString -- ^ selector of the function under test
   -> Addr
   -> m (TestValue, VM Concrete)
-checkFoundryAssertion vm sig addr = do
+checkFoundryAssertion vm sig sel addr = do
   let
     name = fst sig
     -- Whether the last transaction has any value
     hasValue = vm.state.callvalue /= Lit 0
     -- Whether the last transaction called the function `sig`.
-    isCorrectFn =
-      BS.isPrefixOf (BS.take 4 (abiCalldata (encodeSig sig) mempty))
-                    (forceBuf vm.state.calldata)
+    isCorrectFn = BS.isPrefixOf sel (forceBuf vm.state.calldata)
     isAssertionFailure
       -- "testFail" functions are expected to revert, so the test only fails
       -- when the call succeeds.

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -57,33 +57,42 @@ instance Show TestValue where
 data TestType
   = PropertyTest Text Addr
   | OptimizationTest Text Addr
-  | AssertionTest Bool SolSignature Addr ByteString
-    -- ^ foundry-style?, the function, the contract, and the 4-byte selector
-    -- of the function. The selector is derived from the signature; it is kept
-    -- here because the check runs for every open test after every call and
-    -- hashing the signature each time dominated it. Build with 'assertionTest'.
+  | AssertionTest
+      { foundry :: Bool
+        -- ^ Foundry-style test?
+      , sig :: SolSignature
+        -- ^ the function under test
+      , addr :: Addr
+        -- ^ the contract under test
+      , sel :: ByteString
+        -- ^ 4-byte selector of 'sig'. Derived; cached here because the check
+        -- runs for every open test after every call and hashing the signature
+        -- each time dominated it. Build with 'assertionTest'.
+      }
   | CallTest Text (DappInfo -> VM Concrete -> TestValue)
   | Exploration
 
 -- | An 'AssertionTest' with its selector filled in.
 assertionTest :: Bool -> SolSignature -> Addr -> TestType
-assertionTest foundry sig addr = AssertionTest foundry sig addr (selector (encodeSig sig))
+assertionTest foundry sig addr =
+  AssertionTest { foundry, sig, addr, sel = selector (encodeSig sig) }
 
 instance Eq TestType where
-  PropertyTest t a      == PropertyTest t' a'      = t == t' && a == a'
+  -- 'sel' is ignored: it is derived from 'sig'.
+  PropertyTest t a      == PropertyTest t' a'       = t == t' && a == a'
   AssertionTest b s a _ == AssertionTest b' s' a' _ = b == b' && s == s' && a == a'
-  OptimizationTest s a  == OptimizationTest s' a'  = s == s' && a == a'
-  CallTest t _          == CallTest t' _           = t == t'
-  Exploration           == Exploration             = True
-  _                     == _                       = False
+  OptimizationTest s a  == OptimizationTest s' a'   = s == s' && a == a'
+  CallTest t _          == CallTest t' _            = t == t'
+  Exploration           == Exploration              = True
+  _                     == _                        = False
 
 instance Show TestType where
   show = \case
-    PropertyTest t _      -> show t
-    AssertionTest _ s _ _ -> show s
-    OptimizationTest s _  -> show s
-    CallTest t _          -> show t
-    Exploration           -> "Exploration"
+    PropertyTest t _     -> show t
+    AssertionTest{sig}   -> show sig
+    OptimizationTest s _ -> show s
+    CallTest t _         -> show t
+    Exploration          -> "Exploration"
 
 instance ToJSON TestType where
   toJSON = \case
@@ -91,7 +100,7 @@ instance ToJSON TestType where
       object [ "type" .= ("property_test" :: String), "name" .= name, "addr" .= addr ]
     OptimizationTest name addr ->
       object [ "type" .= ("optimization_test" :: String), "name" .= name, "addr" .= addr ]
-    AssertionTest _ sig addr _ ->
+    AssertionTest{sig, addr} ->
       object [ "type" .= ("assertion_test" :: String), "signature" .= sig, "addr" .= addr ]
     CallTest name _ ->
       object [ "type" .= ("call_test" :: String), "name" .= name ]
@@ -136,11 +145,11 @@ isAssertionTest EchidnaTest{testType = AssertionTest {}} = True
 isAssertionTest _ = False
 
 getAssertionSignature :: EchidnaTest -> String
-getAssertionSignature EchidnaTest{testType = AssertionTest _ sig _ _} = unpack $ encodeSig sig
+getAssertionSignature EchidnaTest{testType = AssertionTest{sig}} = unpack $ encodeSig sig
 getAssertionSignature _ = error "Not an assertion test"
 
 getAssertionFunctionName :: EchidnaTest -> String
-getAssertionFunctionName EchidnaTest{testType = AssertionTest _ (name, _) _ _} = unpack name
+getAssertionFunctionName EchidnaTest{testType = AssertionTest{sig = (name, _)}} = unpack name
 getAssertionFunctionName _ = error "Not an assertion test"
 
 isOpen :: EchidnaTest -> Bool

--- a/lib/Echidna/Types/Test.hs
+++ b/lib/Echidna/Types/Test.hs
@@ -4,11 +4,13 @@
 module Echidna.Types.Test where
 
 import Data.Aeson
+import Data.ByteString (ByteString)
 import Data.DoubleWord (Int256)
 import Data.Maybe (maybeToList)
 import Data.Text (Text, unpack)
 import GHC.Generics (Generic)
 
+import EVM.ABI (selector)
 import EVM.Dapp (DappInfo)
 import EVM.Types (Addr, VM, VMType(Concrete))
 
@@ -55,25 +57,33 @@ instance Show TestValue where
 data TestType
   = PropertyTest Text Addr
   | OptimizationTest Text Addr
-  | AssertionTest Bool SolSignature Addr
+  | AssertionTest Bool SolSignature Addr ByteString
+    -- ^ foundry-style?, the function, the contract, and the 4-byte selector
+    -- of the function. The selector is derived from the signature; it is kept
+    -- here because the check runs for every open test after every call and
+    -- hashing the signature each time dominated it. Build with 'assertionTest'.
   | CallTest Text (DappInfo -> VM Concrete -> TestValue)
   | Exploration
 
+-- | An 'AssertionTest' with its selector filled in.
+assertionTest :: Bool -> SolSignature -> Addr -> TestType
+assertionTest foundry sig addr = AssertionTest foundry sig addr (selector (encodeSig sig))
+
 instance Eq TestType where
-  PropertyTest t a     == PropertyTest t' a'     = t == t' && a == a'
-  AssertionTest b s a  == AssertionTest b' s' a' = b == b' && s == s' && a == a'
-  OptimizationTest s a == OptimizationTest s' a' = s == s' && a == a'
-  CallTest t _         == CallTest t' _          = t == t'
-  Exploration          == Exploration            = True
-  _                    == _                      = False
+  PropertyTest t a      == PropertyTest t' a'      = t == t' && a == a'
+  AssertionTest b s a _ == AssertionTest b' s' a' _ = b == b' && s == s' && a == a'
+  OptimizationTest s a  == OptimizationTest s' a'  = s == s' && a == a'
+  CallTest t _          == CallTest t' _           = t == t'
+  Exploration           == Exploration             = True
+  _                     == _                       = False
 
 instance Show TestType where
   show = \case
-    PropertyTest t _     -> show t
-    AssertionTest _ s _  -> show s
-    OptimizationTest s _ -> show s
-    CallTest t _         -> show t
-    Exploration          -> "Exploration"
+    PropertyTest t _      -> show t
+    AssertionTest _ s _ _ -> show s
+    OptimizationTest s _  -> show s
+    CallTest t _          -> show t
+    Exploration           -> "Exploration"
 
 instance ToJSON TestType where
   toJSON = \case
@@ -81,7 +91,7 @@ instance ToJSON TestType where
       object [ "type" .= ("property_test" :: String), "name" .= name, "addr" .= addr ]
     OptimizationTest name addr ->
       object [ "type" .= ("optimization_test" :: String), "name" .= name, "addr" .= addr ]
-    AssertionTest _ sig addr ->
+    AssertionTest _ sig addr _ ->
       object [ "type" .= ("assertion_test" :: String), "signature" .= sig, "addr" .= addr ]
     CallTest name _ ->
       object [ "type" .= ("call_test" :: String), "name" .= name ]
@@ -126,11 +136,11 @@ isAssertionTest EchidnaTest{testType = AssertionTest {}} = True
 isAssertionTest _ = False
 
 getAssertionSignature :: EchidnaTest -> String
-getAssertionSignature EchidnaTest{testType = AssertionTest _ sig _} = unpack $ encodeSig sig
+getAssertionSignature EchidnaTest{testType = AssertionTest _ sig _ _} = unpack $ encodeSig sig
 getAssertionSignature _ = error "Not an assertion test"
 
 getAssertionFunctionName :: EchidnaTest -> String
-getAssertionFunctionName EchidnaTest{testType = AssertionTest _ (name, _) _} = unpack name
+getAssertionFunctionName EchidnaTest{testType = AssertionTest _ (name, _) _ _} = unpack name
 getAssertionFunctionName _ = error "Not an assertion test"
 
 isOpen :: EchidnaTest -> Bool

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -228,7 +228,7 @@ ppTests tests = do
       CallTest n _ -> do
         status <- ppTS t.state t.result (fromJust t.vm) t.reproducer
         pure $ Just (T.unpack n <> ": " <> status)
-      AssertionTest _ s _ -> do
+      AssertionTest _ s _ _ -> do
         status <- ppTS t.state t.result (fromJust t.vm) t.reproducer
         pure $ Just (T.unpack (encodeSig s) <> ": " <> status)
       OptimizationTest n _ -> do
@@ -241,7 +241,7 @@ ppTestName t =
   case t.testType of
     PropertyTest n _ -> T.unpack n
     CallTest n _ -> T.unpack n
-    AssertionTest _ s _ -> T.unpack (encodeSig s)
+    AssertionTest _ s _ _ -> T.unpack (encodeSig s)
     OptimizationTest n _ -> T.unpack n <> ": max value: " <> show t.value
     Exploration -> "<exploration>"
 

--- a/lib/Echidna/UI/Report.hs
+++ b/lib/Echidna/UI/Report.hs
@@ -228,9 +228,9 @@ ppTests tests = do
       CallTest n _ -> do
         status <- ppTS t.state t.result (fromJust t.vm) t.reproducer
         pure $ Just (T.unpack n <> ": " <> status)
-      AssertionTest _ s _ _ -> do
+      AssertionTest{sig} -> do
         status <- ppTS t.state t.result (fromJust t.vm) t.reproducer
-        pure $ Just (T.unpack (encodeSig s) <> ": " <> status)
+        pure $ Just (T.unpack (encodeSig sig) <> ": " <> status)
       OptimizationTest n _ -> do
         status <- ppOPT t.state (fromJust t.vm) t.reproducer
         pure $ Just (T.unpack n <> ": max value: " <> show t.value <> "\n" <> status)
@@ -241,7 +241,7 @@ ppTestName t =
   case t.testType of
     PropertyTest n _ -> T.unpack n
     CallTest n _ -> T.unpack n
-    AssertionTest _ s _ _ -> T.unpack (encodeSig s)
+    AssertionTest{sig} -> T.unpack (encodeSig sig)
     OptimizationTest n _ -> T.unpack n <> ": max value: " <> show t.value
     Exploration -> "<exploration>"
 

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -316,7 +316,7 @@ testWidget test =
     Exploration          -> widget tsWidget "exploration" ""
     PropertyTest n _     -> widget tsWidget n ""
     OptimizationTest n _ -> widget optWidget n "optimizing "
-    AssertionTest _ s _  -> widget tsWidget (encodeSig s) "assertion in "
+    AssertionTest _ s _ _ -> widget tsWidget (encodeSig s) "assertion in "
     CallTest n _         -> widget tsWidget n ""
   where
   widget f n infront = do

--- a/lib/Echidna/UI/Widgets.hs
+++ b/lib/Echidna/UI/Widgets.hs
@@ -316,7 +316,7 @@ testWidget test =
     Exploration          -> widget tsWidget "exploration" ""
     PropertyTest n _     -> widget tsWidget n ""
     OptimizationTest n _ -> widget optWidget n "optimizing "
-    AssertionTest _ s _ _ -> widget tsWidget (encodeSig s) "assertion in "
+    AssertionTest{sig}   -> widget tsWidget (encodeSig sig) "assertion in "
     CallTest n _         -> widget tsWidget n ""
   where
   widget f n infront = do

--- a/lib/Echidna/Worker.hs
+++ b/lib/Echidna/Worker.hs
@@ -152,6 +152,6 @@ ppWorkerEvent = \case
   where
     showTest test = case test.testType of
       PropertyTest n _ -> n
-      AssertionTest _ n _ _ -> encodeSig n
+      AssertionTest{sig} -> encodeSig sig
       CallTest n _ -> n
       _ -> error "impossible"

--- a/lib/Echidna/Worker.hs
+++ b/lib/Echidna/Worker.hs
@@ -152,6 +152,6 @@ ppWorkerEvent = \case
   where
     showTest test = case test.testType of
       PropertyTest n _ -> n
-      AssertionTest _ n _ -> encodeSig n
+      AssertionTest _ n _ _ -> encodeSig n
       CallTest n _ -> n
       _ -> error "impossible"

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -211,7 +211,7 @@ getResult n tests =
 
   where findTest test = case test.testType  of
                           PropertyTest t _        -> t == n
-                          AssertionTest _ (t,_) _ -> t == n
+                          AssertionTest _ (t,_) _ _ -> t == n
                           CallTest t _            -> t == n
                           OptimizationTest t _    -> t == n
                           _                       -> False

--- a/src/test/Common.hs
+++ b/src/test/Common.hs
@@ -210,11 +210,11 @@ getResult n tests =
     _   -> error "found more than one tests"
 
   where findTest test = case test.testType  of
-                          PropertyTest t _        -> t == n
-                          AssertionTest _ (t,_) _ _ -> t == n
-                          CallTest t _            -> t == n
-                          OptimizationTest t _    -> t == n
-                          _                       -> False
+                          PropertyTest t _          -> t == n
+                          AssertionTest{sig = (t,_)} -> t == n
+                          CallTest t _              -> t == n
+                          OptimizationTest t _      -> t == n
+                          _                         -> False
 
 optnFor :: Text -> (Env, WorkerState) -> IO (Maybe TestValue)
 optnFor n (env, _) = do

--- a/src/test/Tests/FoundryTestGen.hs
+++ b/src/test/Tests/FoundryTestGen.hs
@@ -20,7 +20,7 @@ import Echidna.Types.Config (Env)
 import Echidna.Types.Campaign (WorkerState)
 import EVM.ABI (AbiValue(..))
 import Echidna.Output.Foundry (foundryTest)
-import Echidna.Types.Test (EchidnaTest(..), TestType(..), TestValue(..), TestState(..))
+import Echidna.Types.Test (EchidnaTest(..), TestType(..), TestValue(..), TestState(..), assertionTest)
 import Echidna.Types.Tx (Tx(..), TxCall(..))
 import Echidna.Types.Worker (WorkerType(FuzzWorker, SymbolicWorker))
 
@@ -457,7 +457,7 @@ mkMinimalTest = EchidnaTest
   -- Foundry tests are only generated for solved/large tests.
   { state = Large 0
   -- AssertionTest is required for Foundry test generation.
-  , testType = AssertionTest False ("test", []) 0
+  , testType = assertionTest False ("test", []) 0
   , value = BoolValue True
   -- Empty reproducer is sufficient for testing contract name generation.
   , reproducer = []


### PR DESCRIPTION
In assertion mode, `updateOpenTest` runs `checkETest` for every open test after every transaction, and two things in that path were doing far more work than the check needs:

- **`perf(test): precompute assertion test selectors`** — `checkStatefulAssertion`/`checkFoundryAssertion` re-encoded the test's signature and keccak-hashed it (`abiCalldata`) on every call, only to compare the first 4 bytes of calldata. `AssertionTest` now carries its selector (filled in by the `assertionTest` smart constructor) and the check is a `ByteString.isPrefixOf`.
- **`perf(test): check assertion events by name instead of rendering them`** — assertion and overflow detection went through `extractEvents`, which renders every event of the tx to `Text` (ABI-decoding the arguments, looking up contract names) and then prefix-matched `"AssertionFailed("` / `"Panic(n)"`. `showValues` always parenthesises, so that prefix test is exactly "an event with this name was emitted": the new `hasEventNamed` looks the topic up in the dapp's event map and compares the name. `Panic(n)` can only come from the revert reason, so `hasPanic` decodes just that — unless the contract declares an event literally named `Panic`, in which case it falls back to the old rendering path so behaviour stays identical.
- **`refactor(test): hide the cached assertion selector behind record fields`** — follow-up with no behavior change: `AssertionTest` gets named fields so pattern matches bind only what they use instead of carrying the selector positionally, and `checkFoundryAssertion` takes just the function name it actually uses. A same-seed campaign is identical before/after.

**Numbers** (assertion-mode benchmark, 33 functions, 200k calls, 1 worker, fixed seed; base = tip of PR 1):

| | wall time | allocation |
|---|---|---|
| base | 22.5 s | 121.5 GB |
| + selectors | 14.1 s | 64.2 GB |
| + event-name check | **12.1 s** | **54.0 GB** |

Campaign results are bit-identical at each step (same unique instructions, corpus size and call count). In a `--profiling-detail=late` profile of 60k calls the total drops 29.3 s → 9.0 s and `extractEvents` disappears from the top cost centres; what remains on the Echidna side is the coverage step loop (~8%), transaction generation (~4.5%) and ABI encoding in `setupTx` (~3.7%), with hevm's interpreter at ~60%.
