### PR TITLE
perf: pick weighted choices with one bounded draw instead of Rational arithmetic

### DIFF
--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -1,8 +1,7 @@
 module Echidna.ABI where
 
 import Control.Monad (liftM2, liftM3, foldM, replicateM, zipWithM)
-import Control.Monad.Random.Strict (MonadRandom, join, getRandom, getRandoms, getRandomR, uniform, fromList)
-import Control.Monad.Random.Strict qualified as Random
+import Control.Monad.Random.Strict (MonadRandom, join, getRandom, getRandoms, getRandomR)
 import Data.Binary.Put (runPut, putWord32be)
 import Data.BinaryWord (unsignedWord)
 import Data.Bits (bit)
@@ -180,7 +179,7 @@ getRandomPow n = if n <= 0 then return 0 else
 -- * 4% (1/21) using the getRandomPow function
 getRandomUint :: MonadRandom m => Int -> m Integer
 getRandomUint n =
-  join $ Random.weighted
+  join $ weighted
     [ (getRandomR (0, 1023), 2)
     , (getRandomR (0, 2 ^ n - 5), 16)
     , (getRandomR (2 ^ n - 5, 2 ^ n - 1), 2)
@@ -192,7 +191,7 @@ getRandomUint n =
 -- * 90% uniformly from the range -1 * 2 ^ (n - 1) to 2 ^ (n - 1) - 1.
 getRandomInt :: MonadRandom m => Int -> m Integer
 getRandomInt n =
-  getRandomR =<< Random.weighted
+  getRandomR =<< weighted
     [ ((-1023, 1023), 1)
     , (((-1) * 2 ^ (n - 1), 2 ^ (n - 1) - 1), 9)
     ]
@@ -313,7 +312,7 @@ shrinkAbiCall (name, vals) = do
       | otherwise = do
           -- We want to pick which ones to shrink uniformly from the vals list.
           -- Odds of shrinking one element is numToShrink/numShrinkable.
-          shouldShrink <- fromList [(True, numToShrink), (False, numShrinkable-numToShrink)]
+          shouldShrink <- weighted [(True, numToShrink), (False, numShrinkable-numToShrink)]
           h' <- if shouldShrink then shrinkAbiValue h else pure h
           let
             numShrinkable' = numShrinkable-1
@@ -444,7 +443,7 @@ genAbiValueM' genDict funcName depth t =
                liftM2 (\n -> AbiBytesDynamic . BS.pack . take n)
                  (getRandomR (1, 32)) getRandoms
              else
-               join $ Random.weighted
+               join $ weighted
                  [ (do
                      sig@(_, types) <- uniform filteredSigs
                      params <- V.fromList <$> mapM (genAbiValueM' genDict "" $ depth + 1) types

--- a/lib/Echidna/Mutator/Array.hs
+++ b/lib/Echidna/Mutator/Array.hs
@@ -1,11 +1,13 @@
 module Echidna.Mutator.Array where
 
-import Control.Monad.Random.Strict (fromList, MonadRandom, getRandomR)
+import Control.Monad.Random.Strict (MonadRandom, getRandomR)
 import Data.ListLike qualified as LL
+
+import Echidna.Types.Random (weighted)
 
 -- | A list of mutators to randomly select to perform a mutation of list-like values
 listMutators :: (LL.ListLike f i, MonadRandom m) => m (f -> m f)
-listMutators = fromList
+listMutators = weighted
   [ (pure, 1) -- no-op
   , (expandRandList, 10)
   , (deleteRandList, 10)

--- a/lib/Echidna/Mutator/Corpus.hs
+++ b/lib/Echidna/Mutator/Corpus.hs
@@ -1,6 +1,6 @@
 module Echidna.Mutator.Corpus where
 
-import Control.Monad.Random.Strict (MonadRandom, getRandomR, weighted)
+import Control.Monad.Random.Strict (MonadRandom, getRandomR)
 import Data.Maybe (maybeToList)
 import Data.Set qualified as Set
 
@@ -8,13 +8,11 @@ import Echidna.Mutator.Array
 import Echidna.Transaction (forceMutateTx, mutateTx, shrinkTx)
 import Echidna.Types (MutationConsts)
 import Echidna.Types.Corpus
+import Echidna.Types.Random (weighted)
 import Echidna.Types.Tx (Tx)
 
 defaultMutationConsts :: Num a => MutationConsts a
 defaultMutationConsts = (1, 1, 1, 1)
-
-fromConsts :: Num a => MutationConsts Integer -> MutationConsts a
-fromConsts (a, b, c, d) = let fi = fromInteger in (fi a, fi b, fi c, fi d)
 
 data TxsMutation = Identity
                  | Shrinking
@@ -97,7 +95,7 @@ getCorpusMutation RandomInterleave = selectAndCombine interleaveAtRandom
 
 seqMutatorsStateful
   :: MonadRandom m
-  => MutationConsts Rational
+  => MutationConsts Integer
   -> m CorpusMutation
 seqMutatorsStateful (c1, c2, c3, c4) = weighted
   [(RandomAppend Identity,   800),
@@ -123,7 +121,7 @@ seqMutatorsStateful (c1, c2, c3, c4) = weighted
 -- either a fresh transaction or a tweaked copy of a stored one.
 seqMutatorsStateless
   :: MonadRandom m
-  => MutationConsts Rational
+  => MutationConsts Integer
   -> m CorpusMutation
 seqMutatorsStateless (c1, c2, _, _) = weighted
   [(RandomAppend Identity,  500),

--- a/lib/Echidna/Shrink.hs
+++ b/lib/Echidna/Shrink.hs
@@ -2,7 +2,7 @@ module Echidna.Shrink (isShrinkable, shrinkTest, shrinkWorkerTests) where
 
 import Control.Monad ((<=<))
 import Control.Monad.Catch (MonadThrow)
-import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
+import Control.Monad.Random.Strict (MonadRandom, getRandomR)
 import Control.Monad.Reader.Class (MonadReader (ask), asks)
 import Control.Monad.State.Strict (MonadIO)
 import Data.List qualified as List
@@ -17,6 +17,7 @@ import Echidna.Test.State (updateTests)
 import Echidna.Transaction
 import Echidna.Types.Campaign (CampaignConf(..))
 import Echidna.Types.Config
+import Echidna.Types.Random (uniform)
 import Echidna.Types.Solidity (SolConf(..))
 import Echidna.Types.Test (TestValue(..), EchidnaTest(..), TestState(..), isOptimizationTest)
 import Echidna.Types.Tx (Tx(..), hasReverted, isUselessNoCall, catNoCalls, TxCall(..))

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -5,7 +5,7 @@ module Echidna.Transaction where
 
 import Control.Monad (join, replicateM, when, zipWithM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Random.Strict (MonadRandom, getRandomR, uniform)
+import Control.Monad.Random.Strict (MonadRandom, getRandomR)
 import Control.Monad.Reader (MonadReader, ask, asks)
 import Control.Monad.State.Strict (MonadState, gets, modify', execState)
 import Data.ByteString qualified as BS

--- a/lib/Echidna/Types/Random.hs
+++ b/lib/Echidna/Types/Random.hs
@@ -20,11 +20,8 @@ rElem' v = (`S.elemAt` v) <$> getRandomR (0, length v - 1)
 
 -- | Pick an element with probability proportional to its weight.
 --
--- Draws one number in @[0, total)@ and walks the list with a single
--- subtraction and comparison per element. Same distribution as
--- 'Control.Monad.Random.weighted' (whose 'Rational' arithmetic took about 3%
--- of a campaign's CPU time), but the generator draws differ, so seeds do not
--- reproduce campaigns from versions that used it.
+-- Similar to 'Control.Monad.Random.weighted' but optimized to avoid
+-- 'Rational' arithmetic.
 weighted :: MonadRandom m => [(a, Integer)] -> m a
 weighted xs
   | total <= 0 = error "Echidna.Types.Random.weighted: empty list, or total weight <= 0"
@@ -37,13 +34,13 @@ weighted xs
              else getRandomR (0, total - 1)
       pure $ pick r xs
   where
-  total = sum (map snd xs)
-  -- total > 0 rules out the empty list, and r < total means the scan stops
-  -- within the list, so this is exhaustive
-  pick _ [] = error "Echidna.Types.Random.weighted: empty list"
-  pick r ((x, q) : rest)
-    | r < q = x
-    | otherwise = pick (r - q) rest
+    total = sum (map snd xs)
+    -- total > 0 rules out the empty list, and r < total means the scan stops
+    -- within the list, so this is exhaustive
+    pick _ [] = error "Echidna.Types.Random.weighted: empty list"
+    pick r ((x, q) : rest)
+        | r < q = x
+        | otherwise = pick (r - q) rest
 
 -- | Pick an element uniformly.
 uniform :: MonadRandom m => [a] -> m a

--- a/lib/Echidna/Types/Random.hs
+++ b/lib/Echidna/Types/Random.hs
@@ -1,6 +1,6 @@
 module Echidna.Types.Random where
 
-import Control.Monad.Random.Strict (MonadRandom, RandT, StdGen, getRandom, getRandomR, evalRandT, getStdGen, forM_, liftIO)
+import Control.Monad.Random.Strict (MonadRandom, RandT, StdGen, getRandomR, evalRandT, getStdGen, forM_, liftIO)
 import Data.Array.IO (IOArray, newListArray, readArray, writeArray, getElems)
 import Data.List.NonEmpty ((!!), NonEmpty(..))
 import Data.Set (Set)
@@ -20,32 +20,32 @@ rElem' v = (`S.elemAt` v) <$> getRandomR (0, length v - 1)
 
 -- | Pick an element with probability proportional to its weight.
 --
--- Makes the very same choice 'Control.Monad.Random.weighted' makes from the
--- same generator state -- the first element whose cumulative weight @c@
--- satisfies @c >= total * (1 - w / maxBound)@ for one uniformly drawn 'Word64'
--- @w@ -- so a seed still yields the same campaign. MonadRandom decides that in
--- 'Rational', and the gcd normalisation behind each step of it took about 3%
--- of a campaign's CPU time; rearranged to @total * w >= maxBound * (total - c)@
--- it is one 'Integer' comparison per element.
+-- Draws one number in @[0, total)@ and walks the list with a single
+-- subtraction and comparison per element. Same distribution as
+-- 'Control.Monad.Random.weighted' (whose 'Rational' arithmetic took about 3%
+-- of a campaign's CPU time), but the generator draws differ, so seeds do not
+-- reproduce campaigns from versions that used it.
 weighted :: MonadRandom m => [(a, Integer)] -> m a
 weighted xs
   | total <= 0 = error "Echidna.Types.Random.weighted: empty list, or total weight <= 0"
   | otherwise = do
-      w <- getRandom
-      pure $ pick (total * toInteger (w :: Word64)) 0 xs
+      -- weights in practice always sum well below 2^64, and a Word64 draw is
+      -- a single generator step where an Integer draw pays the
+      -- arbitrary-precision range machinery on every call
+      r <- if total <= toInteger (maxBound :: Word64)
+             then toInteger <$> getRandomR (0, fromInteger (total - 1) :: Word64)
+             else getRandomR (0, total - 1)
+      pure $ pick r xs
   where
   total = sum (map snd xs)
-  maxW = toInteger (maxBound :: Word64)
-  -- total > 0 rules out the empty list, and the last element always passes
-  -- the test (its cumulative weight is the total), so this is exhaustive
-  pick _ _ [] = error "Echidna.Types.Random.weighted: empty list"
-  pick lhs c ((x, q) : rest)
-    | lhs >= maxW * (total - c') = x
-    | otherwise = pick lhs c' rest
-    where c' = c + q
+  -- total > 0 rules out the empty list, and r < total means the scan stops
+  -- within the list, so this is exhaustive
+  pick _ [] = error "Echidna.Types.Random.weighted: empty list"
+  pick r ((x, q) : rest)
+    | r < q = x
+    | otherwise = pick (r - q) rest
 
--- | Pick an element uniformly, making the same choice as
--- 'Control.Monad.Random.uniform' from the same generator state.
+-- | Pick an element uniformly.
 uniform :: MonadRandom m => [a] -> m a
 uniform = weighted . map (, 1)
 

--- a/lib/Echidna/Types/Random.hs
+++ b/lib/Echidna/Types/Random.hs
@@ -1,10 +1,11 @@
 module Echidna.Types.Random where
 
-import Control.Monad.Random.Strict (MonadRandom, RandT, StdGen, getRandomR, weighted, evalRandT, getStdGen, forM_, liftIO)
+import Control.Monad.Random.Strict (MonadRandom, RandT, StdGen, getRandom, getRandomR, evalRandT, getStdGen, forM_, liftIO)
 import Data.Array.IO (IOArray, newListArray, readArray, writeArray, getElems)
 import Data.List.NonEmpty ((!!), NonEmpty(..))
 import Data.Set (Set)
 import Data.Set qualified as S
+import Data.Word (Word64)
 import Prelude hiding ((!!))
 
 type Seed = Int
@@ -16,6 +17,37 @@ rElem l  = (l !!) <$> getRandomR (0, length l - 1)
 -- | Get a random element of a Set
 rElem' :: MonadRandom m => Set a -> m a
 rElem' v = (`S.elemAt` v) <$> getRandomR (0, length v - 1)
+
+-- | Pick an element with probability proportional to its weight.
+--
+-- Makes the very same choice 'Control.Monad.Random.weighted' makes from the
+-- same generator state -- the first element whose cumulative weight @c@
+-- satisfies @c >= total * (1 - w / maxBound)@ for one uniformly drawn 'Word64'
+-- @w@ -- so a seed still yields the same campaign. MonadRandom decides that in
+-- 'Rational', and the gcd normalisation behind each step of it took about 3%
+-- of a campaign's CPU time; rearranged to @total * w >= maxBound * (total - c)@
+-- it is one 'Integer' comparison per element.
+weighted :: MonadRandom m => [(a, Integer)] -> m a
+weighted xs
+  | total <= 0 = error "Echidna.Types.Random.weighted: empty list, or total weight <= 0"
+  | otherwise = do
+      w <- getRandom
+      pure $ pick (total * toInteger (w :: Word64)) 0 xs
+  where
+  total = sum (map snd xs)
+  maxW = toInteger (maxBound :: Word64)
+  -- total > 0 rules out the empty list, and the last element always passes
+  -- the test (its cumulative weight is the total), so this is exhaustive
+  pick _ _ [] = error "Echidna.Types.Random.weighted: empty list"
+  pick lhs c ((x, q) : rest)
+    | lhs >= maxW * (total - c') = x
+    | otherwise = pick lhs c' rest
+    where c' = c + q
+
+-- | Pick an element uniformly, making the same choice as
+-- 'Control.Monad.Random.uniform' from the same generator state.
+uniform :: MonadRandom m => [a] -> m a
+uniform = weighted . map (, 1)
 
 oftenUsually :: MonadRandom m => a -> a -> m a
 oftenUsually u r = weighted [(u, 10), (r, 1)]

--- a/lib/Echidna/Worker/Fuzz.hs
+++ b/lib/Echidna/Worker/Fuzz.hs
@@ -151,8 +151,8 @@ genStandardSeq deployedContracts = do
   -- Generate new random transactions
   randTxs <- replicateM seqLen (genTx world deployedContracts)
   -- Generate a random mutator
-  cmut <- if seqLen == 1 then seqMutatorsStateless (fromConsts mutConsts)
-                         else seqMutatorsStateful (fromConsts mutConsts)
+  cmut <- if seqLen == 1 then seqMutatorsStateless mutConsts
+                         else seqMutatorsStateful mutConsts
   -- Fetch the mutator
   let mut = getCorpusMutation cmut
   corpus <- liftIO $ readIORef env.corpusRef


### PR DESCRIPTION
## What

MonadRandom's `weighted`/`uniform`/`fromList` pick an element by comparing cumulative
weights against `total * (1 - w / maxBound)` in `Rational`. Every step of that costs a
GMP gcd (normalisation) plus an Integer cross-multiplication per comparison. Echidna
makes five or six such choices per generated transaction — signature, two delays, value,
each numeric argument, the corpus mutator — plus one `weighted` walk over the whole
corpus per `selectFromCorpus`, and native sampling of an 8-worker campaign showed ~3.5%
of CPU in `__gmpn_gcd_1` alone, with the Rational allocation on top.

This lands a local `Echidna.Types.Random.weighted`/`uniform` in two steps and switches
every call site (dropping the `fromConsts` Rational conversion of the mutation
constants):

1. the same choice from the same generator state, rearranged into exact Integer
   arithmetic — one comparison against `maxBound * (total - c)` per element;
2. the straightforward form: draw one uniform threshold in `[0, total)` — as a single
   `Word64` generator step whenever the total fits, which in practice is always — and
   walk the list with one subtraction and comparison per element.

## Compatibility

Step 1 was bit-compatible; step 2 deliberately gives that up: **a seed no longer
reproduces a campaign run with an earlier version.** The distribution is unchanged — in
fact it becomes exactly `weight / total`, where the old closed-interval draw had 2⁻⁶⁴
edge artifacts (a zero-weight head element could be picked when the draw hit
`maxBound`).

`values/extreme.yaml` pins a seed for a statistical test (finding `-2^127` via the
constants dictionary within 5000 calls), so its seed is repicked against the final draw
stream.

## Numbers

Per call, isolated (GHC 9.8.4, `-O2`, aarch64):

| list shape | Rational (master) | Integer rearrangement (1) | bounded draw + scan (2) |
|---|---|---|---|
| 2 elems (`oftenUsually`) | 598 ns | 34 ns | **17 ns** |
| 4 elems (`getRandomUint`) | 615 ns | 62 ns | **25 ns** |
| 14 elems (`seqMutators`) | 566 ns | 46 ns | **16 ns** |
| 250 elems (corpus-shaped) | 3009 ns | 2740 ns | **1061 ns** |

End to end: same assertion benchmark as before (ERC20-ish contract, seqLen 100), GHC
9.8.4, `-A64m`, release build; each number is the mean of seeds 12345/777/424242, since
the draw streams differ between the two binaries (spreads were within ±2%).

| config | metric | master | this PR |
|---|---|---|---|
| 1 worker, 200k calls | MUT CPU | 10.79 s | 9.76 s (−9.6%) |
| 1 worker, 200k calls | wall | 12.44 s | 11.39 s (−8.5%) |
| 1 worker, 200k calls | allocated | 53.5 GB | 52.4 GB |
| 8 workers, 1.6M calls | MUT CPU | 104.5 s | 94.8 s (−9.3%) |
| 8 workers, 1.6M calls | wall | 15.66 s | 14.35 s (−8.4%) |

The end-to-end win comes from leaving Rational; the bounded-draw form then matches the
Integer rearrangement end to end while being simpler and 2–3× cheaper per call — which
matters most on the corpus-shaped lists `selectFromCorpus` feeds through `weighted`,
whose cost grows with the corpus.