### PR TITLE
Sequence generation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `check`- and `prove`-prefixed functions are always verified in verification mode, even when no assertion was found in them, and are fuzzed like any other test function in foundry mode (#1595)
 * The test limit now counts only executed transactions. Each sequence used to be charged one extra call, which doubled the cost of every iteration when `seqLen` is 1
 * Corpus mutations now always produce sequences of exactly `seqLen` transactions. The prepend mutation could produce shorter sequences and, when `seqLen` is 1, produced an empty sequence about a fifth of the time
+* When `seqLen` is 1 the corpus is now used: about half of the generated transactions are tweaked copies of stored transactions. Stored transactions were previously never fed back into generation, because only strict prefixes of stored sequences were reused
 
 ## 2.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Foundry mode now only calls parameterized `test` functions when `seqLen` is 1, matching Foundry's stateless fuzzing (#1595)
 * `check`- and `prove`-prefixed functions are always verified in verification mode, even when no assertion was found in them, and are fuzzed like any other test function in foundry mode (#1595)
 * The test limit now counts only executed transactions. Each sequence used to be charged one extra call, which doubled the cost of every iteration when `seqLen` is 1
+* Corpus mutations now always produce sequences of exactly `seqLen` transactions. The prepend mutation could produce shorter sequences and, when `seqLen` is 1, produced an empty sequence about a fifth of the time
 
 ## 2.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Foundry mode now follows Foundry's function naming conventions more closely: `invariant`- and `statefulFuzz`-prefixed functions are stateful invariants, and `testFail`-prefixed tests are expected to revert (#1595)
 * Foundry mode now only calls parameterized `test` functions when `seqLen` is 1, matching Foundry's stateless fuzzing (#1595)
 * `check`- and `prove`-prefixed functions are always verified in verification mode, even when no assertion was found in them, and are fuzzed like any other test function in foundry mode (#1595)
+* The test limit now counts only executed transactions. Each sequence used to be charged one extra call, which doubled the cost of every iteration when `seqLen` is 1
 
 ## 2.3.3
 

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -355,8 +355,7 @@ mutateAbiCall = traverse f
                   mv <- mutateAbiValue $ xs !! k
                   return $ replaceAt mv xs k
 
--- | Whether 'forceMutateAbiValue' can change a value. Addresses and function
--- values are never mutated, and a tuple can change only if a component can.
+-- | Whether 'forceMutateAbiValue' can change a value.
 isMutable :: AbiValue -> Bool
 isMutable = \case
   AbiAddress _ -> False
@@ -364,10 +363,8 @@ isMutable = \case
   AbiTuple vs -> any isMutable vs
   _ -> True
 
--- | Mutate a value so that the result differs from the original. 'mutateAbiValue'
--- deliberately leaves most values alone so that a mutated sequence keeps most of
--- its shape; this is for mutating a single transaction, where an unchanged value
--- is a wasted iteration. Nothing when the value cannot change (see 'isMutable').
+-- | Like 'mutateAbiValue', but the result always differs from the original.
+-- Nothing when the value cannot change (see 'isMutable').
 forceMutateAbiValue :: MonadRandom m => AbiValue -> m (Maybe AbiValue)
 forceMutateAbiValue v = case v of
   AbiAddress _ -> pure Nothing
@@ -383,9 +380,7 @@ forceMutateAbiValue v = case v of
   -- bytes, strings and arrays: the list mutations already apply unconditionally
   _ -> changed $ mutateAbiValue v
   where
-    -- Keep the mutation if it changed the value; otherwise fall back to a freshly
-    -- generated one, which can only fail to differ for a type with a single
-    -- inhabitant.
+    -- Fall back to a fresh value when the mutation was a no-op.
     changed m = do
       v' <- m
       if v' /= v then pure (Just v') else do
@@ -393,7 +388,7 @@ forceMutateAbiValue v = case v of
         pure $ if g /= v then Just g else Nothing
 
 -- | Mutate one argument of a call so that the call differs from the original.
--- Only arguments that can change are considered; Nothing when there is none.
+-- Nothing when no argument can change.
 forceMutateAbiCall :: MonadRandom m => SolCall -> m (Maybe SolCall)
 forceMutateAbiCall (name, vals) =
   case [i | (i, v) <- zip [0 ..] vals, isMutable v] of

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -355,6 +355,53 @@ mutateAbiCall = traverse f
                   mv <- mutateAbiValue $ xs !! k
                   return $ replaceAt mv xs k
 
+-- | Whether 'forceMutateAbiValue' can change a value. Addresses and function
+-- values are never mutated, and a tuple can change only if a component can.
+isMutable :: AbiValue -> Bool
+isMutable = \case
+  AbiAddress _ -> False
+  AbiFunction _ _ -> False
+  AbiTuple vs -> any isMutable vs
+  _ -> True
+
+-- | Mutate a value so that the result differs from the original. 'mutateAbiValue'
+-- deliberately leaves most values alone so that a mutated sequence keeps most of
+-- its shape; this is for mutating a single transaction, where an unchanged value
+-- is a wasted iteration. Nothing when the value cannot change (see 'isMutable').
+forceMutateAbiValue :: MonadRandom m => AbiValue -> m (Maybe AbiValue)
+forceMutateAbiValue v = case v of
+  AbiAddress _ -> pure Nothing
+  AbiFunction _ _ -> pure Nothing
+  AbiBool b -> pure $ Just $ AbiBool (not b)
+  AbiUInt n x -> changed $ fixAbiUInt n <$> mutateNum x
+  AbiInt n x -> changed $ fixAbiInt n <$> mutateNum x
+  AbiTuple vs -> case [i | (i, c) <- zip [0 ..] (V.toList vs), isMutable c] of
+    [] -> pure Nothing
+    idxs -> do
+      i <- uniform idxs
+      fmap (\c -> AbiTuple (vs V.// [(i, c)])) <$> forceMutateAbiValue (vs V.! i)
+  -- bytes, strings and arrays: the list mutations already apply unconditionally
+  _ -> changed $ mutateAbiValue v
+  where
+    -- Keep the mutation if it changed the value; otherwise fall back to a freshly
+    -- generated one, which can only fail to differ for a type with a single
+    -- inhabitant.
+    changed m = do
+      v' <- m
+      if v' /= v then pure (Just v') else do
+        g <- genAbiValue (abiValueType v)
+        pure $ if g /= v then Just g else Nothing
+
+-- | Mutate one argument of a call so that the call differs from the original.
+-- Only arguments that can change are considered; Nothing when there is none.
+forceMutateAbiCall :: MonadRandom m => SolCall -> m (Maybe SolCall)
+forceMutateAbiCall (name, vals) =
+  case [i | (i, v) <- zip [0 ..] vals, isMutable v] of
+    [] -> pure Nothing
+    idxs -> do
+      i <- uniform idxs
+      fmap (\v -> (name, replaceAt v vals i)) <$> forceMutateAbiValue (vals !! i)
+
 -- Generation, with dictionary
 
 -- | Given a generator taking an @a@ and returning a @b@ and a way to get @b@s associated with some

--- a/lib/Echidna/Mutator/Corpus.hs
+++ b/lib/Echidna/Mutator/Corpus.hs
@@ -34,24 +34,18 @@ mutator :: MonadRandom m => TxsMutation -> [Tx] -> m [Tx]
 mutator Identity  = return
 mutator Shrinking = mapM shrinkTx
 mutator Mutation = \case
-  -- 'mutateTx' leaves most transactions alone so that a long prefix keeps most
-  -- of its shape, and 'mutateAbiValue' changes an integer only one time in ten.
-  -- On a single transaction that is almost always a verbatim replay, which at
-  -- seqLen 1 (every sequence starts from the same VM) cannot find anything.
-  -- Force a change instead, and drop the transaction when nothing in it can
-  -- change: the caller pads the sequence back to length with fresh
-  -- transactions, so the iteration still runs a useful transaction.
+  -- 'mutateTx' rarely changes anything, which on a single transaction is a
+  -- verbatim replay. Force a change, or drop the transaction so the caller
+  -- pads with a fresh one.
   [tx] -> maybeToList <$> forceMutateTx tx
   txs -> mapM mutateTx txs
 mutator Expansion = expandRandList
 mutator Swapping = swapRandList
 mutator Deletion = deleteRandList
 
--- | The range the cut point is drawn from when a stored sequence of the given
--- length is handed to a mutation. Identity gets a strict prefix: replaying a
--- sequence unchanged finds nothing new, and the empty prefix is the "fresh
--- sequence" case. Every other mutation needs something to work on, so its
--- prefix is non-empty and may be the whole sequence.
+-- | Range of the prefix length taken from a stored sequence. Identity takes a
+-- strict prefix, since replaying it unchanged finds nothing; the other
+-- mutations need a non-empty one.
 cutRange :: TxsMutation -> Int -> (Int, Int)
 cutRange Identity len = (0, max 0 (len - 1))
 cutRange _ len = (min 1 len, len)
@@ -96,10 +90,7 @@ getCorpusMutation (RandomAppend m) = \ql ctxs gtxs -> do
 getCorpusMutation (RandomPrepend m) = \ql ctxs gtxs -> do
   rtxs' <- selectAndMutate m ctxs
   k <- getRandomR (0, ql - 1)
-  -- The fresh transactions not placed in front pad the sequence back to full
-  -- length, as in RandomAppend. Without them a short stored prefix made the
-  -- whole sequence shorter than seqLen, and at seqLen 1 (where k is always 0)
-  -- an empty prefix came out as an empty sequence.
+  -- Pad with the remaining fresh transactions so the sequence has ql entries.
   pure . take ql $ take k gtxs ++ rtxs' ++ drop k gtxs
 getCorpusMutation RandomSplice = selectAndCombine spliceAtRandom
 getCorpusMutation RandomInterleave = selectAndCombine interleaveAtRandom
@@ -128,12 +119,8 @@ seqMutatorsStateful (c1, c2, c3, c4) = weighted
    (RandomInterleave,        c4)
  ]
 
--- | At seqLen 1 a stored sequence is a single transaction, so the stateful
--- vocabulary collapses: there is no prefix to extend and nothing to prepend to,
--- and Identity can only mean a fresh transaction, since replaying the stored
--- one unchanged from the same initial VM finds nothing. Each iteration is
--- therefore either a fresh transaction or a tweaked copy of a stored one, with
--- the mutConsts knobs adding to the tweak share as in the stateful table.
+-- | At seqLen 1 there is nothing to extend or prepend to, so each sequence is
+-- either a fresh transaction or a tweaked copy of a stored one.
 seqMutatorsStateless
   :: MonadRandom m
   => MutationConsts Rational

--- a/lib/Echidna/Mutator/Corpus.hs
+++ b/lib/Echidna/Mutator/Corpus.hs
@@ -81,7 +81,11 @@ getCorpusMutation (RandomPrepend m) = mut (mutator m)
     mut f ql ctxs gtxs = do
       rtxs' <- selectAndMutate f ctxs
       k <- getRandomR (0, ql - 1)
-      pure . take ql $ take k gtxs ++ rtxs'
+      -- The fresh transactions not placed in front pad the sequence back to
+      -- full length, as in RandomAppend. Without them a short stored prefix
+      -- made the whole sequence shorter than seqLen, and at seqLen 1 (where
+      -- the prefix is always empty and k is always 0) it came out empty.
+      pure . take ql $ take k gtxs ++ rtxs' ++ drop k gtxs
 getCorpusMutation RandomSplice = selectAndCombine spliceAtRandom
 getCorpusMutation RandomInterleave = selectAndCombine interleaveAtRandom
 

--- a/lib/Echidna/Mutator/Corpus.hs
+++ b/lib/Echidna/Mutator/Corpus.hs
@@ -1,10 +1,11 @@
 module Echidna.Mutator.Corpus where
 
 import Control.Monad.Random.Strict (MonadRandom, getRandomR, weighted)
+import Data.Maybe (maybeToList)
 import Data.Set qualified as Set
 
 import Echidna.Mutator.Array
-import Echidna.Transaction (mutateTx, shrinkTx)
+import Echidna.Transaction (forceMutateTx, mutateTx, shrinkTx)
 import Echidna.Types (MutationConsts)
 import Echidna.Types.Corpus
 import Echidna.Types.Tx (Tx)
@@ -32,20 +33,38 @@ data CorpusMutation = RandomAppend TxsMutation
 mutator :: MonadRandom m => TxsMutation -> [Tx] -> m [Tx]
 mutator Identity  = return
 mutator Shrinking = mapM shrinkTx
-mutator Mutation = mapM mutateTx
+mutator Mutation = \case
+  -- 'mutateTx' leaves most transactions alone so that a long prefix keeps most
+  -- of its shape, and 'mutateAbiValue' changes an integer only one time in ten.
+  -- On a single transaction that is almost always a verbatim replay, which at
+  -- seqLen 1 (every sequence starts from the same VM) cannot find anything.
+  -- Force a change instead, and drop the transaction when nothing in it can
+  -- change: the caller pads the sequence back to length with fresh
+  -- transactions, so the iteration still runs a useful transaction.
+  [tx] -> maybeToList <$> forceMutateTx tx
+  txs -> mapM mutateTx txs
 mutator Expansion = expandRandList
 mutator Swapping = swapRandList
 mutator Deletion = deleteRandList
 
+-- | The range the cut point is drawn from when a stored sequence of the given
+-- length is handed to a mutation. Identity gets a strict prefix: replaying a
+-- sequence unchanged finds nothing new, and the empty prefix is the "fresh
+-- sequence" case. Every other mutation needs something to work on, so its
+-- prefix is non-empty and may be the whole sequence.
+cutRange :: TxsMutation -> Int -> (Int, Int)
+cutRange Identity len = (0, max 0 (len - 1))
+cutRange _ len = (min 1 len, len)
+
 selectAndMutate
   :: MonadRandom m
-  => ([Tx] -> m [Tx])
+  => TxsMutation
   -> Corpus
   -> m [Tx]
-selectAndMutate f corpus = do
+selectAndMutate m corpus = do
   rtxs <- selectFromCorpus corpus
-  k <- getRandomR (0, length rtxs - 1)
-  f $ take k rtxs
+  k <- getRandomR (cutRange m (length rtxs))
+  mutator m $ take k rtxs
 
 selectAndCombine
   :: MonadRandom m
@@ -71,21 +90,17 @@ getCorpusMutation
   :: MonadRandom m
   => CorpusMutation
   -> (Int -> Corpus -> [Tx] -> m [Tx])
-getCorpusMutation (RandomAppend m) = mut (mutator m)
-  where
-    mut f ql ctxs gtxs = do
-      rtxs' <- selectAndMutate f ctxs
-      pure . take ql $ rtxs' ++ gtxs
-getCorpusMutation (RandomPrepend m) = mut (mutator m)
-  where
-    mut f ql ctxs gtxs = do
-      rtxs' <- selectAndMutate f ctxs
-      k <- getRandomR (0, ql - 1)
-      -- The fresh transactions not placed in front pad the sequence back to
-      -- full length, as in RandomAppend. Without them a short stored prefix
-      -- made the whole sequence shorter than seqLen, and at seqLen 1 (where
-      -- the prefix is always empty and k is always 0) it came out empty.
-      pure . take ql $ take k gtxs ++ rtxs' ++ drop k gtxs
+getCorpusMutation (RandomAppend m) = \ql ctxs gtxs -> do
+  rtxs' <- selectAndMutate m ctxs
+  pure . take ql $ rtxs' ++ gtxs
+getCorpusMutation (RandomPrepend m) = \ql ctxs gtxs -> do
+  rtxs' <- selectAndMutate m ctxs
+  k <- getRandomR (0, ql - 1)
+  -- The fresh transactions not placed in front pad the sequence back to full
+  -- length, as in RandomAppend. Without them a short stored prefix made the
+  -- whole sequence shorter than seqLen, and at seqLen 1 (where k is always 0)
+  -- an empty prefix came out as an empty sequence.
+  pure . take ql $ take k gtxs ++ rtxs' ++ drop k gtxs
 getCorpusMutation RandomSplice = selectAndCombine spliceAtRandom
 getCorpusMutation RandomInterleave = selectAndCombine interleaveAtRandom
 
@@ -113,17 +128,17 @@ seqMutatorsStateful (c1, c2, c3, c4) = weighted
    (RandomInterleave,        c4)
  ]
 
+-- | At seqLen 1 a stored sequence is a single transaction, so the stateful
+-- vocabulary collapses: there is no prefix to extend and nothing to prepend to,
+-- and Identity can only mean a fresh transaction, since replaying the stored
+-- one unchanged from the same initial VM finds nothing. Each iteration is
+-- therefore either a fresh transaction or a tweaked copy of a stored one, with
+-- the mutConsts knobs adding to the tweak share as in the stateful table.
 seqMutatorsStateless
   :: MonadRandom m
   => MutationConsts Rational
   -> m CorpusMutation
 seqMutatorsStateless (c1, c2, _, _) = weighted
-  [(RandomAppend Identity,   800),
-   (RandomPrepend Identity,  200),
-
-   (RandomAppend Shrinking,  c1),
-   (RandomAppend Mutation,   c2),
-
-   (RandomPrepend Shrinking, c1),
-   (RandomPrepend Mutation,  c2)
-  ]
+  [(RandomAppend Identity,  500),
+   (RandomAppend Mutation,  500 + c2),
+   (RandomAppend Shrinking, c1)]

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -156,9 +156,8 @@ mutateTx tx@Tx{call = SolCall c} = do
         skip _ = pure tx
 mutateTx tx = pure tx
 
--- | Mutate one argument of a transaction's call so that the call differs from
--- the original. Nothing when no argument can change, which includes calls
--- without arguments.
+-- | Mutate one call argument so that the transaction differs from the original.
+-- Nothing when no argument can change.
 forceMutateTx :: MonadRandom m => Tx -> m (Maybe Tx)
 forceMutateTx tx@Tx{call = SolCall c} = fmap (\c' -> tx { call = SolCall c' }) <$> forceMutateAbiCall c
 forceMutateTx _ = pure Nothing

--- a/lib/Echidna/Transaction.hs
+++ b/lib/Echidna/Transaction.hs
@@ -156,6 +156,13 @@ mutateTx tx@Tx{call = SolCall c} = do
         skip _ = pure tx
 mutateTx tx = pure tx
 
+-- | Mutate one argument of a transaction's call so that the call differs from
+-- the original. Nothing when no argument can change, which includes calls
+-- without arguments.
+forceMutateTx :: MonadRandom m => Tx -> m (Maybe Tx)
+forceMutateTx tx@Tx{call = SolCall c} = fmap (\c' -> tx { call = SolCall c' }) <$> forceMutateAbiCall c
+forceMutateTx _ = pure Nothing
+
 -- | Given a 'Transaction', set up some 'VM' so it can be executed. Effectively, this just brings
 -- 'Transaction's \"on-chain\".
 setupTx :: (MonadIO m, MonadState (VM Concrete) m) => Tx -> m ()

--- a/lib/Echidna/Worker/Sequence.hs
+++ b/lib/Echidna/Worker/Sequence.hs
@@ -272,12 +272,14 @@ evalSeq vm0 execFunc = go vm0 [] where
     -- NOTE: we do reverse here because we build up this list by prepending,
     -- see the last line of this function.
     updateTests (updateOpenTest vm (reverse executedSoFar))
-    modify' $ \workerState -> workerState { ncalls = workerState.ncalls + 1 }
     case toExecute of
       [] -> pure ([], vm)
       (tx:remainingTxs) -> do
         (result, vm') <- execFunc vm tx
-        modify' $ \workerState -> workerState { totalGas = workerState.totalGas + fromIntegral (vm'.burned - vm.burned) }
+        modify' $ \workerState -> workerState
+          { ncalls = workerState.ncalls + 1
+          , totalGas = workerState.totalGas + fromIntegral (vm'.burned - vm.burned)
+          }
         -- NOTE: we don't use the intermediate VMs, just the last one. If any of
         -- the intermediate VMs are needed, they can be put next to the result
         -- of each transaction - `m ([(Tx, result, VM)])`

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -234,7 +234,7 @@ options = Options . NE.fromList
     <> help ("Number of tries to attempt to shrink a failing sequence of transactions. Default is " ++ show defaultShrinkLimit))
   <*> optional (option auto $ long "seq-len"
     <> metavar "INTEGER"
-    <> help ("Number of transactions to generate during testing. Default is " ++ show defaultSequenceLength))
+    <> help ("Number of transactions in each generated sequence. Default is " ++ show defaultSequenceLength))
   <*> optional (option auto $ long "contract-addr"
     <> metavar "ADDRESS"
     <> help ("Address to deploy the contract to test. Default is " ++ show defaultContractAddr))

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -222,7 +222,7 @@ options = Options . NE.fromList
     <> help "Timeout given in seconds.")
   <*> optional (option auto $ long "test-limit"
     <> metavar "INTEGER"
-    <> help ("Number of sequences of transactions to generate during testing. Default is " ++ show defaultTestLimit))
+    <> help ("Number of transactions to execute during testing. Default is " ++ show defaultTestLimit))
   <*> optional (option auto $ long "rpc-block"
     <> metavar "BLOCK"
     <> help "Block number to use when fetching over RPC.")

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -10,6 +10,7 @@ import Tests.Encoding (encodingJSONTests)
 import Tests.Foundry (foundryTests)
 import Tests.FoundryTestGen (foundryTestGenTests)
 import Tests.Integration (integrationTests)
+import Tests.Mutator (mutatorTests)
 import Tests.Optimization (optimizationTests)
 import Tests.Overflow (overflowTests)
 import Tests.Research (researchTests)
@@ -24,6 +25,7 @@ main = withCurrentDirectory "./tests/solidity" . defaultMain $
            [ configTests
            , compilationTests
            , seedTests
+           , mutatorTests
            , integrationTests
            , valuesTests
            , coverageTests

--- a/src/test/Tests/Mutator.hs
+++ b/src/test/Tests/Mutator.hs
@@ -83,8 +83,7 @@ mutatorTests = testGroup "Corpus mutation"
       ]
   ]
 
--- | A corpus holding one single-transaction sequence, as every entry is at
--- seqLen 1.
+-- | A seqLen 1 corpus: one single-transaction sequence.
 singleton :: Corpus
 singleton = Set.singleton (1, [stored])
 
@@ -110,15 +109,13 @@ allMutations =
   <> [RandomSplice, RandomInterleave]
   where txsMutations = [Identity, Shrinking, Mutation, Expansion, Swapping, Deletion]
 
--- | A non-empty corpus of non-empty sequences. The keys are the selection
--- weights, so they are positive as in a real corpus.
+-- | A non-empty corpus of non-empty sequences with positive weights.
 genCorpus :: Gen Corpus
 genCorpus = Set.fromList <$> listOf1 entry
   where entry = (,) . getPositive <$> arbitrary <*> listOf1 arbitrary
 
--- | A single fuzz worker with coverage on, no shrinking and a property that
--- never fails, so it runs until the limit. Every sequence it runs must then
--- have exactly seqLen transactions and be charged exactly that many calls.
+-- | Run a single worker to the test limit and check that every sequence had
+-- exactly seqLen transactions and was charged that many calls.
 accountingTest :: Int -> Int -> TestTree
 accountingTest n limit =
   testCase ("seqLen " <> show n) $ do

--- a/src/test/Tests/Mutator.hs
+++ b/src/test/Tests/Mutator.hs
@@ -1,20 +1,27 @@
 module Tests.Mutator (mutatorTests) where
 
+import Control.Monad (forM_)
 import Control.Monad.Random.Strict (evalRand, mkStdGen)
 import Data.Function ((&))
 import Data.IORef (readIORef)
 import Data.Set qualified as Set
+import Data.Text (Text)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase, (@?=))
 import Test.Tasty.QuickCheck
-  (Gen, Positive(..), arbitrary, choose, elements, forAll, listOf1, testProperty, vectorOf, (===))
+  (Gen, Positive(..), arbitrary, choose, counterexample, elements, forAll, listOf1, property,
+   testProperty, vectorOf, (===))
+
+import EVM.ABI (AbiValue(..))
 
 import Common (overrideQuiet, runContract)
+import Echidna.ABI (forceMutateAbiValue, isMutable)
 import Echidna.Config (defaultConfig)
-import Echidna.Mutator.Corpus (CorpusMutation(..), TxsMutation(..), getCorpusMutation)
+import Echidna.Mutator.Corpus (CorpusMutation(..), TxsMutation(..), cutRange, getCorpusMutation)
 import Echidna.Types.Campaign
 import Echidna.Types.Config (EConfig(..), Env(..))
 import Echidna.Types.Corpus (Corpus)
+import Echidna.Types.Tx (Tx(..), TxCall(..))
 import Echidna.Types.Worker (WorkerType(..))
 import Tests.Encoding () -- Arbitrary Tx
 
@@ -27,11 +34,74 @@ mutatorTests = testGroup "Corpus mutation"
       forAll (elements allMutations) $ \m ->
       forAll arbitrary $ \seed ->
         length (evalRand (getCorpusMutation m ql corpus gtxs) (mkStdGen seed)) === ql
+  , testGroup "cut point"
+      [ testCase "identity keeps a strict prefix" $ do
+          cutRange Identity 5 @?= (0, 4)
+          cutRange Identity 1 @?= (0, 0)
+          cutRange Identity 0 @?= (0, 0)
+      , testCase "other mutations get a non-empty prefix, up to the whole sequence" $ do
+          cutRange Mutation 5 @?= (1, 5)
+          cutRange Mutation 1 @?= (1, 1)
+          cutRange Shrinking 0 @?= (0, 0)
+      ]
+  , testGroup "seqLen 1"
+      [ testProperty "a stored transaction is tweaked or replaced, never replayed" $
+          forAll (elements [RandomAppend Mutation, RandomPrepend Mutation]) $ \m ->
+          forAll arbitrary $ \seed ->
+            case evalRand (getCorpusMutation m 1 singleton [fresh]) (mkStdGen seed) of
+              [tx] | tx == fresh -> property True
+                   | otherwise ->
+                       counterexample (show tx) $ tx /= stored && fnName tx == fnName stored
+              txs -> counterexample (show txs) False
+      , testProperty "a stored transaction with nothing to change is replaced" $
+          forAll (elements [mkTx "stored" [], mkTx "stored" [AbiAddress 0]]) $ \s ->
+          forAll arbitrary $ \seed ->
+            evalRand (getCorpusMutation (RandomAppend Mutation) 1 (Set.singleton (1, [s])) [fresh])
+                     (mkStdGen seed)
+              === [fresh]
+      , testProperty "identity yields the fresh transaction" $
+          forAll arbitrary $ \seed ->
+            evalRand (getCorpusMutation (RandomAppend Identity) 1 singleton [fresh]) (mkStdGen seed)
+              === [fresh]
+      ]
+  , testGroup "forced mutation"
+      [ testProperty "never returns the original value" $
+          forAll arbitrary $ \v -> forAll arbitrary $ \seed ->
+            let r = evalRand (forceMutateAbiValue v) (mkStdGen seed)
+            in counterexample (show r) $ r /= Just v
+      , testCase "flips booleans" $
+          forM_ [0 .. 20] $ \seed ->
+            evalRand (forceMutateAbiValue (AbiBool True)) (mkStdGen seed) @?= Just (AbiBool False)
+      , testCase "leaves addresses alone" $ do
+          evalRand (forceMutateAbiValue (AbiAddress 0)) (mkStdGen 0) @?= Nothing
+          isMutable (AbiAddress 0) @?= False
+          isMutable (AbiUInt 8 1) @?= True
+      ]
   , testGroup "the test limit is spent on whole sequences"
       [ accountingTest 20 600
       , accountingTest 1 100
       ]
   ]
+
+-- | A corpus holding one single-transaction sequence, as every entry is at
+-- seqLen 1.
+singleton :: Corpus
+singleton = Set.singleton (1, [stored])
+
+-- | The stored transaction takes an integer, the argument type the ABI mutators
+-- change least often. The fresh one is distinguishable by name.
+stored, fresh :: Tx
+stored = mkTx "stored" [AbiInt 8 5]
+fresh = mkTx "fresh" []
+
+mkTx :: Text -> [AbiValue] -> Tx
+mkTx name args =
+  Tx { call = SolCall (name, args), src = 0, dst = 0, gas = 0, gasprice = 0, value = 0, delay = (0, 0) }
+
+fnName :: Tx -> Maybe Text
+fnName tx = case tx.call of
+  SolCall (name, _) -> Just name
+  _ -> Nothing
 
 -- | Every corpus mutation. Neither enum derives 'Enum' or 'Bounded'.
 allMutations :: [CorpusMutation]

--- a/src/test/Tests/Mutator.hs
+++ b/src/test/Tests/Mutator.hs
@@ -1,0 +1,70 @@
+module Tests.Mutator (mutatorTests) where
+
+import Control.Monad.Random.Strict (evalRand, mkStdGen)
+import Data.Function ((&))
+import Data.IORef (readIORef)
+import Data.Set qualified as Set
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
+import Test.Tasty.QuickCheck
+  (Gen, Positive(..), arbitrary, choose, elements, forAll, listOf1, testProperty, vectorOf, (===))
+
+import Common (overrideQuiet, runContract)
+import Echidna.Config (defaultConfig)
+import Echidna.Mutator.Corpus (CorpusMutation(..), TxsMutation(..), getCorpusMutation)
+import Echidna.Types.Campaign
+import Echidna.Types.Config (EConfig(..), Env(..))
+import Echidna.Types.Corpus (Corpus)
+import Echidna.Types.Worker (WorkerType(..))
+import Tests.Encoding () -- Arbitrary Tx
+
+mutatorTests :: TestTree
+mutatorTests = testGroup "Corpus mutation"
+  [ testProperty "every mutation yields exactly seqLen transactions" $
+      forAll genCorpus $ \corpus ->
+      forAll (choose (1, 8)) $ \ql ->
+      forAll (vectorOf ql arbitrary) $ \gtxs ->
+      forAll (elements allMutations) $ \m ->
+      forAll arbitrary $ \seed ->
+        length (evalRand (getCorpusMutation m ql corpus gtxs) (mkStdGen seed)) === ql
+  , testGroup "the test limit is spent on whole sequences"
+      [ accountingTest 20 600
+      , accountingTest 1 100
+      ]
+  ]
+
+-- | Every corpus mutation. Neither enum derives 'Enum' or 'Bounded'.
+allMutations :: [CorpusMutation]
+allMutations =
+  map RandomAppend txsMutations <> map RandomPrepend txsMutations
+  <> [RandomSplice, RandomInterleave]
+  where txsMutations = [Identity, Shrinking, Mutation, Expansion, Swapping, Deletion]
+
+-- | A non-empty corpus of non-empty sequences. The keys are the selection
+-- weights, so they are positive as in a real corpus.
+genCorpus :: Gen Corpus
+genCorpus = Set.fromList <$> listOf1 entry
+  where entry = (,) . getPositive <$> arbitrary <*> listOf1 arbitrary
+
+-- | A single fuzz worker with coverage on, no shrinking and a property that
+-- never fails, so it runs until the limit. Every sequence it runs must then
+-- have exactly seqLen transactions and be charged exactly that many calls.
+accountingTest :: Int -> Int -> TestTree
+accountingTest n limit =
+  testCase ("seqLen " <> show n) $ do
+    (env, final) <- runContract "basic/flags.sol" Nothing cfg FuzzWorker
+    corpus <- readIORef env.corpusRef
+    assertBool "corpus stayed empty, so no mutation was exercised" (not (Set.null corpus))
+    final.ncalls @?= limit
+    final.ncalls @?= final.ncallseqs * n
+  where
+    cfg = defaultConfig
+      { campaignConf = defaultConfig.campaignConf
+        { testLimit = limit
+        , seqLen = n
+        , stopOnFail = False
+        , shrinkLimit = 0
+        , seed = Just 0
+        , corpusDir = Nothing
+        }
+      } & overrideQuiet

--- a/src/test/Tests/Values.hs
+++ b/src/test/Tests/Values.hs
@@ -24,7 +24,8 @@ valuesTests = testGroup "Value extraction tests"
     , testContract' "values/extreme.sol"   Nothing Nothing (Just "values/extreme.yaml") False FuzzWorker
       [ ("testMinInt8 passed",                   solved      "testMinInt8"),
         ("testMinInt16 passed",                  solved      "testMinInt16"),
-        ("testMinInt64 passed",                  solved      "testMinInt32"),
+        ("testMinInt32 passed",                  solved      "testMinInt32"),
+        ("testMinInt64 passed",                  solved      "testMinInt64"),
         ("testMinInt128 passed",                 solved      "testMinInt128")
       ]
     , testContract' "values/utf8.sol"   Nothing Nothing (Just "values/extreme.yaml") False FuzzWorker

--- a/tests/solidity/basic/default.yaml
+++ b/tests/solidity/basic/default.yaml
@@ -16,7 +16,7 @@ propMaxGas: 12500000
 testMaxGas: 12500000
 #maxGasprice is the maximum gas price
 maxGasprice: 0
-#testLimit is the number of test sequences to run
+#testLimit is the number of transactions to execute
 testLimit: 50000
 #stopOnFail makes echidna terminate as soon as any property fails and has been shrunk
 stopOnFail: false


### PR DESCRIPTION
* The test limit now counts only executed transactions. Each sequence used to be charged one extra call, which doubled the cost of every iteration when `seqLen` is 1
* Corpus mutations now always produce sequences of exactly `seqLen` transactions. The prepend mutation could produce shorter sequences and, when `seqLen` is 1, produced an empty sequence about a fifth of the time
* When `seqLen` is 1 the corpus is now used: about half of the generated transactions are tweaked copies of stored transactions. Stored transactions were previously never fed back into generation, because only strict prefixes of stored sequences were reused
* Fix extreme.sol assertions to check all of them