### PR TITLE
tests: extreme: bump limit to 20000

### DIFF
--- a/tests/solidity/values/extreme.yaml
+++ b/tests/solidity/values/extreme.yaml
@@ -1,4 +1,4 @@
-testLimit: 5000
+testLimit: 20000
 shrinkLimit: 100
 testMode: assertion
 seqLen: 1


### PR DESCRIPTION
This test is flaky with the current limit; raise to 20000 to improve success rates.